### PR TITLE
Fix tests to run sequentially by default

### DIFF
--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -38,7 +38,7 @@
     "test:ui:runner": "node ../../scripts/functional_test_runner.js",
     "test:server": "plugin-helpers test:server",
     "test:browser": "plugin-helpers test:browser",
-    "test:jest": "node scripts/jest",
+    "test:jest": "node scripts/jest --runInBand",
     "test:jest:runner": "node scripts/runner test",
     "generate:api-data": "node scripts/generate-api-data.js --spec https://raw.githubusercontent.com/wazuh/wazuh/$(node -e \"console.log(require('./package.json').version)\")/api/api/spec/spec.yaml --output file --output-directory common/api-info --display-configuration",
     "prebuild": "node scripts/generate-build-version"

--- a/plugins/wazuh-check-updates/package.json
+++ b/plugins/wazuh-check-updates/package.json
@@ -14,7 +14,7 @@
     "test:ui:runner": "node ../../scripts/functional_test_runner.js",
     "test:server": "plugin-helpers test:server",
     "test:browser": "plugin-helpers test:browser",
-    "test:jest": "node scripts/jest",
+    "test:jest": "node scripts/jest --runInBand",
     "test:jest:runner": "node scripts/runner test"
   },
   "dependencies": {

--- a/plugins/wazuh-core/package.json
+++ b/plugins/wazuh-core/package.json
@@ -14,7 +14,7 @@
     "test:ui:runner": "node ../../scripts/functional_test_runner.js",
     "test:server": "plugin-helpers test:server",
     "test:browser": "plugin-helpers test:browser",
-    "test:jest": "node scripts/jest",
+    "test:jest": "node scripts/jest --runInBand",
     "test:jest:runner": "node scripts/runner test"
   },
   "dependencies": {


### PR DESCRIPTION
### Description
This PR aims to configure the tests to be ran sequentially by default. This is due to some tests failing when they are executed after a commit, causing the need to re run several times them. 
 
### Issues Resolved
#6107


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
