### PR TITLE
Rename applications on agent menu

### DIFF
--- a/plugins/main/public/components/common/modules/main-agent.tsx
+++ b/plugins/main/public/components/common/modules/main-agent.tsx
@@ -59,18 +59,6 @@ export class MainModuleAgent extends Component {
     this.router = $injector.get('$route');
   }
 
-  showAgentInfo() {
-    const elem = document.getElementsByClassName('wz-module-body-main')[0];
-    if (elem) {
-      if (!this.state.showAgentInfo) {
-        elem.classList.add('wz-module-body-main-double');
-      } else {
-        elem.classList.remove('wz-module-body-main-double');
-      }
-    }
-    this.setState({ showAgentInfo: !this.state.showAgentInfo });
-  }
-
   async startReport() {
     this.setState({ loadingReport: true });
     const syscollectorFilters: any[] = [];
@@ -158,7 +146,7 @@ export class MainModuleAgent extends Component {
         </div>
         {agent && agent.os && (
           <Fragment>
-            <div className='wz-module-header-nav-wrapper'>
+            <div>
               <div
                 className={
                   this.props.tabs &&

--- a/plugins/main/public/components/common/modules/module.scss
+++ b/plugins/main/public/components/common/modules/module.scss
@@ -2,13 +2,6 @@
     display: contents;
 }
 
-.wz-module-header-agent-wrapper, .wz-module-header-nav-wrapper{
-    width: 100%;
-    position: fixed;
-    z-index: 3000;
-    left: 0;
-}
-
 .wz-module-header-agent, .wz-module-header-nav{
     background:#fafbfd;
 }
@@ -61,10 +54,6 @@
     font-weight: 500;
 }
 
-.wz-module-header-nav-wrapper{
-    margin-top: 49px;
-}
-
 .wz-module-header-nav .euiTabs{
     padding-top: 6px;
 }
@@ -79,9 +68,6 @@
 }
 
 .wz-module.wz-module-welcome{
-    .wz-module-agent-body{
-        padding-top: 50px !important;
-    }
     .wz-module-body{
         padding-top: 109px !important;
     }
@@ -93,14 +79,6 @@
 
 .flyout-body .globalQueryBar{
     padding: 2px 0px 8px 0px!important;
-}
-
-.wz-module-body-main {
-    padding-top: 50px!important;
-}
-
-.wz-module-body-main-double {
-    padding-top: 102px!important;
 }
 
 .sidebar-list{
@@ -116,9 +94,6 @@ discover-app-w .sidebar-container {
         padding-top: 189px !important;
     }
     @media only screen and (max-width: 767px){
-        .wz-module.wz-module-welcome .wz-module-agent-body{
-            padding-top: 0px !important;
-        }
         .wz-module-header-agent{
             height: auto;
             h1{
@@ -129,14 +104,6 @@ discover-app-w .sidebar-container {
         }
         .wz-module-body {
             margin-top: -160px;
-        }
-
-        .wz-module-header-agent-wrapper, .wz-module-header-nav-wrapper{
-            position: relative;
-        }
-
-        .wz-module-header-nav-wrapper{
-            margin-top: 15px;
         }
 
         .wz-module-header-nav {

--- a/plugins/main/public/components/common/welcome/components/menu-agent.js
+++ b/plugins/main/public/components/common/welcome/components/menu-agent.js
@@ -95,6 +95,7 @@ class WzMenuAgent extends Component {
       id: item.id,
       name: (
         <EuiFlexGroup
+          responsive={false}
           onMouseEnter={() => {
             this.setState({ hoverAddFilter: item.id });
           }}

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -1628,10 +1628,6 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   padding-left: 320px;
 }
 
-.chrHeaderWrapper--navIsLocked~.app-wrapper .wz-module-header-nav-wrapper {
-  padding-left: 320px;
-}
-
 .icon-box-action {
   display: flex;
 }

--- a/plugins/main/public/templates/agents/dashboards.html
+++ b/plugins/main/public/templates/agents/dashboards.html
@@ -127,17 +127,16 @@
   </div>
   <!-- end agents module -->
   <!-- agents syscollector -->
-  <div ng-if="tab === 'syscollector'" ng-show="!load" class="euiPageBody wz-module-body-main">
+  <div ng-if="tab === 'syscollector'" ng-show="!load" class="euiPageBody">
     <react-component name="MainSyscollector" props="{agent: agent}"></react-component>
   </div>
   <!-- end agents syscollector-->
   <!-- agents stats -->
-  <div ng-if="tab === 'stats'" class="euiPageBody wz-module-body-main">
+  <div ng-if="tab === 'stats'" class="euiPageBody">
     <react-component name="MainAgentStats" props="{agent: agent}"></react-component>
   </div>
   <!-- end agents stats-->
   <react-component
-    class="wz-module-body-main"
     ng-if="tab === 'configuration' && agent"
     name="WzManagementConfiguration"
     props="{agent: agent, goGroups: goGroups, exportConfiguration: exportConfiguration}"

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -20,10 +20,11 @@ const overview = {
   }),
   euiIconType: 'lensApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/overview/',
 };
 
-const fileIntegrityMonitoring = {
+export const fileIntegrityMonitoring = {
   category: 'wz-category-endpoint-security',
   id: 'file-integrity-monitoring',
   title: i18n.translate('wz-app-file-integrity-monitoring', {
@@ -35,6 +36,7 @@ const fileIntegrityMonitoring = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=fim&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -54,6 +56,7 @@ const endpointSumary = {
   }),
   euiIconType: 'usersRolesApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/agents-preview/',
 };
 
@@ -69,6 +72,7 @@ const malwareDetection = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=pm&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -77,7 +81,7 @@ const malwareDetection = {
     }`,
 };
 
-const configurationAssessment = {
+export const configurationAssessment = {
   category: 'wz-category-endpoint-security',
   id: 'configuration-assessment',
   title: i18n.translate('wz-app-configuration-assessment', {
@@ -89,6 +93,7 @@ const configurationAssessment = {
   }),
   euiIconType: 'managementApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=sca&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -97,11 +102,11 @@ const configurationAssessment = {
     }`,
 };
 
-const threatHunting = {
+export const threatHunting = {
   category: 'wz-category-threat-intelligence',
   id: 'threat-hunting',
   title: i18n.translate('wz-app-threat-hunting', {
-    defaultMessage: 'Threat Hunting',
+    defaultMessage: 'Threat hunting',
   }),
   description: i18n.translate('threat-hunting-description', {
     defaultMessage:
@@ -109,6 +114,7 @@ const threatHunting = {
   }),
   euiIconType: 'securityAnalyticsApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=general&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -117,7 +123,7 @@ const threatHunting = {
     }`,
 };
 
-const vulnerabilityDetection = {
+export const vulnerabilityDetection = {
   category: 'wz-category-threat-intelligence',
   id: 'vulnerability-detection',
   title: i18n.translate('wz-app-vulnerability-detection', {
@@ -129,6 +135,7 @@ const vulnerabilityDetection = {
   }),
   euiIconType: 'heartbeatApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=vuls&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -137,7 +144,7 @@ const vulnerabilityDetection = {
     }`,
 };
 
-const mitreAttack = {
+export const mitreAttack = {
   category: 'wz-category-threat-intelligence',
   id: 'mitre-attack',
   title: i18n.translate('wz-app-mitre-attack', {
@@ -149,6 +156,7 @@ const mitreAttack = {
   }),
   euiIconType: 'grokApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=mitre&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -169,6 +177,7 @@ const virustotal = {
   }),
   euiIconType: 'monitoringApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=virustotal&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -189,6 +198,7 @@ const pciDss = {
   }),
   euiIconType: 'sqlApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=pci&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -209,6 +219,7 @@ const hipaa = {
   }),
   euiIconType: 'monitoringApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=hipaa&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -229,6 +240,7 @@ const gdpr = {
   }),
   euiIconType: 'sqlApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=gdpr&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -249,6 +261,7 @@ const nist80053 = {
   }),
   euiIconType: 'notebookApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=nist&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -269,6 +282,7 @@ const tsc = {
   }),
   euiIconType: 'packetbeatApp',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=tsc&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -289,6 +303,7 @@ const itHygiene = {
   }),
   euiIconType: 'visualizeApp',
   showInOverviewApp: true,
