### PR TITLE
Change the display order of tabs in all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Changed dashboards. [#6035](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6035)
+- Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 00
 

--- a/plugins/main/public/components/agents/sca/main.tsx
+++ b/plugins/main/public/components/agents/sca/main.tsx
@@ -88,10 +88,10 @@ export const MainSca = compose(
 
   return (
     <>
-      {selectView === 'dashboard' ? (
-        <Dashboard {...rest} agent={agentData} />
-      ) : (
+      {selectView === 'inventory' ? (
         <Inventory {...rest} agent={agentData} />
+      ) : (
+        <Dashboard {...rest} agent={agentData} />
       )}
     </>
   );

--- a/plugins/main/public/components/agents/sca/main.tsx
+++ b/plugins/main/public/components/agents/sca/main.tsx
@@ -88,10 +88,10 @@ export const MainSca = compose(
 
   return (
     <>
-      {selectView === 'inventory' ? (
-        <Inventory {...rest} agent={agentData} />
-      ) : (
+      {selectView === 'dashboard' ? (
         <Dashboard {...rest} agent={agentData} />
+      ) : (
+        <Inventory {...rest} agent={agentData} />
       )}
     </>
   );

--- a/plugins/main/public/components/common/modules/modules-defaults.js
+++ b/plugins/main/public/components/common/modules/modules-defaults.js
@@ -36,13 +36,13 @@ const EventsTab = {
   component: Events,
 };
 const RegulatoryComplianceTabs = [
+  DashboardTab,
   {
     id: 'inventory',
     name: 'Controls',
     buttons: [ButtonModuleExploreAgent],
     component: ComplianceTable,
   },
-  DashboardTab,
   EventsTab,
 ];
 
@@ -55,13 +55,13 @@ export const ModulesDefaults = {
   fim: {
     init: 'dashboard',
     tabs: [
+      DashboardTab,
       {
         id: 'inventory',
         name: 'Inventory',
         buttons: [ButtonModuleExploreAgent],
         component: MainFim,
       },
-      DashboardTab,
       EventsTab,
     ],
     availableFor: ['manager', 'agent'],
@@ -90,14 +90,14 @@ export const ModulesDefaults = {
     init: 'dashboard',
     tabs: [
       {
-        id: 'inventory',
-        name: 'Inventory',
+        id: 'dashboard',
+        name: 'Dashboard',
         buttons: [ButtonModuleExploreAgent],
         component: MainSca,
       },
       {
-        id: 'dashboard',
-        name: 'Dashboard',
+        id: 'inventory',
+        name: 'Inventory',
         buttons: [ButtonModuleExploreAgent],
         component: MainSca,
       },
@@ -110,16 +110,16 @@ export const ModulesDefaults = {
     init: 'dashboard',
     tabs: [
       {
-        id: 'inventory',
-        name: 'Panel',
-        buttons: [ButtonModuleExploreAgent],
-        component: withModuleNotForAgent(OfficePanel),
-      },
-      {
         id: 'dashboard',
         name: 'Dashboard',
         buttons: [ButtonModuleExploreAgent, ButtonModuleGenerateReport],
         component: withModuleNotForAgent(Dashboard),
+      },
+      {
+        id: 'inventory',
+        name: 'Panel',
+        buttons: [ButtonModuleExploreAgent],
+        component: withModuleNotForAgent(OfficePanel),
       },
       { ...EventsTab, component: withModuleNotForAgent(Events) },
     ],
@@ -128,13 +128,13 @@ export const ModulesDefaults = {
   github: {
     init: 'dashboard',
     tabs: [
+      DashboardTab,
       {
         id: 'inventory',
         name: 'Panel',
         buttons: [ButtonModuleExploreAgent],
         component: GitHubPanel,
       },
-      DashboardTab,
       EventsTab,
     ],
     availableFor: ['manager', 'agent'],
@@ -161,6 +161,7 @@ export const ModulesDefaults = {
   mitre: {
     init: 'dashboard',
     tabs: [
+      DashboardTab,
       {
         id: 'intelligence',
         name: 'Intelligence',
@@ -172,7 +173,6 @@ export const ModulesDefaults = {
         buttons: [ButtonModuleExploreAgent],
         component: MainMitre,
       },
-      DashboardTab,
       EventsTab,
     ],
     availableFor: ['manager', 'agent'],

--- a/plugins/main/public/components/wz-menu/wz-menu-overview.js
+++ b/plugins/main/public/components/wz-menu/wz-menu-overview.js
@@ -10,7 +10,14 @@
  * Find more information about this on the LICENSE file.
  */
 import React, { Component } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiFlexGrid, EuiButtonEmpty, EuiSideNav, EuiIcon } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlexGrid,
+  EuiButtonEmpty,
+  EuiSideNav,
+  EuiIcon,
+} from '@elastic/eui';
 import { connect } from 'react-redux';
 import store from '../../redux/store';
 import { updateCurrentAgentData } from '../../redux/actions/appStateActions';
@@ -26,7 +33,7 @@ class WzMenuOverview extends Component {
     super(props);
     this.currentApi = JSON.parse(AppState.getCurrentAPI()).id;
     this.state = {
-      extensions: []
+      extensions: [],
     };
 
     this.overviewSections = {
@@ -75,7 +82,8 @@ class WzMenuOverview extends Component {
       },
       sca: {
         id: WAZUH_MODULES_ID.SECURITY_CONFIGURATION_ASSESSMENT,
-        cyTestId: WAZUH_MENU_MODULES_SECTIONS_CY_TEST_ID.SECURITY_CONFIGURATION_ASSESSMENT,
+        cyTestId:
+          WAZUH_MENU_MODULES_SECTIONS_CY_TEST_ID.SECURITY_CONFIGURATION_ASSESSMENT,
         text: 'Security configuration assessment',
       },
       audit: {
@@ -156,28 +164,28 @@ class WzMenuOverview extends Component {
       this.overviewSections.office,
       this.overviewSections.aws,
       this.overviewSections.gcp,
-      this.overviewSections.github
+      this.overviewSections.github,
     ];
     this.auditingItems = [
       this.overviewSections.pm,
       this.overviewSections.audit,
       this.overviewSections.oscap,
       this.overviewSections.ciscat,
-      this.overviewSections.sca
+      this.overviewSections.sca,
     ];
     this.threatDetectionItems = [
       this.overviewSections.vuls,
       this.overviewSections.virustotal,
       this.overviewSections.osquery,
       this.overviewSections.docker,
-      this.overviewSections.mitre
+      this.overviewSections.mitre,
     ];
     this.regulatoryComplianceItems = [
       this.overviewSections.pci,
       this.overviewSections.gdpr,
       this.overviewSections.hipaa,
       this.overviewSections.nist,
-      this.overviewSections.tsc
+      this.overviewSections.tsc,
     ];
   }
 
@@ -192,19 +200,20 @@ class WzMenuOverview extends Component {
     this.props.closePopover();
     const params = { tab: section };
     if (this.props.currentAgentData.id)
-      params["agentId"] = this.props.currentAgentData.id;
-    if (section === "sca") { // SCA initial tab is inventory
-      params["tabView"] = "inventory"
+      params['agentId'] = this.props.currentAgentData.id;
+    if (section === 'sca') {
+      // SCA initial tab is inventory
+      params['tabView'] = 'dashboard';
     }
 
     if (this.props.currentTab !== section) {
       // do not redirect if we already are in that tab
       if (!this.props.isAgent) {
-        AppNavigate.navigateToModule(ev, 'overview', params)
+        AppNavigate.navigateToModule(ev, 'overview', params);
       } else {
         if (!this.props.switchTab) {
           this.props.updateCurrentAgentData(this.props.isAgent);
-          AppNavigate.navigateToModule(ev, 'overview', params)
+          AppNavigate.navigateToModule(ev, 'overview', params);
         } else {
           this.props.switchTab(section);
         }
@@ -215,9 +224,16 @@ class WzMenuOverview extends Component {
   createItems = items => {
     const keyExists = key => Object.keys(this.state.extensions).includes(key);
     const keyIsTrue = key => (this.state.extensions || [])[key];
-    return items.filter(item => 
-      (Object.keys(this.props.currentAgentData).length ? hasAgentSupportModule(this.props.currentAgentData, item.id) : true) && Object.keys(this.state.extensions).length && (!keyExists(item.id) || keyIsTrue(item.id))
-    ).map(item => this.createItem(item));
+    return items
+      .filter(
+        item =>
+          (Object.keys(this.props.currentAgentData).length
+            ? hasAgentSupportModule(this.props.currentAgentData, item.id)
+            : true) &&
+          Object.keys(this.state.extensions).length &&
+          (!keyExists(item.id) || keyIsTrue(item.id)),
+      )
+      .map(item => this.createItem(item));
   };
 
   createItem = (item, data = {}) => {
@@ -228,8 +244,8 @@ class WzMenuOverview extends Component {
       name: item.text,
       'data-test-subj': item.cyTestId,
       isSelected: this.props.currentTab === item.id,
-      onClick: () => { },
-      onMouseDown: (ev) => this.clickMenuItem(ev, item.id)
+      onClick: () => {},
+      onMouseDown: ev => this.clickMenuItem(ev, item.id),
     };
   };
 
@@ -239,57 +255,58 @@ class WzMenuOverview extends Component {
   }
 
   render() {
-
     const securityInformation = [
       {
         name: this.overviewSections.securityInformation.text,
         id: this.overviewSections.securityInformation.id,
-        icon: <EuiIcon type="managementApp" color="primary" />,
-        items: this.createItems(this.securityInformationItems)
-      }
+        icon: <EuiIcon type='managementApp' color='primary' />,
+        items: this.createItems(this.securityInformationItems),
+      },
     ];
 
     const auditing = [
       {
         name: this.overviewSections.auditing.text,
         id: this.overviewSections.auditing.id,
-        icon: <EuiIcon type="managementApp" color="primary" />,
-        items: this.createItems(this.auditingItems)
-      }
+        icon: <EuiIcon type='managementApp' color='primary' />,
+        items: this.createItems(this.auditingItems),
+      },
     ];
 
     const threatDetection = [
       {
         name: this.overviewSections.threatDetection.text,
         id: this.overviewSections.threatDetection.id,
-        icon: <EuiIcon type="reportingApp" color="primary" />,
-        items: this.createItems(this.threatDetectionItems)
-      }
+        icon: <EuiIcon type='reportingApp' color='primary' />,
+        items: this.createItems(this.threatDetectionItems),
+      },
     ];
 
     const regulatoryCompliance = [
       {
         name: this.overviewSections.regulatoryCompliance.text,
         id: this.overviewSections.regulatoryCompliance.id,
-        icon: <EuiIcon type="reportingApp" color="primary" />,
-        items: this.createItems(this.regulatoryComplianceItems)
-      }
+        icon: <EuiIcon type='reportingApp' color='primary' />,
+        items: this.createItems(this.regulatoryComplianceItems),
+      },
     ];
 
-    const agentData = store.getState().appStateReducers.currentAgentData
+    const agentData = store.getState().appStateReducers.currentAgentData;
 
     return (
-      <div className="WzManagementSideMenu wz-menu-overview">
-        {Object.keys(this.state.extensions).length && (
+      <div className='WzManagementSideMenu wz-menu-overview'>
+        {(Object.keys(this.state.extensions).length && (
           <div>
             {!agentData.id && (
               <EuiFlexGroup>
                 <EuiFlexItem grow={false} style={{ marginLeft: 14 }}>
-                  <EuiButtonEmpty iconType="apps"
+                  <EuiButtonEmpty
+                    iconType='apps'
                     onClick={() => {
                       this.props.closePopover();
                       window.location.href = '#/overview';
-                    }}>
+                    }}
+                  >
                     Modules directory
                   </EuiButtonEmpty>
                 </EuiFlexItem>
@@ -303,10 +320,7 @@ class WzMenuOverview extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiSideNav
-                  items={auditing}
-                  style={{ padding: '4px 12px' }}
-                />
+                <EuiSideNav items={auditing} style={{ padding: '4px 12px' }} />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiSideNav
@@ -322,8 +336,7 @@ class WzMenuOverview extends Component {
               </EuiFlexItem>
             </EuiFlexGrid>
           </div>
-        ) || (<div style={{ width: 300 }}></div>
-          )}
+        )) || <div style={{ width: 300 }}></div>}
       </div>
     );
   }
@@ -332,15 +345,13 @@ class WzMenuOverview extends Component {
 const mapStateToProps = state => {
   return {
     currentAgentData: state.appStateReducers.currentAgentData,
-    currentTab: state.appStateReducers.currentTab
+    currentTab: state.appStateReducers.currentTab,
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  updateCurrentAgentData: (agentData) => dispatch(updateCurrentAgentData(agentData))
+  updateCurrentAgentData: agentData =>
+    dispatch(updateCurrentAgentData(agentData)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(WzMenuOverview);
+export default connect(mapStateToProps, mapDispatchToProps)(WzMenuOverview);


### PR DESCRIPTION
### Description

Change the display order of tabs in all modules
 
### Issues Resolved

#6066 

### Test

Compruebe que en todos los modulos que tengan las pestañas de Inventory, Dashboard y Events aparezcan ordenadas de la siguiente manera:

Dashboard | Inventory | Events

Y que en el resto de los modulos siempre aparezca primero el tab de dashboard

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
