### PR TITLE
Fix UI crash on retrieving log collection configuration for macos agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed problem when using non latin characters in the username [#6076](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6076)
+- Fixed UI crash on retrieving log collection configuration for macos agent. [#6104](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6104)
 
 ## Wazuh v4.7.0 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/plugins/main/public/controllers/management/components/management/configuration/log-collection/log-collection.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/log-collection/log-collection.js
@@ -13,19 +13,20 @@
 import React, { Component, Fragment } from 'react';
 
 import WzTabSelector, {
-  WzTabSelectorTab
+  WzTabSelectorTab,
 } from '../util-components/tab-selector';
 import WzConfigurationLogCollectionLogs from './log-collection-logs';
 import WzConfigurationLogCollectionCommands from './log-collection-commands';
-import WzConfigurationLogCollectionWindowsEvents from './log-collection-windowsevents'
+import WzConfigurationLogCollectionWindowsEvents from './log-collection-windowsevents';
 import WzConfigurationLogCollectionSockets from './log-collection-sockets';
 import withWzConfig from '../util-hocs/wz-config';
 import { isString } from '../utils/utils';
-import { 
-  LOCALFILE_COMMANDS_PROP, 
-  LOCALFILE_LOGS_PROP, 
-  LOCALFILE_WINDOWSEVENT_PROP, 
-  LOGCOLLECTOR_LOCALFILE_PROP } from './types'
+import {
+  LOCALFILE_COMMANDS_PROP,
+  LOCALFILE_LOGS_PROP,
+  LOCALFILE_WINDOWSEVENT_PROP,
+  LOGCOLLECTOR_LOCALFILE_PROP,
+} from './types';
 
 class WzConfigurationLogCollection extends Component {
   constructor(props) {
@@ -40,45 +41,94 @@ class WzConfigurationLogCollection extends Component {
             ...currentConfig,
             [LOGCOLLECTOR_LOCALFILE_PROP]: {
               ...currentConfig[LOGCOLLECTOR_LOCALFILE_PROP],
-              [LOCALFILE_LOGS_PROP]: currentConfig[LOGCOLLECTOR_LOCALFILE_PROP].localfile.filter(item => typeof item.file !== 'undefined'), // TODO: it needs to be defined to support localfile as `eventchannel`. These doesn't have file property.
-              [LOCALFILE_WINDOWSEVENT_PROP]: currentConfig[LOGCOLLECTOR_LOCALFILE_PROP].localfile.filter(item => item.logformat === 'eventchannel' || item.logformat === 'eventlog'),
-              [LOCALFILE_COMMANDS_PROP]: currentConfig[LOGCOLLECTOR_LOCALFILE_PROP].localfile.filter(item => item.logformat === 'command' || item.logformat === 'full_command')
-            }
+              [LOCALFILE_LOGS_PROP]: currentConfig[
+                LOGCOLLECTOR_LOCALFILE_PROP
+              ].localfile.filter(item => typeof item.file !== 'undefined'), // TODO: it needs to be defined to support localfile as `eventchannel`. These doesn't have file property.
+              [LOCALFILE_WINDOWSEVENT_PROP]: currentConfig[
+                LOGCOLLECTOR_LOCALFILE_PROP
+              ].localfile.filter(
+                item =>
+                  item.logformat === 'eventchannel' ||
+                  item.logformat === 'eventlog',
+              ),
+              [LOCALFILE_COMMANDS_PROP]: currentConfig[
+                LOGCOLLECTOR_LOCALFILE_PROP
+              ].localfile.filter(
+                item =>
+                  item.logformat === 'command' ||
+                  item.logformat === 'full_command',
+              ),
+            },
           }
         : currentConfig;
-    return (
-      <Fragment>
-        <WzTabSelector>
-          { currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_LOGS_PROP].length > 0 && 
-            <WzTabSelectorTab label="Logs">
-              <WzConfigurationLogCollectionLogs
-                currentConfig={currentConfig}
-                agent={agent}
-              />
-            </WzTabSelectorTab>
-          }
-          { currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_WINDOWSEVENT_PROP].length > 0 && 
-            <WzTabSelectorTab label="Windows Events">
-              <WzConfigurationLogCollectionWindowsEvents
-                currentConfig={currentConfig}
-                agent={agent}
-              />
-            </WzTabSelectorTab>
-          }
-          { currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_COMMANDS_PROP].length > 0 && 
-            <WzTabSelectorTab label="Commands">
-              <WzConfigurationLogCollectionCommands
-                currentConfig={currentConfig}
-                agent={agent}
-              />
-            </WzTabSelectorTab>
-          }
-          <WzTabSelectorTab label="Sockets">
+
+    const tabsToRender = [
+      {
+        condition:
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_LOGS_PROP]
+            .length > 0,
+        component: (
+          <WzTabSelectorTab label='Logs'>
+            <WzConfigurationLogCollectionLogs
+              currentConfig={currentConfig}
+              agent={agent}
+            />
+          </WzTabSelectorTab>
+        ),
+      },
+      {
+        condition:
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][
+            LOCALFILE_WINDOWSEVENT_PROP
+          ].length > 0,
+        component: (
+          <WzTabSelectorTab label='Windows Events'>
+            <WzConfigurationLogCollectionWindowsEvents
+              currentConfig={currentConfig}
+              agent={agent}
+            />
+          </WzTabSelectorTab>
+        ),
+      },
+      {
+        condition:
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
+          currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_COMMANDS_PROP]
+            .length > 0,
+        component: (
+          <WzTabSelectorTab label='Commands'>
+            <WzConfigurationLogCollectionCommands
+              currentConfig={currentConfig}
+              agent={agent}
+            />
+          </WzTabSelectorTab>
+        ),
+      },
+      {
+        condition: true, // Will always render
+        component: (
+          <WzTabSelectorTab label='Sockets'>
             <WzConfigurationLogCollectionSockets
               currentConfig={currentConfig}
               agent={agent}
             />
           </WzTabSelectorTab>
+        ),
+      },
+    ];
+
+    return (
+      <Fragment>
+        <WzTabSelector>
+          {tabsToRender
+            .filter(tab => tab.condition)
+            .map((tab, index) =>
+              React.cloneElement(tab.component, {
+                key: `WzTabSelectorTab_${index}`,
+              }),
+            )}
         </WzTabSelector>
       </Fragment>
     );
