### PR TITLE
Fix agent name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed problem when using non latin characters in the username [#6076](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6076)
+- Fixed incorrect validation of the agent name on the Deploy new agent window [#6105](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6105)
 
 ## Wazuh v4.7.0 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
@@ -65,7 +65,7 @@ describe('Validations', () => {
   test('should return an error message for invalid length', () => {
     const invalidAgentName = 'a';
     const result = validateAgentName(invalidAgentName);
-    expect(result).toBe('The minimum length is 2 characters. ');
+    expect(result).toBe('The minimum length is 2 characters.');
   });
 
   test('should return an empty string for a valid agent name', () => {

--- a/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
@@ -42,22 +42,30 @@ describe('Validations', () => {
     const invalidAgentName = '?';
     const result = validateAgentName(invalidAgentName);
     expect(result).toBe(
-      'The minimum length is 2 characters. The character is not valid. Allowed characters are A-Z, a-z, ".", "-", "_"',
+      'The minimum length is 2 characters. The character "?" is not valid. Allowed characters are A-Z, a-z, 0-9, ".", "-", "_"',
     );
   });
 
-  test('should return an error message for invalid format', () => {
+  test('should return an error message for invalid format of 1 character', () => {
     const invalidAgentName = 'agent$name';
     const result = validateAgentName(invalidAgentName);
     expect(result).toBe(
-      'The character is not valid. Allowed characters are A-Z, a-z, ".", "-", "_"',
+      'The character "$" is not valid. Allowed characters are A-Z, a-z, 0-9, ".", "-", "_"',
+    );
+  });
+
+  test('should return an error message for invalid format of more than 1 character', () => {
+    const invalidAgentName = 'agent$?name';
+    const result = validateAgentName(invalidAgentName);
+    expect(result).toBe(
+      'The characters "$,?" are not valid. Allowed characters are A-Z, a-z, 0-9, ".", "-", "_"',
     );
   });
 
   test('should return an error message for invalid length', () => {
     const invalidAgentName = 'a';
     const result = validateAgentName(invalidAgentName);
-    expect(result).toBe('The minimum length is 2 characters.');
+    expect(result).toBe('The minimum length is 2 characters. ');
   });
 
   test('should return an empty string for a valid agent name', () => {

--- a/plugins/main/public/controllers/register-agent/utils/validations.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.tsx
@@ -43,7 +43,9 @@ export const validateAgentName = (value: any) => {
     return undefined;
   }
   if (value.length < 2) {
-    return `The minimum length is 2 characters. ${validateCharacters(value)}`;
+    return `The minimum length is 2 characters.${
+      validateCharacters(value) && ` ${validateCharacters(value)}`
+    }`;
   }
   return `${validateCharacters(value)}`;
 };

--- a/plugins/main/public/controllers/register-agent/utils/validations.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.tsx
@@ -42,12 +42,13 @@ export const validateAgentName = (value: any) => {
   if (value.length === 0) {
     return undefined;
   }
+  let invalidCharacters = validateCharacters(value);
   if (value.length < 2) {
     return `The minimum length is 2 characters.${
-      validateCharacters(value) && ` ${validateCharacters(value)}`
+      invalidCharacters && ` ${invalidCharacters}`
     }`;
   }
-  return `${validateCharacters(value)}`;
+  return `${invalidCharacters}`;
 };
 
 const validateCharacters = (value: any) => {

--- a/plugins/main/public/controllers/register-agent/utils/validations.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.tsx
@@ -42,16 +42,26 @@ export const validateAgentName = (value: any) => {
   if (value.length === 0) {
     return undefined;
   }
-  const regex = /^[A-Za-z.\-_,]+$/;
-
   const isLengthValid = value.length >= 2 && value.length <= 63;
-  const isFormatValid = regex.test(value);
-  if (!isFormatValid && !isLengthValid) {
-    return 'The minimum length is 2 characters. The character is not valid. Allowed characters are A-Z, a-z, ".", "-", "_"';
-  } else if (!isLengthValid) {
-    return 'The minimum length is 2 characters.';
-  } else if (!isFormatValid) {
-    return 'The character is not valid. Allowed characters are A-Z, a-z, ".", "-", "_"';
+  if (!isLengthValid) {
+    return `The name must have between 2 and 63 characters. ${validateCharacters(
+      value,
+    )}`;
+  }
+  return `${validateCharacters(value)}`;
+};
+
+const validateCharacters = (value: any) => {
+  const regex = /^[a-z0-9.\-_,]+$/i;
+  const invalidCharacters = [
+    ...new Set(value.split('').filter(char => !regex.test(char))),
+  ];
+  if (invalidCharacters.length > 1) {
+    return `The characters "${invalidCharacters.join(
+      ',',
+    )}" are not valid. Allowed characters are A-Z, a-z, 0-9, ".", "-", "_"`;
+  } else if (invalidCharacters.length === 1) {
+    return `The character "${invalidCharacters[0]}" is not valid. Allowed characters are A-Z, a-z, 0-9, ".", "-", "_"`;
   }
   return '';
 };

--- a/plugins/main/public/controllers/register-agent/utils/validations.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.tsx
@@ -42,11 +42,8 @@ export const validateAgentName = (value: any) => {
   if (value.length === 0) {
     return undefined;
   }
-  const isLengthValid = value.length >= 2 && value.length <= 63;
-  if (!isLengthValid) {
-    return `The name must have between 2 and 63 characters. ${validateCharacters(
-      value,
-    )}`;
+  if (value.length < 2) {
+    return `The minimum length is 2 characters. ${validateCharacters(value)}`;
   }
   return `${validateCharacters(value)}`;
 };


### PR DESCRIPTION
### Description
This PR aims to fix an incorrect validation of the agent name in the `Deploy new agent` window, that prevents the use of numeric characters.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6029

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/3149bcfb-f1a7-4a0a-8a12-7ea68d1d205b)


### Test
- Navigate to the `Deploy new agent` section and verify that the agent name is correctly validated. It must allow `A-Z`, `a-z`, `0-9`, `.`,`-`,`_`.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