+  showInAgentMenu: false,
   redirectTo: () =>
     `/agents/?tab=welcome${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -309,6 +324,7 @@ const amazonWebServices = {
   }),
   euiIconType: 'logoAWSMono',
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=aws&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -329,6 +345,7 @@ const googleCloud = {
   }),
   euiIconType: LogoGoogleCloud,
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=gcp&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -349,6 +366,7 @@ const github = {
   }),
   euiIconType: LogoGitHub,
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=github&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -368,6 +386,7 @@ const office365 = {
   }),
   euiIconType: LogoOffice365,
   showInOverviewApp: true,
+  showInAgentMenu: false,
   redirectTo: () =>
     `/overview/?tab=office&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -388,6 +407,7 @@ const docker = {
   }),
   euiIconType: LogoDocker,
   showInOverviewApp: true,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=docker&tabView=panels${
       store.getState()?.appStateReducers?.currentAgentData?.id
@@ -407,6 +427,7 @@ const rules = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=ruleset',
 };
 
@@ -421,6 +442,7 @@ const decoders = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=decoders',
 };
 
@@ -435,6 +457,7 @@ const cdbLists = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=lists',
 };
 
@@ -449,6 +472,7 @@ const endpointGroups = {
   }),
   euiIconType: 'usersRolesApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=groups',
 };
 
@@ -463,6 +487,7 @@ const serverStatus = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=status',
 };
 
@@ -477,6 +502,7 @@ const cluster = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=monitoring',
 };
 
@@ -491,6 +517,7 @@ const statistics = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=statistics',
 };
 
@@ -505,6 +532,7 @@ const logs = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=logs',
 };
 
@@ -519,6 +547,7 @@ const reporting = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/manager/?tab=reporting',
 };
 