@@ -87,7 +137,7 @@ class WzConfigurationLogCollection extends Component {
 
 const sections = [
   { component: 'logcollector', configuration: 'localfile' },
-  { component: 'logcollector', configuration: 'socket' }
+  { component: 'logcollector', configuration: 'socket' },
 ];
 
 export default withWzConfig(sections)(WzConfigurationLogCollection);

--- a/plugins/main/public/controllers/management/components/management/configuration/util-components/tab-selector.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/util-components/tab-selector.js
@@ -19,7 +19,9 @@ class WzTabSelector extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedTab: this.props.children[0].props.label
+      selectedTab: this.props.children.find(
+        child => child.props?.label !== undefined,
+      )?.props?.label,
     };
   }
   changeSelectedTab(tab) {
@@ -28,24 +30,26 @@ class WzTabSelector extends Component {
   render() {
     const { selectedTab } = this.state;
     const { children, container, spacer } = this.props;
-    const activeTabContent = children.filter(child => child).find(
-      child => child.props.label === selectedTab
-    );
+    const activeTabContent = children
+      .filter(child => child)
+      .find(child => child.props.label === selectedTab);
     return (
       <Fragment>
         <EuiTabs>
-          {children.filter(child => child).map(child => {
-            const { label } = child.props;
-            return (
-              <EuiTab
-                onClick={() => this.changeSelectedTab(label)}
-                isSelected={label === selectedTab}
-                key={`tab-${label}`}
-              >
-                {label}
-              </EuiTab>
-            );
-          })}
+          {children
+            .filter(child => child)
+            .map(child => {
+              const { label } = child.props;
+              return (
+                <EuiTab
+                  onClick={() => this.changeSelectedTab(label)}
+                  isSelected={label === selectedTab}
+                  key={`tab-${label}`}
+                >
+                  {label}
+                </EuiTab>
+              );
+            })}
         </EuiTabs>
         {(container && container(activeTabContent)) || (
           <div>
@@ -60,7 +64,7 @@ class WzTabSelector extends Component {
 
 WzTabSelector.propTypes = {
   children: PropTypes.array.isRequired,
-  spacer: PropTypes.string
+  spacer: PropTypes.string,
 };
 
 export default WzTabSelector;
@@ -75,5 +79,5 @@ export class WzTabSelectorTab extends Component {
 }
 
 WzTabSelectorTab.propTypes = {
-  label: PropTypes.string
+  label: PropTypes.string,
 };


### PR DESCRIPTION
## Description
This pull request fix UI cash on retrieving log collection configuration for macOS agent. The issue occurs when you go to the settings of a macOS agent and navigate to the Log Collection section. The reason for this error is described in [this comment](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6088#issuecomment-1790625859).

## Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6088

## Evidence
### Log Collection section (UI)
![evidence_macos_response](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/02d45078-0134-4f76-96bc-9dafa3a440f9)

### Log Collection test
![evidence_run_test](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/765ac088-ea71-4b50-b92a-3944ae0cb93f)


## Test

1. To be able to reproduce the context you must have an agent on macOS or you can modify the imposter to emulate the response.
<details>
<summary>
Emulate agent response on macOS with the imposter
</summary>

You must go to the file `~/docker/imposter/agents/configuration/logcollector-localfile.json` and change the default response to the following and restart the imposter:

```json
{
	"data": {
		"localfile": [
			{
				"logformat": "full_command",
				"command": "netstat -an | awk '{if ((/^(tcp|udp)/) && ($4 != \".\") && ($5 == \".\")) {print $1\" \"$4\" \"$5}}' | sort -u",
				"alias": "netstat listening ports",
				"ignore_binaries": "no",
				"target": [
					"agent"
				],
				"frequency": 360
			}
		]
	},
	"error": 0
}
```

</details>

2. Go to the agents section, then select the `Configuration` tab and go to `Log Collection` within the `Log Data analysis` section

3. You should no longer see the error described in the issue and should see what is shown in the evidence.

4. Leave the imposter back as it was originally and verify that it works normally when it is not a macOS agent.



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
