### PR TITLE
Feature/2701 migrating plugin browser side security

### DIFF
--- a/public/app-router.tsx
+++ b/public/app-router.tsx
@@ -21,6 +21,7 @@ import { AppDependencies } from './types';
 //import { ToastNotificationsModal } from './components/notifications/modal';
 import { HealthCheck } from './components/health-check';
 import { MainOverview } from './components/main-overview';
+import { MainSecurity } from './components/main-security';
 
 
 const LANDING_PAGE_URL = '/overview';
@@ -33,6 +34,7 @@ export function AppRouter(props: AppDependencies) {
           <Switch>
             <Route path={LANDING_PAGE_URL} render={() => <MainOverview />} />
             <Route path="/health-check" render={() => <HealthCheck />} />
+            <Route path="/security" render={() => <MainSecurity />} />
             <Redirect exact from="/" to={LANDING_PAGE_URL} />
           </Switch>
         </EuiPageBody>

--- a/public/components/common/hooks/use-filter-manager.ts
+++ b/public/components/common/hooks/use-filter-manager.ts
@@ -11,9 +11,11 @@
  */
 import { useState, useEffect} from 'react';
 //@ts-ignore
-import { getServices } from '../../../../../../src/plugins/discover/public/kibana_services';
+// import { getServices } from '../../../../../../src/plugins/discover/public/kibana_services';
+import { getDataPlugin } from '../../../kibana-services';
 
 export const useFilterManager = () => {
-    const [filterManager, setFilterManager] = useState(getServices().filterManager);
+    const timefilter = getDataPlugin().query.timefilter;
+    const [filterManager, setFilterManager] = useState(timefilter.filterManager);
     return filterManager;
 }

--- a/public/components/common/hooks/use-index-pattern.ts
+++ b/public/components/common/hooks/use-index-pattern.ts
@@ -14,12 +14,14 @@ import { useState, useEffect} from 'react';
 import { getServices } from '../../../../../../src/plugins/discover/public/kibana_services';
 import { AppState } from '../../../react-services/app-state';
 import { IIndexPattern } from '../../../../../../src/plugins/data/public';
+import { getDataPlugin } from '../../../kibana-services';
 
 export const useIndexPattern = (): IIndexPattern | undefined => {
+  const timefilter = getDataPlugin().query.timefilter;
   const [indexPattern, setIndexPattern] = useState();
   useEffect(() => {
   const idIndexPattern = AppState.getCurrentPattern();
-  getServices().indexPatterns.get(idIndexPattern)
+  timefilter.indexPatterns.get(idIndexPattern)
     .then(setIndexPattern);
   }, []);
   return indexPattern;

--- a/public/components/common/hooks/use-time-filter.ts
+++ b/public/components/common/hooks/use-time-filter.ts
@@ -10,11 +10,13 @@
  * Find more information about this on the LICENSE file.
  */
 import { useState, useEffect } from 'react';
+import { getDataPlugin } from '../../../kibana-services';
 //@ts-ignore
-import { getServices } from '../../../../../../src/plugins/discover/public/kibana_services';
+// import { getServices } from '../../../../../../src/plugins/discover/public/kibana_services';
+
 
 export function useTimeFilter() {
-  const { timefilter, } = getServices();
+  const timefilter = getDataPlugin().query.timefilter;
   const [timeFilter, setTimeFilter] = useState(timefilter.getTime());
   const [timeHistory, setTimeHistory] = useState(timefilter._history);
   useEffect(() => {

--- a/public/components/main-security/container/main-security.container.tsx
+++ b/public/components/main-security/container/main-security.container.tsx
@@ -1,0 +1,37 @@
+/*
+ * Wazuh app - React component for main overview
+ *
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { compose } from 'redux';
+import AppState from '../../../react-services/app-state';
+import { withGlobalBreadcrumb } from '../../common/hocs/withGlobalBreadcrumb';
+import { WzSecurity } from '../../security/index';
+import { useHistory } from 'react-router-dom';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+export const MainSecurity = compose(withGlobalBreadcrumb([{ text: '' }, { text: 'Security' }]))(
+  () => {
+     return (
+       <WzSecurity></WzSecurity>
+      //  <p>SECURITY</p>
+      // <EuiFlexGroup direction="column">
+      //   <EuiFlexItem grow={false}>
+      //     <OverviewStats summary={agentsSummary} />
+      //   </EuiFlexItem>
+      //   <EuiFlexItem grow={false}>
+      //     <OverviewWelcome extensions={extensions} />
+      //   </EuiFlexItem>
+      // </EuiFlexGroup>
+    );
+  }
+);

--- a/public/components/main-security/index.ts
+++ b/public/components/main-security/index.ts
@@ -1,0 +1,1 @@
+export { MainSecurity } from './container/main-security.container';

--- a/public/components/security/main.tsx
+++ b/public/components/security/main.tsx
@@ -10,6 +10,7 @@ import {
   EuiEmptyPrompt,
   EuiSpacer,
 } from '@elastic/eui';
+import { Router, Route, Switch, Redirect, useHistory, useLocation, useRouteMatch  } from 'react-router-dom';
 import { Users } from './users/users';
 import { Roles } from './roles/roles';
 import { Policies } from './policies/policies';
@@ -47,39 +48,69 @@ export const WzSecurity = compose(
   withGlobalBreadcrumb([{ text: '' }, { text: 'Security' }]),
   withUserAuthorizationPrompt(null, [WAZUH_ROLE_ADMINISTRATOR_NAME])
 )(() => {
+  const history = useHistory();
+  const location = useLocation();
+  const routeMatch = useRouteMatch();
   const dispatch = useDispatch();
+  const LANDING_PAGE_URL = '/overview';
+  // // Get the initial tab when the component is initiated
+  // const securityTabRegExp = new RegExp(`tab=(${tabs.map(tab => tab.id).join('|')})`);
+  // const tab = window.location.href.match(securityTabRegExp);
+   
+  const [selectedTabId, setSelectedTabId] = useState('users');
+  // const [selectedTabId, setSelectedTabId] = useState('users');
 
-  // Get the initial tab when the component is initiated
-  const securityTabRegExp = new RegExp(`tab=(${tabs.map(tab => tab.id).join('|')})`);
-  const tab = window.location.href.match(securityTabRegExp);
-
-  const [selectedTabId, setSelectedTabId] = useState(tab && tab[1] || 'users');
-
-  const listenerLocationChanged = () => {
-    const tab = window.location.href.match(securityTabRegExp);
-    setSelectedTabId(tab && tab[1] || 'users')
-  }
-  // This allows to redirect to a Security tab if you click a Security link in menu when you're already in a Security section 
+  //check current url for select security tab
   useEffect(() => {
-    window.addEventListener('popstate', listenerLocationChanged)
-    return () => window.removeEventListener('popstate', listenerLocationChanged);
-  });
+    switch(location.pathname) {
+      case "/security/users":
+        return setSelectedTabId("users");
+      case "/security/roles":
+        return setSelectedTabId("roles");
+      case "/security/policies":
+        return setSelectedTabId("policies");
+      case "/security/roleMapping":
+        return setSelectedTabId("roleMapping");
+      case "/security":
+        return setSelectedTabId("users");
+      default:
+        return setSelectedTabId("users");
+    }
+  },[]);
 
-  useEffect(() => {
-    dispatch(updateSecuritySection(selectedTabId));
-  })
+
+  // const listenerLocationChanged = () => {
+  //   const tab = window.location.href.match(securityTabRegExp);
+  //   // setSelectedTabId(tab && tab[1] || 'users')
+  // }
+  // // This allows to redirect to a Security tab if you click a Security link in menu when you're already in a Security section 
+  // useEffect(() => {
+  //   window.addEventListener('popstate', listenerLocationChanged)
+  //   return () => window.removeEventListener('popstate', listenerLocationChanged);
+  // });
+
+  // useEffect(() => {
+  //   dispatch(updateSecuritySection(selectedTabId));
+  // })
+
 
   const onSelectedTabChanged = id => {
-    window.location.href = window.location.href.replace(`tab=${selectedTabId}`, `tab=${id}`);
     setSelectedTabId(id);    
+    useHistory().push(`/security/${id}`)
+    // window.location.href = window.location.href.replace(`tab=${selectedTabId}`, `tab=${id}`);
   };
 
   const renderTabs = () => {
-    return tabs.map((tab, index) => (
+    return tabs.map((tab, index) => (          
       <EuiTab
-        {...(tab.href && { href: tab.href, target: '_blank' })}
-        onClick={() => onSelectedTabChanged(tab.id)}
+        // {...(tab.href && { href: tab.href, target: '_blank' })}
+        onClick={() => {
+          setSelectedTabId(tab.id);  
+          history.push(`/security/${tab.id}`)
+          // onSelectedTabChanged(tab.id)
+        }}
         isSelected={tab.id === selectedTabId}
+        // isSelected={tab.id}
         disabled={tab.disabled}
         key={index}>
         {tab.name}
@@ -93,7 +124,7 @@ export const WzSecurity = compose(
         <EuiFlexItem>
           <EuiTabs>{renderTabs()}</EuiTabs>
           <EuiSpacer size='m'></EuiSpacer>
-          {selectedTabId === 'users' &&
+          {/* {selectedTabId === 'users' &&
             <Users></Users>
           }
           {selectedTabId === 'roles' &&
@@ -104,9 +135,34 @@ export const WzSecurity = compose(
           }
           {selectedTabId === 'roleMapping' &&
             <RolesMapping></RolesMapping>
-          }
+          } */}
+          <Switch>
+            <Route path="/security/users" render={() => <Users />} />
+            <Route path="/security/roles" render={() => <Roles />} />
+            <Route path="/security/policies" render={() => <Policies />} />
+            <Route path="/security/roleMapping" render={() => <RolesMapping />} />
+            <Redirect exact from="/" to={LANDING_PAGE_URL} />
+          </Switch>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPage>
+
+          
+
+  //   <Router history={props.params.history}>
+  //   <EuiPage>
+  //     <EuiPageBody>
+  //       <Switch>
+  //         <Route path={LANDING_PAGE_URL} render={() => <MainOverview />} />
+  //         <Route path="/health-check" render={() => <HealthCheck />} />
+  //         <Route path="/security" render={() => <MainSecurity />} />
+  //         <Redirect exact from="/" to={LANDING_PAGE_URL} />
+  //       </Switch>
+  //     </EuiPageBody>
+  //     {/* <WzMenuWrapper/>
+  //     <WzAgentSelectorWrapper/>
+  //     <ToastNotificationsModal/> */}
+  //   </EuiPage>
+  // </Router>
   );
 });

--- a/public/components/security/main.tsx
+++ b/public/components/security/main.tsx
@@ -137,6 +137,7 @@ export const WzSecurity = compose(
             <RolesMapping></RolesMapping>
           } */}
           <Switch>
