### PR TITLE
Fix Security Events table query filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed a problem with the agent menu header when the side menu is docked [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
+- Fixed how the query filters apply on the Security Alerts table [#6102](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6102)
 
 ### Removed
 

--- a/plugins/main/public/components/common/hooks/use-query.ts
+++ b/plugins/main/public/components/common/hooks/use-query.ts
@@ -11,38 +11,6 @@
  */
 import { getDataPlugin } from '../../../kibana-services';
 import { useState, useEffect } from 'react';
-import { ModulesHelper } from '../modules/modules-helper';
-import _ from 'lodash';
-
-export function useQuery(): [
-  {
-    language: 'kuery' | 'lucene';
-    query: string;
-  },
-  (query: any) => void
-] {
-  const [query, setQuery] = useState({ language: 'kuery', query: '' });
-  useEffect(() => {
-    let subscription;
-    ModulesHelper.getDiscoverScope().then((scope) => {
-      setQuery(scope.state.query);
-      subscription = scope.$watchCollection('fetchStatus', () => {
-        if (!_.isEqual(query, scope.state.query)) {
-          setQuery(scope.state.query);
-        }
-      });
-    });
-    return () => {
-      subscription && subscription();
-    };
-  }, []);
-  const updateQuery = (query) => {
-    ModulesHelper.getDiscoverScope().then((scope) => {
-      scope.state.query = query;
-    });
-  };
-  return [query, updateQuery];
-}
 
 export const useQueryManager = () => {
   const [query, setQuery] = useState(getDataPlugin().query.queryString.getQuery());

--- a/plugins/main/public/components/visualize/components/security-alerts.tsx
+++ b/plugins/main/public/components/visualize/components/security-alerts.tsx
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 import React from 'react';
-import { useFilterManager, useQuery, useRefreshAngularDiscover } from '../../common/hooks';
+import { useFilterManager, useQueryManager, useRefreshAngularDiscover } from '../../common/hooks';
 import { Discover } from '../../common/modules/discover';
 import { useAllowedAgents } from '../../common/hooks/useAllowedAgents';
 
@@ -37,7 +37,7 @@ export const SecurityAlerts = ({
   ],
   useAgentColumns = true,
 }) => {
-  const [query] = useQuery();
+  const [query] = useQueryManager();
   const { filterManager } = useFilterManager();
   const refreshAngularDiscover = useRefreshAngularDiscover();
 


### PR DESCRIPTION
### Description
Hi team,
this pull request deprecates the `useQuery` hook which uses the method `getDiscoverScope()` of the legacy Discover. It replaces its implementation with the `useQueryManager` hook that makes use of the Data plugin to handle the query state. 
 
### Issues Resolved
Closes #6042 

### Evidence
![Peek 2023-11-06 18-51](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/24c4663d-bef5-44a8-82eb-34c517758faf)


### Test

- Go to Security Events
- Click in the input Query bar
- Type a value, like 553 (_a rule ID_) and press "enter"
- See the change apply to the visualizations and the table
- Delete the value from the input Query bar and press enter
- Check the values in the visualizations and the Security alerts table are correct

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
