### PR TITLE
Add Github actions to run wazuh check updates plugin tests

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -39,15 +39,28 @@ on:
         default: false
         required: false
 
-env:
-  MAIN_PLUGIN_PATH: 'wazuh/plugins/main'
-
 jobs:
   # Deploy the plugin in a development environment and run a command
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        plugins:
+          [
+            {
+              name: 'Main',
+              path: 'wazuh/plugins/main',
+              container_path: 'wazuh',
+            },
+            {
+              name: 'Wazuh Check Updates',
+              path: 'wazuh/plugins/wazuh-check-updates',
+              container_path: 'wazuh-check-updates',
+            },
+          ]
+
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v3
@@ -65,13 +78,13 @@ jobs:
           # Detect which platform to use from source code
           platform=kbn;
           echo "Detecting platform [kbn, osd]...";
-          find ${{ env.MAIN_PLUGIN_PATH }}/opensearch_dashboards.json && { platform=osd; };
+          find ${{ matrix.plugins.path }}/opensearch_dashboards.json && { platform=osd; };
           echo "Platform is $platform";
 
           # Read the platform version from the package.json file
           echo "Reading the platform version from the package.json...";
           # Support plugins whose version is defined under pluginPlatform or Kibana properties
-          platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ env.MAIN_PLUGIN_PATH }}/package.json);
+          platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ matrix.plugins.path }}/package.json);
           echo "Plugin platform version: $platform_version";
 
           # Set the environment variable to the correct platform
@@ -81,12 +94,12 @@ jobs:
           # Up the environment and run the command
           docker run -t --rm \
             -e ${docker_env_plugin_platform}=${platform_version} \
-            -v `pwd`/${{ env.MAIN_PLUGIN_PATH }}:/home/node/kbn/plugins/wazuh \
+            -v `pwd`/${{ matrix.plugins.path }}:/home/node/kbn/plugins/${{ matrix.plugins.container_path }} \
             ${{ inputs.docker_run_extra_args }} \
             quay.io/wazuh/${platform}-dev:${platform_version} \
             bash -c '
               yarn config set registry https://registry.yarnpkg.com;
-              cd /home/node/kbn/plugins/wazuh && yarn && ${{ inputs.command }};
+              cd /home/node/kbn/plugins/${{ matrix.plugins.container_path }} && yarn && ${{ inputs.command }};
             '
 
       - name: Step 04 - Upload artifact to GitHub
@@ -94,13 +107,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
-          path: ${{env.MAIN_PLUGIN_PATH}}/${{ inputs.artifact_path }}
+          path: ${{ matrix.plugins.path }}/${{ inputs.artifact_path }}
           if-no-files-found: 'error'
 
       - name: Step 05 - Upload coverage results to GitHub
         if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}
-        uses: AthleticNet/comment-test-coverage@1.2.2
+        uses: lucianogorza/comment-test-coverage@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./${{ env.MAIN_PLUGIN_PATH }}/target/test-coverage/coverage-summary.json
-          title: "Code coverage (Jest)"
+          path: ./${{ matrix.plugins.path }}/target/test-coverage/coverage-summary.json
+          title: '${{ matrix.plugins.name }} plugin code coverage (Jest) test'

--- a/plugins/wazuh-check-updates/scripts/manifest.js
+++ b/plugins/wazuh-check-updates/scripts/manifest.js
@@ -1,0 +1,17 @@
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const fs = require('fs');
+
+/**
+ * Reads the package.json file.
+ * @returns {Object} JSON object.
+ */
+function loadPackageJson() {
+  const packageJson = fs.readFileSync('./package.json');
+  return JSON.parse(packageJson);
+}
+
+module.exports = {
+  loadPackageJson
+};