@@ -533,7 +562,7 @@ const settings = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
-  redirectTo: () => '/manager/?tab=configuration',
+  showInAgentMenu: false,
 };
 
 const devTools = {
@@ -547,6 +576,7 @@ const devTools = {
   }),
   euiIconType: 'devToolsApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/wazuh-dev/?tab=devTools',
 };
 
@@ -561,6 +591,7 @@ const rulesetTest = {
   }),
   euiIconType: 'visualizeApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/wazuh-dev/?tab=logtest',
 };
 
@@ -576,6 +607,7 @@ const security = {
   }),
   euiIconType: 'securityAnalyticsApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/security',
 };
 
@@ -590,6 +622,7 @@ const serverApi = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/settings?tab=api',
 };
 
@@ -604,6 +637,7 @@ const serverData = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/settings?tab=sample_data',
 };
 
@@ -618,7 +652,7 @@ const wazuhPluginSettings = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
-  redirectTo: () => '/settings?tab=configuration',
+  showInAgentMenu: false,
 };
 
 const wazuhPluginLogs = {
@@ -632,6 +666,7 @@ const wazuhPluginLogs = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/settings?tab=logs',
 };
 
@@ -646,6 +681,7 @@ const wazuhPluginAbout = {
   }),
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
+  showInAgentMenu: false,
   redirectTo: () => '/settings?tab=about',
 };
 

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -563,6 +563,7 @@ const settings = {
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
   showInAgentMenu: false,
+  redirectTo: () => '/manager/?tab=configuration',
 };
 
 const devTools = {
@@ -653,6 +654,7 @@ const wazuhPluginSettings = {
   euiIconType: 'indexRollupApp',
   showInOverviewApp: false,
   showInAgentMenu: false,
+  redirectTo: () => '/settings?tab=configuration',
 };
 
 const wazuhPluginLogs = {


### PR DESCRIPTION
### Description
This pull request adapts the agent menu to display the applications related to agents.

Changes: 
- Refactor agent menu to use the applications and categories
- Simplify the data saved in the local storage to keep the pinned applications
- Remove the usage of extensions configuration
- Change the data schema of the pinned applications
- Rename the session storage key to `wz-menu-agent-apps-pinned` where the pinned applications are stored
- Fix a problem with the agent menu header when the side menu is docked

### Issues Resolved
#5893 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/05dd2445-196b-4f1e-8fee-fbe4b3ebd82d)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/cba0bab7-3190-41f7-a967-9916d7dc3b59)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/097608da-b5a8-4d0f-b2b5-02a644257e2a)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/24a322d9-2d43-43f4-9ddb-ae08487b25b0)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome |
| --- |  --- |
| With a fresh browser, ensure the Threat hunting, File integrity monitoring, Configuration assessment, Vulnerability detection and MITRE ATT&CK applications are displayed as the default ones in the agent welcome view | :black_circle: |
| Clicking on the More button of agent welcome, should display all the applications | :black_circle: |
| Pinning an application from the More/Applications menu should display that application out of the More menu | :black_circle: |
| Unpinning an application from the More/Applications menu should not display that application out of the More menu | :black_circle: |
| Using a small window width, the More button on the agent welcome should display as Applications | :black_circle: |
| Modify the pinned applications from the agent welcome, close the browser, open it and navigate the the agent welcome view. The pinned applications should be kept | :black_circle: |
| The agent's navbar should display correctly | :black_circle: |
| The agent's navbar should display correctly with the dock menu. | :black_circle: |
| Inventory data, statistics and configuration must be displayed correctly | :black_circle: |


**Details**
<details>
<summary>:black_circle: With a fresh browser, ensure the Threat hunting, File integrity monitoring, Configuration assessment, Vulnerability detection and MITRE ATT&CK applications are displayed as the default ones in the agent welcome view</summary>

Chrome - :black_circle:

</details>

<details>
<summary>:black_circle: Clicking on the More button of agent welcome, should display all the applications</summary>

Chrome - :black_circle:

</details>

<details>
<summary>:black_circle: Pinning an application from the More/Applications menu should display that application out of the More menu</summary>

Chrome - :black_circle:

</details>

<details>
<summary>:black_circle: Unpinning an application from the More/Applications menu should not display that application out of the More menu</summary>

Chrome - :black_circle:

</details>

<details>
<summary>:black_circle: Using a small window width, the More button on the agent welcome should display as Applications</summary>

Chrome - :black_circle:

</details>

<details>
<summary>:black_circle: Modify the pinned applications from the agent welcome, close the browser, open it and navigate the the agent welcome view. The pinned applications should be kept</summary>

Chrome - :black_circle:

</details>
<details>
<summary>:black_circle: The agent's navbar should display correctly</summary>

Chrome - :black_circle:

</details>
<details>
<summary>:black_circle: The agent's navbar should display correctly with the dock menu</summary>

Chrome - :black_circle:

</details>
<details>
<summary>:black_circle: Inventory data, statistics and configuration must be displayed correctly</summary>

Chrome - :black_circle:

</details>


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
