### PR TITLE
Add ssl agent ca configuration entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.8.0
 - Added remember server address check [#5791](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5791)
+- Added the ssl_agent_ca configuration to the SSL Settings form [#6083](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6083)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 00
 

--- a/plugins/main/public/controllers/management/components/management/configuration/registration-service/registration-service.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/registration-service/registration-service.js
@@ -97,7 +97,8 @@ const keyRequestSettings = [
 ];
 
 const sslSettings = [
-  { field: 'ssl_verify_host', label: 'Verify agents using a CA certificate' },
+  { field: 'ssl_verify_host', label: 'Verify host when a CA certificate is specified' },
+  { field: 'ssl_agent_ca', label: 'Path to the CA certificate used to verify clients' },
   {
     field: 'ssl_auto_negotiate',
     label: 'Auto-select the SSL negotiation method',


### PR DESCRIPTION
### Description
Hi team,
this PR adds `ssl_agent_ca` to _Management -> Configuration -> Registration service_ with the label **_"Path to the CA certificate used to verify clients"_**.
 Also, it changes the previous label from _""_ to _"Verify host when a CA certificate is specified"_

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/053b2a18-8fac-4e34-a2aa-1ba7c00e64d5)


### Test

- Add the **_ssl_agent_ca_** entry to the `ossec.conf` file and restart the manager.
- Verify this configuration entry is included in the _Management -> Configuration -> Registration service_

```xml

<!-- Configuration for wazuh-authd -->
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>no</use_source_ip>
    <purge>yes</purge>
    <use_password>no</use_password>
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <ssl_agent_ca>etc/sslmanager.cert</ssl_agent_ca>
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>

```

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