--- a/plugins/wazuh-check-updates/scripts/runner.js
+++ b/plugins/wazuh-check-updates/scripts/runner.js
@@ -1,0 +1,148 @@
+/* eslint-disable array-element-newline */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/**
+Runs yarn commands using a Docker container.
+
+Intended to test and build locally.
+
+Uses development images. Must be executed from the root folder of the project.
+
+See /docker/runner/docker-compose.yml for available environment variables.
+
+# Usage:
+# -------------
+#   - node scripts/runner <command> [<command_args>]
+#   - yarn test:jest:runner [<jest_args>]
+#   - yarn build:runner
+*/
+
+const childProcess = require('child_process');
+const { loadPackageJson } = require('./manifest');
+
+const COMPOSE_DIR = '../../docker/runner';
+
+function getProjectInfo() {
+  const manifest = loadPackageJson();
+
+  return {
+    app: 'osd',
+    version: manifest['pluginPlatform']['version'],
+    repo: process.cwd(),
+  };
+}
+
+function getBuildArgs({ app, version }) {
+  return `--opensearch-dashboards-version=${version}`;
+}
+
+/**
+ * Transforms the Jest CLI options from process.argv back to a string.
+ * If no options are provided, default ones are generated.
+ * @returns {String} Space separated string with all Jest CLI options provided.
+ */
+function getJestArgs() {
+  // Take args only after `test` word
+  const index = process.argv.indexOf('test');
+  const args = process.argv.slice(index + 1);
+  // Remove duplicates using set
+  return Array.from(new Set([...args, '--runInBand'])).join(' ');
+}
+
+/**
+ * Generates the execution parameters if they are not set.
+ * @returns {Object} Default environment variables.
+ */
+const buildEnvVars = ({ app, version, repo, cmd, args }) => {
+  return {
+    APP: app,
+    VERSION: version,
+    REPO: repo,
+    CMD: cmd,
+    ARGS: args,
+  };
+};
+
+/**
+ * Captures the SIGINT signal (Ctrl + C) to stop the container and exit.
+ */
+function setupAbortController() {
+  process.on('SIGINT', () => {
+    childProcess.spawnSync('docker', [
+      'compose',
+      '--project-directory',
+      COMPOSE_DIR,
+      'stop',
+    ]);
+    process.exit();
+  });
+}
+
+/**
+ * Start the container.
+ */
+function startRunner() {
+  const runner = childProcess.spawn('docker', [
+    'compose',
+    '--project-directory',
+    COMPOSE_DIR,
+    'up',
+  ]);
+
+  runner.stdout.on('data', data => {
+    console.log(`${data}`);
+  });
+
+  runner.stderr.on('data', data => {
+    console.error(`${data}`);
+  });
+}
+
+/**
+ * Main function
+ */
+function main() {
+  if (process.argv.length < 2) {
+    process.stderr.write('Required parameters not provided');
+    process.exit(-1);
+  }
+
+  const projectInfo = getProjectInfo();
+  let envVars = {};
+
+  switch (process.argv[2]) {
+    case 'build':
+      envVars = buildEnvVars({
+        ...projectInfo,
+        cmd: 'plugin-helpers build',
+        args: getBuildArgs({ ...projectInfo }),
+      });
+      break;
+
+    case 'test':
+      envVars = buildEnvVars({
+        ...projectInfo,
+        cmd: 'test:jest',
+        args: getJestArgs(),
+      });
+      break;
+
+    default:
+      // usage();
+      console.error('Unsupported or invalid yarn command.');
+      process.exit(-1);
+  }
+
+  // Check the required environment variables are set
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+    console.log(`${key}: ${process.env[key]}`);
+  }
+
+  setupAbortController();
+  startRunner();
+}
+
+main();


### PR DESCRIPTION
### Description
Add the GitHub Actions to run tests for the Wazuh Check Updates plugin when pushing changes to a PR.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard/issues/111

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/5601c13d-6968-401b-977f-8fe8953fa89f)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/d07e22fc-b57e-4059-a1d2-f62636a32fd0)

### Test
One way to test the changes is to fork the repository, make a commit with some modifications, and create a PR. Once the tests are run and automatic comments are generated, you should make another commit and push it to test that new comments are generated and the previous ones are removed.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
