### PR TITLE
Fix/5964 fix the breadcrumb of applications

### DIFF
--- a/plugins/main/public/application.ts
+++ b/plugins/main/public/application.ts
@@ -8,6 +8,9 @@ export async function renderApp(moduleName: string, element: HTMLElement) {
   await import('./app');
   const $injector = mountWazuhApp(moduleName, element);
   return () => {
+    // This is done because when not using the breadcrumb that opensearch offers
+    // we add a display: "none" so that it is seen as we want the breadcrumb
+    // and for the other applications we have to remove it.
     removeDisplayNoneBreadcrumb();
     return $injector.get('$rootScope').$destroy();
   };

--- a/plugins/main/public/application.ts
+++ b/plugins/main/public/application.ts
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import { removeDisplayNoneBreadcrumb } from './utils/wz-logo-menu';
 
 /**
  * Here's where Discover's inner angular is mounted and rendered
@@ -6,7 +7,10 @@ import angular from 'angular';
 export async function renderApp(moduleName: string, element: HTMLElement) {
   await import('./app');
   const $injector = mountWazuhApp(moduleName, element);
-  return () => $injector.get('$rootScope').$destroy();
+  return () => {
+    removeDisplayNoneBreadcrumb();
+    return $injector.get('$rootScope').$destroy();
+  };
 }
 
 function mountWazuhApp(moduleName: string, element: HTMLElement) {

--- a/plugins/main/public/components/common/globalBreadcrumb/globalBreadcrumb.tsx
+++ b/plugins/main/public/components/common/globalBreadcrumb/globalBreadcrumb.tsx
@@ -20,7 +20,8 @@ class WzGlobalBreadcrumb extends Component {
     const breadcrumbs = this.props.state.breadcrumb.map(breadcrumb =>
       breadcrumb.agent
         ? {
-            className: 'euiLink euiLink--subdued osdBreadcrumbs',
+            className:
+              'euiLink euiLink--subdued osdBreadcrumbs wz-vertical-align-middle',
             onClick: ev => {
               ev.stopPropagation();
               navigateAppURL(

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -1833,3 +1833,7 @@ iframe.width-changed {
 .wz-overflow-auto{
   overflow: auto;
 }
+
+.wz-vertical-align-middle {
+  vertical-align: middle !important;
+}

--- a/plugins/main/public/utils/wz-logo-menu.js
+++ b/plugins/main/public/utils/wz-logo-menu.js
@@ -22,3 +22,12 @@ export const changeWazuhNavLogo = () => {
     }
   }, 200);
 };
+
+export const removeDisplayNoneBreadcrumb = () => {
+  const nav = document.querySelector(
+    '[data-test-subj="breadcrumbs"]  > .euiBreadcrumbWall',
+  );
+  if (nav) {
+    nav.style.display = 'block';
+  }
+};

--- a/plugins/main/public/utils/wz-logo-menu.js
+++ b/plugins/main/public/utils/wz-logo-menu.js
@@ -13,7 +13,9 @@
 // Remove plugin platform Wazuh name and breadcrumb
 export const changeWazuhNavLogo = () => {
   const interval = setInterval(() => {
-    const nav = document.querySelector('[data-test-subj="breadcrumbs"]  > .euiBreadcrumb');
+    const nav = document.querySelector(
+      '[data-test-subj="breadcrumbs"]  > .euiBreadcrumbWall',
+    );
     if (nav) {
       clearInterval(interval);
       nav.style.display = 'none';


### PR DESCRIPTION
### Description
Fixes breadcrumb after OSD upgrade to version 2.10.0

### Issues Resolved
- #5964

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/bfaffc01-a45b-4e48-9a9e-3c6e40c54194)
![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/82be4c9d-17ea-4296-9f0b-81e2830bb0e5)
![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/0858a700-1398-4d96-9016-b5dbf94a7dec)
![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/ef84208c-bfe5-46cf-a4ad-8dd1b6c19add)


### Test
Navigate in the various wazuh and OSD applications and view the breadcumb well.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