+            {/* <Route path="/security" render={() => <Users />} /> */}
             <Route path="/security/users" render={() => <Users />} />
             <Route path="/security/roles" render={() => <Roles />} />
             <Route path="/security/policies" render={() => <Policies />} />

--- a/public/components/security/policies/edit-policy.tsx
+++ b/public/components/security/policies/edit-policy.tsx
@@ -17,8 +17,8 @@ import {
     EuiInMemoryTable,
     EuiFieldText,
 } from '@elastic/eui';
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+import ErrorHandler from '../../../react-services/error-handler';
 import { WzAPIUtils } from '../../../react-services/wz-api-utils';
 
 
@@ -62,7 +62,7 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
             if (data.failed_items && data.failed_items.length) {
                 return;
             }
-            ErrorHandler.info('Role was successfully updated with the selected policies');
+            ErrorHandler.info('Role was successfully updated with the selected policies','');
             closeFlyout();
         }catch(error){ 
             ErrorHandler.handle(error, 'Unexpected error');

--- a/public/components/security/policies/policies-table.tsx
+++ b/public/components/security/policies/policies-table.tsx
@@ -6,8 +6,8 @@ import {
     EuiToolTip,
     EuiButtonIcon
 } from '@elastic/eui';
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+import ErrorHandler from '../../../react-services/error-handler';
 import { WzAPIUtils } from '../../../react-services/wz-api-utils';
 import { WzButtonModalConfirm } from '../../common/buttons';
 
@@ -92,7 +92,7 @@ export const PoliciesTable = ({policies, loading, editPolicy, updatePolicies}) =
                     if (data.failed_items && data.failed_items.length){
                         return;
                     }
-                    ErrorHandler.info('Policy was successfully deleted');
+                    ErrorHandler.info('Policy was successfully deleted','');
                     await updatePolicies();
                 }catch(error){
                     ErrorHandler.handle(error, 'Error deleting policy');

--- a/public/components/security/policies/policies.tsx
+++ b/public/components/security/policies/policies.tsx
@@ -21,9 +21,10 @@ import {
   EuiInMemoryTable
 } from '@elastic/eui';
 import { PoliciesTable } from './policies-table';
-import { WzRequest } from '../../../react-services/wz-request';
+import WzRequest from '../../../react-services/wz-request';
 import { WazuhSecurity } from '../../../factories/wazuh-security'
-import { ErrorHandler } from '../../../react-services/error-handler';
+// import { ErrorHandler } from '../../../react-services/error-handler';
+import * as  ErrorHandler from '../../../react-services/error-handler';
 import { EditPolicyFlyout } from './edit-policy';
 
 export const Policies = () => {
@@ -42,6 +43,10 @@ export const Policies = () => {
   const [loading, setLoading] = useState(false);
   const [isEditingPolicy, setIsEditingPolicy] = useState(false);
   const [editingPolicy, setEditingPolicy] = useState('');
+
+  // useEffect(() => { console.log("---------------"); console.log(addedResources); console.log(addedActions);  }, []);
+  // useEffect(() => { console.log("---------------"); console.log(addedActions) }, [addedActions]);
+  // useEffect(() => { console.log("---------------"); console.log(addedResources) }, [addedResources]);
 
   useEffect(() => { loadResources() }, [addedActions]);
 

--- a/public/components/security/policies/policies.tsx
+++ b/public/components/security/policies/policies.tsx
@@ -24,7 +24,7 @@ import { PoliciesTable } from './policies-table';
 import WzRequest from '../../../react-services/wz-request';
 import { WazuhSecurity } from '../../../factories/wazuh-security'
 // import { ErrorHandler } from '../../../react-services/error-handler';
-import * as  ErrorHandler from '../../../react-services/error-handler';
+import ErrorHandler from '../../../react-services/error-handler';
 import { EditPolicyFlyout } from './edit-policy';
 
 export const Policies = () => {
@@ -43,10 +43,6 @@ export const Policies = () => {
   const [loading, setLoading] = useState(false);
   const [isEditingPolicy, setIsEditingPolicy] = useState(false);
   const [editingPolicy, setEditingPolicy] = useState('');
-
-  // useEffect(() => { console.log("---------------"); console.log(addedResources); console.log(addedActions);  }, []);
-  // useEffect(() => { console.log("---------------"); console.log(addedActions) }, [addedActions]);
-  // useEffect(() => { console.log("---------------"); console.log(addedResources) }, [addedResources]);
 
   useEffect(() => { loadResources() }, [addedActions]);
 
@@ -351,7 +347,7 @@ export const Policies = () => {
                   <EuiFlexGroup>
                     <EuiFlexItem>
                       <EuiInMemoryTable
-                        items={addedActions}
+                        items={addedActions || []}
                         columns={actions_columns}
                       />
                     </EuiFlexItem>
@@ -400,7 +396,7 @@ export const Policies = () => {
                   <EuiFlexGroup>
                     <EuiFlexItem>
                       <EuiInMemoryTable
-                        items={addedResources}
+                        items={addedResources || []}
                         columns={resources_columns}
                       />
                     </EuiFlexItem>
@@ -422,7 +418,7 @@ export const Policies = () => {
                 onClick={() => createPolicy()}
                 fill>
                 Create policy
-                                    </EuiButton>
+              </EuiButton>
             </EuiForm>
           </EuiFlyoutBody>
         </EuiFlyout>

--- a/public/components/security/roles-mapping/components/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-create.tsx
@@ -49,7 +49,7 @@ export const RolesMappingCreate = ({
       await Promise.all(
         formattedRoles.map(async role => await RolesServices.AddRoleRules(role, [newRule.id]))
       );
-      ErrorHandler.info('Role mapping was successfully created');
+      ErrorHandler.info('Role mapping was successfully created','');
     } catch (error) {
       ErrorHandler.handle(error, 'There was an error');
     }

--- a/public/components/security/roles-mapping/components/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-create.tsx
@@ -12,7 +12,7 @@ import {
   EuiComboBox,
   EuiFieldText,
 } from '@elastic/eui';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { RuleEditor } from './rule-editor';
 import RulesServices from '../../rules/services';
 import RolesServices from '../../roles/services';
@@ -29,8 +29,8 @@ export const RolesMappingCreate = ({
   const [ruleName, setRuleName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  const getRolesList = roles => {
-    const list = roles.map(item => {
+  const getRolesList = roles => {    
+    const list = (roles || []).map(item => {
       return { label: rolesEquivalences[item.id], id: item.id };
     });
     return list;

--- a/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
@@ -13,7 +13,7 @@ import {
   EuiComboBox,
   EuiFieldText,
 } from '@elastic/eui';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { RuleEditor } from './rule-editor';
 import RulesServices from '../../rules/services';
 import RolesServices from '../../roles/services';
@@ -72,9 +72,9 @@ export const RolesMappingEdit = ({
         })
       );
 
-      ErrorHandler.info('Role mapping was successfully updated');
+      ErrorHandler.info('Role mapping was successfully updated', '');
     } catch (error) {
-      ErrorHandler.handle(error, 'There was an error');
+      ErrorHandler.handle(error, 'There was an error editing roles mapping');
     }
     onSave();
     setIsLoading(false);

--- a/public/components/security/roles-mapping/components/roles-mapping-table.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-table.tsx
@@ -7,7 +7,7 @@ import {
   EuiBasicTableColumn,
   SortDirection,
 } from '@elastic/eui';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { WzButtonModalConfirm } from '../../../common/buttons';
 import { WzAPIUtils } from '../../../../react-services/wz-api-utils';
 import RulesServices from '../../rules/services';
@@ -82,10 +82,10 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
             onConfirm={async () => {
               try {
                 await RulesServices.DeleteRules([item.id]);
-                ErrorHandler.info('Role mapping was successfully deleted');
+                ErrorHandler.info('Role mapping was successfully deleted','');
                 updateRules();
               } catch (err) {
-                ErrorHandler.error(err);
+                ErrorHandler.handle(error, 'There was an error deleting roles mapping');
               }
             }}
             modalProps={{ buttonColor: 'danger' }}

--- a/public/components/security/roles-mapping/roles-mapping.tsx
+++ b/public/components/security/roles-mapping/roles-mapping.tsx
@@ -46,28 +46,29 @@ export const RolesMapping = () => {
       setRolesEquivalences(_rolesObject);
     }
     if (rolesError) {
-      // ErrorHandler.error('There was an error loading roles');
-      ErrorHandler.handle('There was an error loading roles');
+      ErrorHandler.handle(rolesError,'There was an error loading roles');
     }
   }, [rolesLoading]);
 
   const getInternalUsers = async () => {
     try {
       const wazuhSecurity = new WazuhSecurity();
-      const users = await wazuhSecurity.security.getUsers();
-      const _users = users.map((item, idx) => {
-        return {
-          id: idx,
-          user: item.username,
-          roles: [],
-          full_name: item.full_name,
-          email: item.email,
-        };
-      }).sort((a, b) => (a.user > b.user) ? 1 : (a.user < b.user) ? -1 : 0);      
-      setInternalUsers(_users);
-    } catch (error) {
-      // ErrorHandler.error('There was an error loading internal users');
-      ErrorHandler.handle('There was an error loading internal users');
+
+      if(wazuhSecurity.security){
+        const users = await wazuhSecurity.security.getUsers();     
+        const _users = users.map((item, idx) => {
+          return {
+            id: idx,
+            user: item.username,
+            roles: [],
+            full_name: item.full_name,
+            email: item.email,
+          };
+        }).sort((a, b) => (a.user > b.user) ? 1 : (a.user < b.user) ? -1 : 0);      
+        setInternalUsers(_users);
+      }
+    } catch (error) {     
+      ErrorHandler.handle(error,'There was an error loading internal users');
     }
   };
 
@@ -76,8 +77,7 @@ export const RolesMapping = () => {
       const _rules = await RulesServices.GetRules();
       setRules(_rules);
     } catch (error) {
-      // ErrorHandler.error('There was an error loading rules');
-      ErrorHandler.handle('There was an error loading rules');
+      ErrorHandler.handle(error,'There was an error loading rules');
     }
   };
 

--- a/public/components/security/roles-mapping/roles-mapping.tsx
+++ b/public/components/security/roles-mapping/roles-mapping.tsx
@@ -11,7 +11,9 @@ import {
 import { RolesMappingTable } from './components/roles-mapping-table';
 import { RolesMappingEdit } from './components/roles-mapping-edit';
 import { RolesMappingCreate } from './components/roles-mapping-create';
-import { ErrorHandler } from '../../../react-services/error-handler';
+// import { ErrorHandler } from '../../../react-services/error-handler';
+// import * as ErrorHandler from '../../../react-services/error-handler';
+import ErrorHandler from '../../../react-services/error-handler';
 import { WazuhSecurity } from '../../../factories/wazuh-security';
 import { useApiService } from '../../common/hooks/useApiService';
 import { Rule } from '../rules/types/rule.type';
@@ -31,7 +33,7 @@ export const RolesMapping = () => {
   const [internalUsers, setInternalUsers] = useState([]);
   const currentPlatform = useSelector((state: any) => state.appStateReducers.currentPlatform);
 
-  useEffect(() => {
+  useEffect(() => {   
     initData();
   }, []);
 
@@ -44,7 +46,8 @@ export const RolesMapping = () => {
       setRolesEquivalences(_rolesObject);
     }
     if (rolesError) {
-      ErrorHandler.error('There was an error loading roles');
+      // ErrorHandler.error('There was an error loading roles');
+      ErrorHandler.handle('There was an error loading roles');
     }
   }, [rolesLoading]);
 
@@ -63,7 +66,8 @@ export const RolesMapping = () => {
       }).sort((a, b) => (a.user > b.user) ? 1 : (a.user < b.user) ? -1 : 0);      
       setInternalUsers(_users);
     } catch (error) {
-      ErrorHandler.error('There was an error loading internal users');
+      // ErrorHandler.error('There was an error loading internal users');
+      ErrorHandler.handle('There was an error loading internal users');
     }
   };
 
@@ -72,7 +76,8 @@ export const RolesMapping = () => {
       const _rules = await RulesServices.GetRules();
       setRules(_rules);
     } catch (error) {
-      ErrorHandler.error('There was an error loading rules');
+      // ErrorHandler.error('There was an error loading rules');
+      ErrorHandler.handle('There was an error loading rules');
     }
   };
 

--- a/public/components/security/roles/create-role.tsx
+++ b/public/components/security/roles/create-role.tsx
@@ -12,8 +12,9 @@ import {
     EuiComboBox
 } from '@elastic/eui';
 
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+// import * as ErrorHandler from '../../../react-services/error-handler';
+import ErrorHandler from '../../../react-services/error-handler';
 
 
 
@@ -41,7 +42,7 @@ export const CreateRole = ({ closeFlyout }) => {
 
 
 
-    const createUser = async () => {
+    const createRole = async () => {
         if (!roleName) {
             setRoleNameError(true);
             return;
@@ -88,10 +89,10 @@ export const CreateRole = ({ closeFlyout }) => {
             if(policiesData.failed_items && policiesData.failed_items.length){
                 return;
             }
-            ErrorHandler.info('Role was successfully created with the selected policies');
+            ErrorHandler.info('Role was successfully created with the selected policies', '');
 
         } catch (error) {
-            ErrorHandler.handle(error, "There was an error");
+            ErrorHandler.handle(error, "Error creating a new role");
         }
         closeFlyout(false)
     }
@@ -142,7 +143,7 @@ export const CreateRole = ({ closeFlyout }) => {
                     />
                 </EuiFormRow>
                 <EuiSpacer />
-                <EuiButton fill onClick={createUser}>
+                <EuiButton fill onClick={createRole}>
                     Create role
                 </EuiButton>
             </EuiForm>

--- a/public/components/security/roles/edit-role-table.tsx
+++ b/public/components/security/roles/edit-role-table.tsx
@@ -5,8 +5,8 @@ import {
     EuiDescriptionList,
 } from '@elastic/eui';
 import { RIGHT_ALIGNMENT } from '@elastic/eui/lib/services';
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+import ErrorHandler from '../../../react-services/error-handler';
 
 
 
@@ -96,7 +96,7 @@ export const EditRolesTable = ({ policies, role, onChange, isDisabled, loading})
                         setIsLoading(false);
                         return;
                     }
-                    ErrorHandler.info(`Policy was successfull removed from role ${role.name}`);
+                    ErrorHandler.info(`Policy was successfull removed from role ${role.name}`,'');
                     await onChange();
                   }catch(err){ }
                   setIsLoading(false);

--- a/public/components/security/roles/edit-role.tsx
+++ b/public/components/security/roles/edit-role.tsx
@@ -15,8 +15,8 @@ import {
     EuiComboBox,
 } from '@elastic/eui';
 
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+import ErrorHandler from '../../../react-services/error-handler';
 import { EditRolesTable } from './edit-role-table';
 
 const reservedRoles = ['administrator', 'readonly', 'users_admin', 'agents_readonly', 'agents_admin', 'cluster_readonly', 'cluster_admin'];
@@ -76,7 +76,7 @@ export const EditRole = ({ role, closeFlyout }) => {
 
 
 
-    const addPolicy = async () => {
+    const editPolicy = async () => {
         if (!selectedPolicies.length) {
             setSelectedPoliciesError(true);
             return;
@@ -104,7 +104,7 @@ export const EditRole = ({ role, closeFlyout }) => {
             if (policiesData.failed_items && policiesData.failed_items.length) {
                 return;
             }
-            ErrorHandler.info('Role was successfully updated with the selected policies');
+            ErrorHandler.info('Role was successfully updated with the selected policies','');
             setSelectedPolicies([])
             await update();
         } catch (error) {
@@ -154,7 +154,7 @@ export const EditRole = ({ role, closeFlyout }) => {
                         </EuiFormRow>
                     </EuiFlexItem>
                     <EuiFlexItem grow={true}>
-                        <EuiButton style={{ marginTop: 20, maxWidth: 45 }} isDisabled={isReserved} fill onClick={addPolicy}>
+                        <EuiButton style={{ marginTop: 20, maxWidth: 45 }} isDisabled={isReserved} fill onClick={editPolicy}>
                             Add policy
                     </EuiButton>
 

--- a/public/components/security/roles/roles-table.tsx
+++ b/public/components/security/roles/roles-table.tsx
@@ -10,20 +10,20 @@ import {
     EuiSpacer,
     EuiLoadingSpinner
 } from '@elastic/eui';
-import { WzRequest } from '../../../react-services/wz-request';
-import { ErrorHandler } from '../../../react-services/error-handler';
+import WzRequest from '../../../react-services/wz-request';
+import ErrorHandler from '../../../react-services/error-handler';
 import { WzButtonModalConfirm } from '../../common/buttons';
 import { WzAPIUtils } from '../../../react-services/wz-api-utils';
 
-export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}) => {
-   
+export const RolesTable = ({ roles, policiesData, loading, editRole, updateRoles }) => {
+
     const getRowProps = item => {
         const { id } = item;
         return {
-          'data-test-subj': `row-${id}`,
-          onClick: () => editRole(item),
+            'data-test-subj': `row-${id}`,
+            onClick: () => editRole(item),
         };
-      };
+    };
 
     const columns = [
         {
@@ -65,7 +65,7 @@ export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}
                                         <p>{(data.policy || {}).effect}</p>
                                     </div>
                                 }>
-                                <EuiBadge color="hollow" onClick={() => {}} onClickAriaLabel={`${data.name} policy`} title={null}>{
+                                <EuiBadge color="hollow" onClick={() => { }} onClickAriaLabel={`${data.name} policy`} title={null}>{
                                     data.name
                                 }</EuiBadge>
                             </EuiToolTip>
@@ -86,41 +86,41 @@ export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}
             sortable: false,
         },
         {
-          align: 'right',
-          width: '5%',
-          name: 'Actions',
-          render: item => (
-            <div onClick={ev => ev.stopPropagation()}>
-                <WzButtonModalConfirm
-                buttonType='icon'
-                tooltip={{content: WzAPIUtils.isReservedID(item.id) ? "Reserved roles can't be deleted" : 'Delete role', position: 'left'}}
-                isDisabled={WzAPIUtils.isReservedID(item.id)}
-                modalTitle={`Do you want to delete the ${item.name} role?`}
-                onConfirm={async () => {
-                    try{
-                        const response = await WzRequest.apiReq(
-                        'DELETE',
-                        `/security/roles/`,
-                        {
-                            params: {
-                                role_ids: item.id
-                            }
-                        }
-                    );                    
-                    const data = (response.data || {}).data;
-                    if (data.failed_items && data.failed_items.length){
-                        return;
-                    }
-                    ErrorHandler.info('Role was successfully deleted');
-                    await updateRoles();
-                }catch(error){}
-                }}
-                modalProps={{buttonColor: 'danger'}}
-                iconType='trash'
-                color='danger'
-                aria-label='Delete role'
-                />
-            </div>
+            align: 'right',
+            width: '5%',
+            name: 'Actions',
+            render: item => (
+                <div onClick={ev => ev.stopPropagation()}>
+                    <WzButtonModalConfirm
+                        buttonType='icon'
+                        tooltip={{ content: WzAPIUtils.isReservedID(item.id) ? "Reserved roles can't be deleted" : 'Delete role', position: 'left' }}
+                        isDisabled={WzAPIUtils.isReservedID(item.id)}
+                        modalTitle={`Do you want to delete the ${item.name} role?`}
+                        onConfirm={async () => {
+                            try {
+                                const response = await WzRequest.apiReq(
+                                    'DELETE',
+                                    `/security/roles/`,
+                                    {
+                                        params: {
+                                            role_ids: item.id
+                                        }
+                                    }
+                                );
+                                const data = (response.data || {}).data;
+                                if (data.failed_items && data.failed_items.length) {
+                                    return;
+                                }
+                                ErrorHandler.info('Role was successfully deleted','');
+                                await updateRoles();
+                            } catch (error) { }
+                        }}
+                        modalProps={{ buttonColor: 'danger' }}
+                        iconType='trash'
+                        color='danger'
+                        aria-label='Delete role'
+                    />
+                </div>
             )
         }
     ];

--- a/public/components/security/roles/roles.tsx
+++ b/public/components/security/roles/roles.tsx
@@ -17,7 +17,7 @@ import {
   EuiComboBox
 } from '@elastic/eui';
 import { RolesTable } from './roles-table';
-import { WzRequest } from '../../../react-services/wz-request'
+import WzRequest from '../../../react-services/wz-request'
 import { CreateRole } from './create-role';
 import { EditRole } from './edit-role';
 
@@ -38,6 +38,7 @@ export const Roles = () => {
       {}
     );
     const roles = (((roles_request || {}).data || {}).data || {}).affected_items || [];
+    
     setRoles(roles);
     const policies_request = await WzRequest.apiReq(
       'GET',

--- a/public/components/security/roles/services/add-role-rules.service.ts
+++ b/public/components/security/roles/services/add-role-rules.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { Role } from '../types/role.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const AddRoleRulesService = async (roleId: number, rules: number[]): Promise<Role> => {

--- a/public/components/security/roles/services/get-roles.service.ts
+++ b/public/components/security/roles/services/get-roles.service.ts
@@ -11,7 +11,7 @@ import IApiResponse from '../../../../react-services/interfaces/api-response.int
  * Find more information about this on the LICENSE file.
  */
 
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import { Role } from '../types/role.type';
 
 const GetRolesService = async (): Promise<Role[]> => {

--- a/public/components/security/roles/services/remove-role-rules.service.ts
+++ b/public/components/security/roles/services/remove-role-rules.service.ts
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 import { Role } from '../types/role.type';
 

--- a/public/components/security/rules/services/create-rule.service.ts
+++ b/public/components/security/rules/services/create-rule.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { CreateRule, Rule } from '../types/rule.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const CreateRuleService = async (rule: CreateRule): Promise<Rule> => {

--- a/public/components/security/rules/services/delete-rules.service.ts
+++ b/public/components/security/rules/services/delete-rules.service.ts
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import { Rule } from '../types/rule.type';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 

--- a/public/components/security/rules/services/get-rules.service.ts
+++ b/public/components/security/rules/services/get-rules.service.ts
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import { Rule } from '../types/rule.type';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 

--- a/public/components/security/rules/services/update-rule.service.ts
+++ b/public/components/security/rules/services/update-rule.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { UpdateRule, Rule } from '../types/rule.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const UpdateRuleService = async (ruleId: number, rule: UpdateRule): Promise<Rule> => {

--- a/public/components/security/users/components/create-user.tsx
+++ b/public/components/security/users/components/create-user.tsx
@@ -23,7 +23,7 @@ import { Role } from '../../roles/types/role.type';
 import { CreateUser as TCreateUser } from '../types/user.type';
 import UsersServices from '../services';
 import RolesServices from '../../roles/services';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { useDebouncedEffect } from '../../../common/hooks/useDebouncedEffect';
 
 export const CreateUser = ({ closeFlyout }) => {
@@ -130,7 +130,7 @@ export const CreateUser = ({ closeFlyout }) => {
 
   const editUser = async () => {
     if (!isValidForm()) {
-      ErrorHandler.warning('Please resolve the incorrect fields.');
+      ErrorHandler.warning('Please resolve the incorrect fields.','');
       return;
     }
 
@@ -146,7 +146,7 @@ export const CreateUser = ({ closeFlyout }) => {
       const user = await UsersServices.CreateUser(userData);
       await addRoles(user.id);
 
-      ErrorHandler.info('User was successfully created');
+      ErrorHandler.info('User was successfully created','');
       closeFlyout(true);
     } catch (error) {
       ErrorHandler.handle(error, 'There was an error');

--- a/public/components/security/users/components/edit-user.tsx
+++ b/public/components/security/users/components/edit-user.tsx
@@ -22,7 +22,7 @@ import { Role } from '../../roles/types/role.type';
 import { UpdateUser } from '../types/user.type';
 import UsersServices from '../services';
 import RolesServices from '../../roles/services';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { WzAPIUtils } from '../../../../react-services/wz-api-utils';
 import { useDebouncedEffect } from '../../../common/hooks/useDebouncedEffect';
 
@@ -115,7 +115,7 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
 
   const editUser = async () => {
     if (!isValidForm()) {
-      ErrorHandler.warning('Please resolve the incorrect fields.');
+      ErrorHandler.warning('Please resolve the incorrect fields.','');
       return;
     }
 
@@ -131,7 +131,7 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
     try {
       await Promise.all([UsersServices.UpdateUser(currentUser.id, userData), updateRoles()]);
 
-      ErrorHandler.info('User was successfully updated');
+      ErrorHandler.info('User was successfully updated','');
       closeFlyout(true);
     } catch (error) {
       ErrorHandler.handle(error, 'There was an error');

--- a/public/components/security/users/components/users-table.tsx
+++ b/public/components/security/users/components/users-table.tsx
@@ -10,7 +10,7 @@ import {
 } from '@elastic/eui';
 import { WzButtonModalConfirm } from '../../../common/buttons';
 import UsersServices from '../services';
-import { ErrorHandler } from '../../../../react-services/error-handler';
+import ErrorHandler from '../../../../react-services/error-handler';
 import { WzAPIUtils } from '../../../../react-services/wz-api-utils';
 
 export const UsersTable = ({ users, editUserFlyover, rolesLoading, roles, onSave }) => {
@@ -76,10 +76,10 @@ export const UsersTable = ({ users, editUserFlyover, rolesLoading, roles, onSave
             onConfirm={async () => {
               try {
                 await UsersServices.DeleteUsers([item.id]);
-                ErrorHandler.info('User was successfully deleted');
+                ErrorHandler.info('User was successfully deleted','');
                 onSave();
               } catch (err) {
-                ErrorHandler.error(err);
+                ErrorHandler.handle(err,'There are an error');
               }
             }}
             modalProps={{ buttonColor: 'danger' }}

--- a/public/components/security/users/services/add-user-roles.service.ts
+++ b/public/components/security/users/services/add-user-roles.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { User } from '../types/user.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const AddUserRolesService = async (userId: number, roles: number[]): Promise<User> => {

--- a/public/components/security/users/services/create-user.service.ts
+++ b/public/components/security/users/services/create-user.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { CreateUser, User } from '../types/user.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const CreateUserService = async (user: CreateUser): Promise<User> => {

--- a/public/components/security/users/services/delete-users.service.ts
+++ b/public/components/security/users/services/delete-users.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { User } from '../types/user.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const DeleteUsersService = async (

--- a/public/components/security/users/services/get-users.service.ts
+++ b/public/components/security/users/services/get-users.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { User } from '../types/user.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const GetUsersService = async (): Promise<User[]> => {

--- a/public/components/security/users/services/remove-user-roles.service.ts
+++ b/public/components/security/users/services/remove-user-roles.service.ts
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 import { User } from '../types/user.type';
 

--- a/public/components/security/users/services/update-user.service.ts
+++ b/public/components/security/users/services/update-user.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { UpdateUser, User } from '../types/user.type';
-import { WzRequest } from '../../../../react-services/wz-request';
+import WzRequest from '../../../../react-services/wz-request';
 import IApiResponse from '../../../../react-services/interfaces/api-response.interface';
 
 const UpdateUserService = async (userId: number, user: UpdateUser): Promise<User> => {

--- a/public/components/security/users/users.tsx
+++ b/public/components/security/users/users.tsx
@@ -34,6 +34,9 @@ export const Users = () => {
       setSecurityError(true);
     });
 
+    console.log("_users");
+    console.log(_users);
+  
     setUsers(_users as User[]);
   };
 

--- a/public/react-services/error-handler.ts
+++ b/public/react-services/error-handler.ts
@@ -120,6 +120,31 @@ const warning = (message, location) => {
 };
 
 /**
+ * Fires a red toast (danger toast) using given message
+ * @param {string} message The message to be shown
+ * @param {string} location Usually means the file where this method was called
+ */
+const error = (message, location) => {
+  const toasts = getToasts();
+  if (typeof message === 'string') {
+    // Current date in milliseconds
+    const date = new Date().getTime();
+
+    // Remove errors older than 2s from the error history
+    history = filterRecentHistory(date);
+
+    // Check if the incoming error was already shown in the last two seconds
+    const recentlyShown = isErrorRecentlyShown(message);
+
+    if (!recentlyShown) {
+      message = location ? `${location}. ${message}` : message;
+      history.push({ text: message, date });
+      toasts.addDanger(message);
+    }
+  }
+};
+
+/**
  * Main method to show error, warning or info messages
  * @param {*} error
  * @param {string} location Usually means the file where this method was called
@@ -186,4 +211,5 @@ export default {
   info,
   warning,
   handle,
+  error,
 };

--- a/public/react-services/wz-authentication.ts
+++ b/public/react-services/wz-authentication.ts
@@ -27,6 +27,7 @@ const login = async (force = false) => {
     }
     const response = await WzRequest.genericReq('POST', '/api/login', { idHost, force });
     const token = ((response || {}).data || {}).token;
+
     return token as string;
   } catch (error) {
     return Promise.reject(error);

--- a/public/react-services/wz-authentication.ts
+++ b/public/react-services/wz-authentication.ts
@@ -32,6 +32,7 @@ const login = async (force = false) => {
     return Promise.reject(error);
   }
 };
+
 const refresh = async (force = false) => {
   try {
     // Get user token
@@ -42,6 +43,8 @@ const refresh = async (force = false) => {
     // Decode token and get expiration time
     const jwtPayload = jwtDecode(token);
 
+    
+    
     // Get user Policies
     const userPolicies = await getUserPolicies();
     // Dispatch actions to set permissions and roles

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -73,8 +73,10 @@ export class WazuhApiCtrl {
     try {
       const { force, idHost } = request.body;
       const { userName, authContext } = await this.securityObj.getCurrentUser(request, context);
+      
       if (!force && request.headers.cookie && userName === this.getUserFromCookie(request.headers.cookie) && idHost === this.getApiIdFromCookie(request.headers.cookie)) {
         const wzToken = this.getTokenFromCookie(request.headers.cookie);
+
         if (wzToken) {
           try { // if the current token is not a valid jwt token we ask for a new one
             const decodedToken = jwtDecode(wzToken);
@@ -966,6 +968,13 @@ export class WazuhApiCtrl {
    * @returns {Object} API response or ErrorResponse
    */
   async makeRequest(method, path, data, id, response, token) {
+    // console.log("makeRequest");
+    // console.log(method);
+    // console.log(method, path );
+    // console.log(method, path, data );
+    // console.log(method, path, data, id );
+    // console.log(method, path, data, id, response)
+    
     const devTools = !!(data || {}).devTools;
     try {
       const api = await this.manageHosts.getHostById(id);
@@ -1053,7 +1062,10 @@ export class WazuhApiCtrl {
         }
       }
 
-      const responseToken = await this.apiInterceptor.requestToken(method, fullUrl, data, options, token);
+      const responseToken = await this.apiInterceptor.requestToken(method, fullUrl, data, options, token);  
+
+      console.log(responseToken.data, path);
+      
       const responseIsDown = this.checkResponseIsDown(responseToken);
       if (responseIsDown) {
         return ErrorResponse(

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -104,7 +104,7 @@ export class WazuhApiCtrl {
             `wz-api=${idHost};Path=/;HttpOnly`,
           ],
         },
-        body: {}
+        body: {token}
       });
     } catch (error) {
       const errorMessage = ((error.response || {}).data || {}).detail || error.message || error;

--- a/server/routes/wazuh-api.ts
+++ b/server/routes/wazuh-api.ts
@@ -74,7 +74,7 @@ export function WazuhApiRoutes(router: IRouter, securityObj: ISecurityFactory) {
         id: schema.string(),
         method: schema.string(),
         path: schema.string(),
-        body: schema.object({}),
+        body: schema.any(),
       })
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "esModuleInterop": true,
     "outDir": "./target",
     "allowUnusedLabels": true,


### PR DESCRIPTION
- Migrate Security components to React.
- Modify imports for security migration.
- Add useHistory component for react-router.
- Add useLocation component to check the current URL and select the current security tab by URL.
- Refactor getInternalUsers function: Now, if the security check is false, don't try to get Elastic users.

Close [#2701](https://github.com/wazuh/wazuh-kibana-app/issues/2701)