### PR TITLE
Fix agent name text in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-
 ## Wazuh v4.7.0 - OpenSearch Dashboards 2.8.0 - Revision 01
 
 ### Added
@@ -20,7 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed problem with new or missing columns in agent table. [#5591](https://github.com/wazuh/wazuh-kibana-app/pull/5591)
-- Fixed the color of the agent name in the groups section in dark mode. [#5676](https://github.com/wazuh/wazuh-kibana-app/pull/5676)
+- Fixed the color of the agent name in the groups section in dark mode. [#5676](https://github.com/wazuh/wazuh-kibana-app/pull/5676) [#6018](https://github.com/wazuh/wazuh-kibana-app/pull/6018)
 - Fixed the propagation event so that the flyout data, in the decoders, does not change when the button is pressed. [#5597](https://github.com/wazuh/wazuh-kibana-app/pull/5597)
 - Fixed the tooltips of the tables in the security section, and unnecessary requests are removed. [#5631](https://github.com/wazuh/wazuh-kibana-app/pull/5631)
 
@@ -29,7 +28,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed views in JSON and XML formats from management settings. [#5747](https://github.com/wazuh/wazuh-kibana-app/pull/5747)
 
 ## Wazuh v4.6.0 - OpenSearch Dashboards 2.8.0 - Revision 02
-
 
 ### Added
 

--- a/plugins/main/public/styles/theme/dark/index.dark.scss
+++ b/plugins/main/public/styles/theme/dark/index.dark.scss
@@ -234,6 +234,9 @@ table thead > tr {
 .wzMultipleSelector select {
   border-color: #343741;
 }
+.wzMultipleSelectorSelect {
+  color: #dfe5ef;
+}
 
 .btn-info {
   border: 1px solid #343741 !important;


### PR DESCRIPTION
### Description
This PR aims to fix an issue detected in #6000 regarding the color of the agent's name text in the group selector while using dark mode
 
### Issues Resolved
#6016 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/ab23e99d-4a7a-4ee0-ba37-693cde3f5ec8)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/7453ff78-9e7f-47d6-8653-ca2c3baa785c)

### Test
1. Enable dark mode in Stack Management
2. Navigate to management/groups
3. Select a group and go to Manage Agents
4. Verify that the text is clearly visible

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
