### PR TITLE
Bump version 4.8.1 rev 00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.8.1 - OpenSearch Dashboards 2.10.0 - Revision 00
+
+### Added
+
+- Support for Wazuh 4.8.1
+
 ## Wazuh v4.8.0 - OpenSearch Dashboards 2.10.0 - Revision 00
 
 ### Added

--- a/plugins/main/common/api-info/endpoints.json
+++ b/plugins/main/common/api-info/endpoints.json
@@ -7,7 +7,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.default_controller.default_info",
         "description": "Return basic information about the API",
         "summary": "Get API info",
-        "tags": ["API Info"],
+        "tags": [
+          "API Info"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -24,7 +26,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents",
         "description": "Return information about all available agents or a list of them",
         "summary": "List agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -61,7 +65,10 @@
             "description": "Agent groups configuration sync status",
             "schema": {
               "type": "string",
-              "enum": ["synced", "not synced"]
+              "enum": [
+                "synced",
+                "not synced"
+              ]
             }
           },
           {
@@ -206,7 +213,12 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["active", "pending", "never_connected", "disconnected"]
+                "enum": [
+                  "active",
+                  "pending",
+                  "never_connected",
+                  "disconnected"
+                ]
               },
               "minItems": 1
             }
@@ -234,7 +246,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_config",
         "description": "Return the active configuration the agent is currently using. This can be different from the configuration present in the configuration file, if it has been modified and the agent has not been restarted yet",
         "summary": "Get active configuration",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -332,7 +346,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_daemon_stats",
         "description": "Return Wazuh statistical information from specified daemons in a specified agent",
         "summary": "Get Wazuh daemon stats from an agent",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -354,7 +370,10 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["wazuh-analysisd", "wazuh-remoted"]
+                "enum": [
+                  "wazuh-analysisd",
+                  "wazuh-remoted"
+                ]
               }
             }
           },
@@ -381,7 +400,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_sync_agent",
         "description": "Return whether the agent configuration has been synchronized with the agent or not. This can be useful to check after updating a group configuration",
         "summary": "Get configuration sync status",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -419,7 +440,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_key",
         "description": "Return the key of an agent",
         "summary": "Get key",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -457,7 +480,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_component_stats",
         "description": "Return Wazuh's {component} statistical information from agent {agent_id}",
         "summary": "Get agent's component stats",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -476,7 +501,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["logcollector", "agent"]
+              "enum": [
+                "logcollector",
+                "agent"
+              ]
             }
           }
         ],
@@ -504,7 +532,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_no_group",
         "description": "Return a list with all the available agents without an assigned group",
         "summary": "List agents without group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "limit",
@@ -584,7 +614,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_outdated",
         "description": "Return the list of outdated agents",
         "summary": "List outdated agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "limit",
@@ -653,7 +685,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_fields",
         "description": "Return all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination",
         "summary": "List agents distinct",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "fields",
@@ -733,7 +767,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_os",
         "description": "Return a summary of the OS of available agents",
         "summary": "Summarize agents OS",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -758,7 +794,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_status",
         "description": "Return a summary of the connection and groups configuration synchronization statuses of available agents",
         "summary": "Summarize agents status",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -783,7 +821,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_upgrade",
         "description": "Return the agents upgrade results",
         "summary": "Get upgrade results",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -909,7 +949,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.ciscat_controller.get_agents_ciscat_results",
         "description": "Return the agent's ciscat results info",
         "summary": "Get results",
-        "tags": ["Ciscat"],
+        "tags": [
+          "Ciscat"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -1071,7 +1113,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_configuration_node",
         "description": "Return wazuh configuration used in node {node_id}. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
         "summary": "Get node config",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1163,7 +1207,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_node_config",
         "description": "Return the requested configuration in JSON format for the specified node",
         "summary": "Get node active configuration",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":component",
@@ -1259,7 +1305,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_daemon_stats_node",
         "description": "Return Wazuh statistical information from specified daemons in a specified cluster node",
         "summary": "Get Wazuh daemon stats from a cluster node",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1279,7 +1327,11 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["wazuh-analysisd", "wazuh-remoted", "wazuh-db"]
+                "enum": [
+                  "wazuh-analysisd",
+                  "wazuh-remoted",
+                  "wazuh-db"
+                ]
               }
             }
           },
@@ -1306,7 +1358,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_info_node",
         "description": "Return basic information about a specified node such as version, compilation date, installation path",
         "summary": "Get node info",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1342,7 +1396,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_node",
         "description": "Return the last 2000 wazuh log entries in the specified node",
         "summary": "Get node logs",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1464,7 +1520,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_summary_node",
         "description": "Return a summary of the last 2000 wazuh log entries in the specified node",
         "summary": "Get node logs summary",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1500,7 +1558,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_node",
         "description": "Return Wazuh statistical information in node {node_id} for the current or specified date",
         "summary": "Get node stats",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1544,7 +1604,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_analysisd_node",
         "description": "Return Wazuh analysisd statistical information in node {node_id}",
         "summary": "Get node stats analysisd",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1580,7 +1642,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_hourly_node",
         "description": "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field represents the average of alerts per hour",
         "summary": "Get node stats hour",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1616,7 +1680,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_remoted_node",
         "description": "Return Wazuh remoted statistical information in node {node_id}",
         "summary": "Get node stats remoted",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1652,7 +1718,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_weekly_node",
         "description": "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field represents the average of alerts per hour for that specific day",
         "summary": "Get node stats week",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1688,7 +1756,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status_node",
         "description": "Return the status of all Wazuh daemons in node node_id",
         "summary": "Get node status",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -1724,7 +1794,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_api_config",
         "description": "Return the API configuration of all nodes (or a list of them) in JSON format",
         "summary": "Get nodes API config",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "nodes_list",
@@ -1759,7 +1831,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_conf_validation",
         "description": "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them",
         "summary": "Check nodes config",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "nodes_list",
@@ -1794,7 +1868,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_healthcheck",
         "description": "Return cluster healthcheck information for all nodes or a list of them. Such information includes last keep alive, last synchronization time and number of agents reporting on each node",
         "summary": "Get nodes healthcheck",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "nodes_list",
@@ -1829,7 +1905,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_config",
         "description": "Return the current node cluster configuration",
         "summary": "Get local node config",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -1854,7 +1932,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_node",
         "description": "Return basic information about the cluster node receiving the request",
         "summary": "Get local node info",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -1879,7 +1959,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_nodes",
         "description": "Get information about all nodes in the cluster or a list of them",
         "summary": "Get nodes info",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -1967,7 +2049,10 @@
             "description": "Filter by node type",
             "schema": {
               "type": "string",
-              "enum": ["worker", "master"]
+              "enum": [
+                "worker",
+                "master"
+              ]
             }
           },
           {
@@ -1985,7 +2070,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_nodes_ruleset_sync_status",
         "description": "Return ruleset synchronization status for all nodes or a list of them. This synchronization only covers the user custom ruleset",
         "summary": "Get cluster nodes ruleset synchronization status",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "nodes_list",
@@ -2020,7 +2107,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status",
         "description": "Return information about the cluster status",
         "summary": "Get cluster status",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -2045,7 +2134,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders",
         "description": "Return information about all decoders included in ossec.conf. This information include decoder's route, decoder's name, decoder's file among others",
         "summary": "List decoders",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "query": [
           {
             "name": "decoder_names",
@@ -2153,7 +2244,11 @@
             "description": "Filter by list status. Use commas to enter multiple statuses",
             "schema": {
               "type": "string",
-              "enum": ["enabled", "disabled", "all"],
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
               "minItems": 1
             }
           },
@@ -2172,7 +2267,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_files",
         "description": "Return information about all decoders files used in Wazuh. This information include decoder's file, decoder's route and decoder's status among others",
         "summary": "Get files",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -2269,7 +2366,11 @@
             "description": "Filter by list status. Use commas to enter multiple statuses",
             "schema": {
               "type": "string",
-              "enum": ["enabled", "disabled", "all"],
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
               "minItems": 1
             }
           },
@@ -2288,7 +2389,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_file",
         "description": "Get the content of a specified decoder file",
         "summary": "Get decoders file content",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -2340,7 +2443,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_parents",
         "description": "Return information about all parent decoders. A parent decoder is a decoder used as base of other decoders",
         "summary": "Get parent decoders",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "query": [
           {
             "name": "limit",
@@ -2413,7 +2518,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_cis_cat_results",
         "description": "Return CIS-CAT results for all agents or a list of them",
         "summary": "Get agents CIS-CAT results",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -2568,7 +2675,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hardware_info",
         "description": "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info among others of all agents",
         "summary": "Get agents hardware",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -2705,7 +2814,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hotfixes_info",
         "description": "Return all agents (or a list of them) hotfixes info",
         "summary": "Get agents hotfixes",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -2798,7 +2909,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_address_info",
         "description": "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network interfaces. This information include used IP protocol, interface, and IP address among others",
         "summary": "Get agents netaddr",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "address",
@@ -2916,7 +3029,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_interface_info",
         "description": "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx info and some network information among other",
         "summary": "Get agents netiface",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "adapter",
@@ -3115,7 +3230,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_protocol_info",
         "description": "Return all agents (or a list of them) routing configuration for each network interface. This information includes interface, type protocol information among other",
         "summary": "Get agents netproto",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -3136,7 +3253,12 @@
             "schema": {
               "type": "string",
               "description": "DHCP status",
-              "enum": ["enabled", "disabled", "unknown", "BOOTP"]
+              "enum": [
+                "enabled",
+                "disabled",
+                "unknown",
+                "BOOTP"
+              ]
             }
           },
           {
@@ -3234,7 +3356,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_os_info",
         "description": "Return all agents (or a list of them) OS info. This information includes os information, architecture information among other",
         "summary": "Get agents OS",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -3360,7 +3484,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_packages_info",
         "description": "Return all agents (or a list of them) packages info. This information includes name, section, size, and priority information of all packages among other",
         "summary": "Get agents packages",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -3484,7 +3610,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_ports_info",
         "description": "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP, protocol information among other",
         "summary": "Get agents ports",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -3634,7 +3762,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_processes_info",
         "description": "Return all agents (or a list of them) processes info",
         "summary": "Get agents processes",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -3832,7 +3962,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_list_group",
         "description": "Get information about all groups or a list of them. Returns a list containing basic information about each group such as number of agents belonging to the group and the checksums of the configuration and shared files",
         "summary": "Get groups",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -3953,7 +4085,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents_in_group",
         "description": "Return the list of agents that belong to the specified group",
         "summary": "Get agents in a group",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":group_id",
@@ -4045,7 +4179,12 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["active", "pending", "never_connected", "disconnected"]
+                "enum": [
+                  "active",
+                  "pending",
+                  "never_connected",
+                  "disconnected"
+                ]
               },
               "minItems": 1
             }
@@ -4065,7 +4204,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_config",
         "description": "Return the group configuration defined in the `agent.conf` file",
         "summary": "Get group configuration",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":group_id",
@@ -4123,7 +4264,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_files",
         "description": "Return the files placed under the group directory",
         "summary": "Get group files",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":group_id",
@@ -4244,7 +4387,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_json",
         "description": "Return the content of the specified group file parsed to JSON",
         "summary": "Get a file in group",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":file_name",
@@ -4282,7 +4427,12 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["conf", "rootkit_files", "rootkit_trojans", "rcl"]
+                "enum": [
+                  "conf",
+                  "rootkit_files",
+                  "rootkit_trojans",
+                  "rcl"
+                ]
               }
             }
           },
@@ -4301,7 +4451,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_xml",
         "description": "Return the contents of the specified group file parsed to XML",
         "summary": "Get a file in group",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":file_name",
@@ -4339,7 +4491,12 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["conf", "rootkit_files", "rootkit_trojans", "rcl"]
+                "enum": [
+                  "conf",
+                  "rootkit_files",
+                  "rootkit_trojans",
+                  "rcl"
+                ]
               }
             }
           },
@@ -4358,7 +4515,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists",
         "description": "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria. See available parameters for more details",
         "summary": "Get CDB lists info",
-        "tags": ["Lists"],
+        "tags": [
+          "Lists"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -4465,7 +4624,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists_files",
         "description": "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder",
         "summary": "Get CDB lists files",
-        "tags": ["Lists"],
+        "tags": [
+          "Lists"
+        ],
         "query": [
           {
             "name": "filename",
@@ -4546,7 +4707,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_file",
         "description": "Return the content of a CDB list file. Only the filename can be specified. It will be searched recursively if not found",
         "summary": "Get CDB list file content",
-        "tags": ["Lists"],
+        "tags": [
+          "Lists"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -4590,7 +4753,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_api_config",
         "description": "Return the local API configuration in JSON format",
         "summary": "Get API config",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -4615,7 +4780,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_configuration",
         "description": "Return wazuh configuration used. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
         "summary": "Get configuration",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -4704,7 +4871,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_manager_config_ondemand",
         "description": "Return the requested active configuration in JSON format",
         "summary": "Get active configuration",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "args": [
           {
             "name": ":component",
@@ -4791,7 +4960,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_conf_validation",
         "description": "Return whether the Wazuh configuration is correct",
         "summary": "Check config",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -4816,7 +4987,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_daemon_stats",
         "description": "Return Wazuh statistical information from specified daemons",
         "summary": "Get Wazuh daemon stats",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "daemons_list",
@@ -4825,7 +4998,11 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["wazuh-analysisd", "wazuh-remoted", "wazuh-db"]
+                "enum": [
+                  "wazuh-analysisd",
+                  "wazuh-remoted",
+                  "wazuh-db"
+                ]
               }
             }
           },
@@ -4852,7 +5029,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_info",
         "description": "Return basic information such as version, compilation date, installation path",
         "summary": "Get information",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -4877,7 +5056,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log",
         "description": "Return the last 2000 wazuh log entries",
         "summary": "Get logs",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -4988,7 +5169,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log_summary",
         "description": "Return a summary of the last 2000 wazuh log entries",
         "summary": "Get logs summary",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5013,7 +5196,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats",
         "description": "Return Wazuh statistical information for the current or specified date",
         "summary": "Get stats",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "date",
@@ -5046,7 +5231,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_analysisd",
         "description": "Return Wazuh analysisd statistical information",
         "summary": "Get stats analysisd",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5071,7 +5258,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_hourly",
         "description": "Return Wazuh statistical information per hour. Each number in the averages field represents the average of alerts per hour",
         "summary": "Get stats hour",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5096,7 +5285,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_remoted",
         "description": "Return Wazuh remoted statistical information",
         "summary": "Get stats remoted",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5121,7 +5312,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_weekly",
         "description": "Return Wazuh statistical information per week. Each number in the averages field represents the average of alerts per hour for that specific day",
         "summary": "Get stats week",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5146,32 +5339,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_status",
         "description": "Return the status of all Wazuh daemons",
         "summary": "Get status",
-        "tags": ["Manager"],
-        "query": [
-          {
-            "name": "pretty",
-            "description": "Show results in human-readable format",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "name": "wait_for_complete",
-            "description": "Disable timeout response",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ]
-      },
-      {
-        "name": "/manager/version/check",
-        "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_available_updates",
-        "description": "Return the version of the API and the available updates",
-        "summary": "Get available updates",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5196,7 +5366,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_groups",
         "description": "Return the groups from MITRE database",
         "summary": "Get MITRE groups",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -5295,7 +5467,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_metadata",
         "description": "Return the metadata from MITRE database",
         "summary": "Get MITRE metadata",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5320,7 +5494,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_mitigations",
         "description": "Return the mitigations from MITRE database",
         "summary": "Get MITRE mitigations",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -5419,7 +5595,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_references",
         "description": "Return the references from MITRE database",
         "summary": "Get MITRE references",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "limit",
@@ -5510,7 +5688,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_software",
         "description": "Return the software from MITRE database",
         "summary": "Get MITRE software",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -5609,7 +5789,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_tactics",
         "description": "Return the tactics from MITRE database",
         "summary": "Get MITRE tactics",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -5708,7 +5890,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_techniques",
         "description": "Return the techniques from MITRE database",
         "summary": "Get MITRE techniques",
-        "tags": ["MITRE"],
+        "tags": [
+          "MITRE"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -5807,7 +5991,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.overview_controller.get_overview_agents",
         "description": "Return a dictionary with a full agents overview",
         "summary": "Get agents overview",
-        "tags": ["Overview"],
+        "tags": [
+          "Overview"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -5832,7 +6018,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_rootcheck_agent",
         "description": "Return the rootcheck database of an agent",
         "summary": "Get results",
-        "tags": ["Rootcheck"],
+        "tags": [
+          "Rootcheck"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -5957,7 +6145,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_last_scan_agent",
         "description": "Return the timestamp of the last rootcheck scan of an agent",
         "summary": "Get last scan datetime",
-        "tags": ["Rootcheck"],
+        "tags": [
+          "Rootcheck"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -5995,7 +6185,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules",
         "description": "Return a list containing information about each rule such as file where it's defined, description, rule group, status, etc",
         "summary": "List rules",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -6168,7 +6360,11 @@
             "description": "Filter by list status. Use commas to enter multiple statuses",
             "schema": {
               "type": "string",
-              "enum": ["enabled", "disabled", "all"],
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
               "minItems": 1
             }
           },
@@ -6195,7 +6391,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_files",
         "description": "Return a list containing all files used to define rules and their status",
         "summary": "Get files",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -6292,7 +6490,11 @@
             "description": "Filter by list status. Use commas to enter multiple statuses",
             "schema": {
               "type": "string",
-              "enum": ["enabled", "disabled", "all"],
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
               "minItems": 1
             }
           },
@@ -6311,7 +6513,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_file",
         "description": "Get the content of a specified rule in the ruleset",
         "summary": "Get rules file content",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -6363,7 +6567,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_groups",
         "description": "Return a list containing all rule groups names",
         "summary": "Get groups",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "query": [
           {
             "name": "limit",
@@ -6425,7 +6631,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_requirement",
         "description": "Return all specified requirement names defined in the Wazuh ruleset",
         "summary": "Get requirements",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "args": [
           {
             "name": ":requirement",
@@ -6505,7 +6713,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_agent",
         "description": "Return the security SCA database of an agent",
         "summary": "Get results",
-        "tags": ["SCA"],
+        "tags": [
+          "SCA"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -6628,7 +6838,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_checks",
         "description": "Return the policy monitoring alerts for a given policy",
         "summary": "Get policy checks",
-        "tags": ["SCA"],
+        "tags": [
+          "SCA"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -6839,7 +7051,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_actions",
         "description": "Get all RBAC actions, including the potential related resources and endpoints.",
         "summary": "List RBAC actions",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "endpoint",
@@ -6863,7 +7077,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_security_config",
         "description": "Return the security configuration in JSON format",
         "summary": "Get security config",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -6888,7 +7104,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_policies",
         "description": "Get all policies in the system, including the administrator policy",
         "summary": "List policies",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -6988,7 +7206,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_resources",
         "description": "This method should be called to get all current defined RBAC resources.",
         "summary": "List RBAC resources",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -7025,7 +7245,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_roles",
         "description": "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3",
         "summary": "List roles",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -7125,7 +7347,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rules",
         "description": "Get a list of security rules from the system or all of them. These rules must be mapped with roles to obtain certain access privileges. For a specific list, indicate the ids separated by commas. Example: ?rule_ids=1,2,3",
         "summary": "List security rules",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -7225,7 +7449,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.deprecated_login_user",
         "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "raw",
@@ -7242,7 +7468,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_users",
         "description": "Get the information of a specified user",
         "summary": "List users",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "distinct",
@@ -7342,7 +7570,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me",
         "description": "Get the information of the current user",
         "summary": "Get current user info",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -7367,7 +7597,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me_policies",
         "description": "Get the processed policies information for the current user",
         "summary": "Get current user processed policies",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -7384,7 +7616,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_syscheck_agent",
         "description": "Return FIM findings in the specified agent",
         "summary": "Get results",
-        "tags": ["Syscheck"],
+        "tags": [
+          "Syscheck"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -7404,7 +7638,10 @@
             "description": "Filter by architecture",
             "schema": {
               "type": "string",
-              "enum": ["[x32]", "[x64]"]
+              "enum": [
+                "[x32]",
+                "[x64]"
+              ]
             }
           },
           {
@@ -7531,7 +7768,11 @@
             "description": "Filter by file type. Registry_key and registry_value types are only available in Windows agents",
             "schema": {
               "type": "string",
-              "enum": ["file", "registry_key", "registry_value"]
+              "enum": [
+                "file",
+                "registry_key",
+                "registry_value"
+              ]
             }
           },
           {
@@ -7565,7 +7806,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_last_scan_agent",
         "description": "Return when the last syscheck scan started and ended. If the scan is still in progress the end date will be unknown",
         "summary": "Get last scan datetime",
-        "tags": ["Syscheck"],
+        "tags": [
+          "Syscheck"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -7603,7 +7846,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hardware_info",
         "description": "Return the agent's hardware info. This information include cpu, ram, scan info among others",
         "summary": "Get agent hardware",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -7652,7 +7897,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hotfix_info",
         "description": "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)",
         "summary": "Get agent hotfixes",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -7760,7 +8007,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_address_info",
         "description": "Return the agent's network address info. This information include used IP protocol, interface, IP address  among others",
         "summary": "Get agent netaddr",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -7901,7 +8150,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_interface_info",
         "description": "Return the agent's network interface info. This information include rx, scan, tx info and some network information among others",
         "summary": "Get agent netiface",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8114,7 +8365,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_protocol_info",
         "description": "Return the agent's routing configuration for each network interface",
         "summary": "Get agent netproto",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8135,15 +8388,12 @@
             "schema": {
               "type": "string",
               "description": "DHCP status",
-              "enum": ["enabled", "disabled", "unknown", "BOOTP"]
-            }
-          },
-          {
-            "name": "distinct",
-            "description": "Look for distinct values.",
-            "schema": {
-              "type": "boolean",
-              "default": false
+              "enum": [
+                "enabled",
+                "disabled",
+                "unknown",
+                "BOOTP"
+              ]
             }
           },
           {
@@ -8256,7 +8506,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_os_info",
         "description": "Return the agent's OS info. This information include os information, architecture information among others of all agents",
         "summary": "Get agent OS",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8305,7 +8557,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_packages_info",
         "description": "Return the agent's packages info. This information include name, section, size, priority information of all packages among others",
         "summary": "Get agent packages",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8444,7 +8698,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_ports_info",
         "description": "Return the agent's ports info. This information include local IP, Remote IP, protocol information among others",
         "summary": "Get agent ports",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8609,7 +8865,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_processes_info",
         "description": "Return the agent's processes info",
         "summary": "Get agent processes",
-        "tags": ["Syscollector"],
+        "tags": [
+          "Syscollector"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -8822,7 +9080,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.task_controller.get_tasks_status",
         "description": "Returns all available information about the specified tasks",
         "summary": "List tasks",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -8959,7 +9219,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerability_agent",
         "description": "Return the vulnerabilities of an agent",
         "summary": "Get vulnerabilities",
-        "tags": ["Vulnerability"],
+        "tags": [
+          "Vulnerability"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -9082,7 +9344,11 @@
             "description": "Filter by CVE status",
             "schema": {
               "type": "string",
-              "enum": ["valid", "pending", "obsolete"]
+              "enum": [
+                "valid",
+                "pending",
+                "obsolete"
+              ]
             }
           },
           {
@@ -9090,7 +9356,10 @@
             "description": "Filter by CVE type",
             "schema": {
               "type": "string",
-              "enum": ["os", "package"]
+              "enum": [
+                "os",
+                "package"
+              ]
             }
           },
           {
@@ -9116,7 +9385,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_last_scan_agent",
         "description": "Return when the last full and partial vulnerability scan of a specified agent ended.",
         "summary": "Get last scan datetime",
-        "tags": ["Vulnerability"],
+        "tags": [
+          "Vulnerability"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -9154,7 +9425,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerabilities_field_summary",
         "description": "Return a summary of the vulnerabilities' field of an agent",
         "summary": "Get agent vulnerabilities' field summary",
-        "tags": ["Vulnerability"],
+        "tags": [
+          "Vulnerability"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -9233,7 +9506,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.active_response_controller.run_command",
         "description": "Run an Active Response command on all agents or a list of them",
         "summary": "Run command",
-        "tags": ["Active-response"],
+        "tags": [
+          "Active-response"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9291,7 +9566,9 @@
                 }
               }
             },
-            "required": ["command"]
+            "required": [
+              "command"
+            ]
           }
         ]
       },
@@ -9300,7 +9577,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_agent_single_group",
         "description": "Assign an agent to a specified group",
         "summary": "Assign agent to group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -9355,7 +9634,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agent",
         "description": "Restart the specified agent",
         "summary": "Restart agent",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -9393,7 +9674,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_multiple_agent_single_group",
         "description": "Assign all agents or a list of them to the specified group",
         "summary": "Assign agents to group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9448,7 +9731,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_group",
         "description": "Restart all agents which belong to a given group",
         "summary": "Restart agents in group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":group_id",
@@ -9485,7 +9770,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_node",
         "description": "Restart all agents which belong to a specific given node",
         "summary": "Restart agents in node",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -9521,7 +9808,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.reconnect_agents",
         "description": "Force reconnect all agents or a list of them",
         "summary": "Force reconnect agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9559,7 +9848,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents",
         "description": "Restart all agents or a list of them",
         "summary": "Restart agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9597,7 +9888,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_agents",
         "description": "Upgrade agents using a WPK file from online repository. When upgrading more than 3000 agents at the same time, it's highly recommended to use the parameter `wait_for_complete` set to `true` to avoid a possible API timeout",
         "summary": "Upgrade agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9756,7 +10049,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_custom_agents",
         "description": "Upgrade the agents using a local WPK file. When upgrading more than 3000 agents at the same time, it's highly recommended to use the parameter `wait_for_complete` set to `true` to avoid a possible API timeout",
         "summary": "Upgrade agents custom",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -9900,7 +10195,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.update_configuration",
         "description": "Replace wazuh configuration for the given node with the data contained in the API request",
         "summary": "Update node configuration",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "args": [
           {
             "name": ":node_id",
@@ -9936,7 +10233,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_restart",
         "description": "Restart all nodes in the cluster or a list of them",
         "summary": "Restart nodes",
-        "tags": ["Cluster"],
+        "tags": [
+          "Cluster"
+        ],
         "query": [
           {
             "name": "nodes_list",
@@ -9971,7 +10270,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.put_file",
         "description": "Upload or replace a user decoder file content",
         "summary": "Update decoders file",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -10023,7 +10324,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_group_config",
         "description": "Update an specified group's configuration. This API call expects a full valid XML file with the shared configuration tags/syntax",
         "summary": "Update group configuration",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "args": [
           {
             "name": ":group_id",
@@ -10060,7 +10363,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.put_file",
         "description": "Replace or upload a CDB list file with the data contained in the API request",
         "summary": "Update CDB list file",
-        "tags": ["Lists"],
+        "tags": [
+          "Lists"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -10104,7 +10409,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.logtest_controller.run_logtest_tool",
         "description": "Run logtest tool to check if a specified log raises any alert among other information",
         "summary": "Run logtest",
-        "tags": ["Logtest"],
+        "tags": [
+          "Logtest"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10126,7 +10433,11 @@
         "body": [
           {
             "type": "object",
-            "required": ["event", "log_format", "location"],
+            "required": [
+              "event",
+              "log_format",
+              "location"
+            ],
             "properties": {
               "token": {
                 "type": "string",
@@ -10153,7 +10464,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.update_configuration",
         "description": "Replace Wazuh configuration with the data contained in the API request",
         "summary": "Update Wazuh configuration",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10178,7 +10491,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_restart",
         "description": "Restart the wazuh manager",
         "summary": "Restart manager",
-        "tags": ["Manager"],
+        "tags": [
+          "Manager"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10203,7 +10518,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.put_rootcheck",
         "description": "Run rootcheck scan in all agents or a list of them",
         "summary": "Run scan",
-        "tags": ["Rootcheck"],
+        "tags": [
+          "Rootcheck"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -10241,7 +10558,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.put_file",
         "description": "Upload or replace a user ruleset file content",
         "summary": "Update rules file",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -10293,7 +10612,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.put_security_config",
         "description": "Update the security configuration with the data contained in the API request",
         "summary": "Update security config",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10327,7 +10648,10 @@
               "rbac_mode": {
                 "description": "RBAC mode (white/black)",
                 "type": "string",
-                "enum": ["white", "black"],
+                "enum": [
+                  "white",
+                  "black"
+                ],
                 "example": "white"
               }
             }
@@ -10339,7 +10663,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.update_policy",
         "description": "Modify a policy, at least one property must be indicated",
         "summary": "Update policy",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":policy_id",
@@ -10403,7 +10729,11 @@
                     "description": "Effect of the policy"
                   }
                 },
-                "required": ["actions", "resources", "effect"]
+                "required": [
+                  "actions",
+                  "resources",
+                  "effect"
+                ]
               }
             }
           }
@@ -10414,7 +10744,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.update_role",
         "description": "Modify a role, cannot modify associated policies in this endpoint, at least one property must be indicated",
         "summary": "Update role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":role_id",
@@ -10464,7 +10796,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.update_rule",
         "description": "Modify a security rule by specifying its ID",
         "summary": "Update security rule",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":rule_id",
@@ -10518,14 +10852,18 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.revoke_all_tokens",
         "description": "This method should be called to revoke all active JWT tokens",
         "summary": "Revoke JWT tokens",
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       },
       {
         "name": "/security/users/:user_id",
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.update_user",
         "description": "Modify a user's password by specifying their ID",
         "summary": "Update users",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":user_id",
@@ -10573,7 +10911,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.edit_run_as",
         "description": "Modify a user's allow_run_as flag by specifying their ID",
         "summary": "Enable/Disable run_as",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":user_id",
@@ -10618,7 +10958,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.put_syscheck",
         "description": "Run FIM scan in all agents",
         "summary": "Run scan",
-        "tags": ["Syscheck"],
+        "tags": [
+          "Syscheck"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -10656,7 +10998,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.run_vulnerability_scan",
         "description": "Run a vulnerability detector scan in all nodes",
         "summary": "Run vulnerability detector scan",
-        "tags": ["Vulnerability"],
+        "tags": [
+          "Vulnerability"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10686,7 +11030,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.add_agent",
         "description": "Add a new agent",
         "summary": "Add agent",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10720,7 +11066,9 @@
                 "format": "alphanumeric"
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         ]
       },
@@ -10729,7 +11077,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.insert_agent",
         "description": "Add an agent specifying its name, ID and IP. If an agent with the same name, the same ID or the same IP already exists, replace it using the `force` parameter",
         "summary": "Add agent full",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10809,7 +11159,9 @@
                 }
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         ]
       },
@@ -10818,7 +11170,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_new_agent",
         "description": "Add a new agent with name `agent_name`. This agent will use `any` as IP",
         "summary": "Add agent quick",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agent_name",
@@ -10853,7 +11207,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.event_controller.forward_event",
         "description": "Send security events to analysisd.\n\nThe endpoint is limited to receiving a max of 30 requests per minute and a max bulk size of 100 events per request.",
         "summary": "Ingest events",
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10884,7 +11240,9 @@
                 }
               }
             },
-            "required": ["events"]
+            "required": [
+              "events"
+            ]
           }
         ]
       },
@@ -10893,7 +11251,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_group",
         "description": "Create a new group",
         "summary": "Create a group",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10923,7 +11283,9 @@
                 "maxLength": 128
               }
             },
-            "required": ["group_id"]
+            "required": [
+              "group_id"
+            ]
           }
         ]
       },
@@ -10932,7 +11294,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.add_policy",
         "description": "Add a new policy, all fields need to be specified",
         "summary": "Add policy",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -10954,7 +11318,10 @@
         "body": [
           {
             "type": "object",
-            "required": ["name", "policy"],
+            "required": [
+              "name",
+              "policy"
+            ],
             "properties": {
               "name": {
                 "description": "Policy name",
@@ -10985,7 +11352,11 @@
                     "description": "Effect of the policy"
                   }
                 },
-                "required": ["actions", "resources", "effect"]
+                "required": [
+                  "actions",
+                  "resources",
+                  "effect"
+                ]
               }
             }
           }
@@ -10996,7 +11367,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.add_role",
         "description": "Add a new role, all fields need to be specified",
         "summary": "Add role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -11018,7 +11391,9 @@
         "body": [
           {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -11035,7 +11410,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_policy",
         "description": "Create a specified relation role-policy, one role may have multiples policies",
         "summary": "Add policies to role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":role_id",
@@ -11094,7 +11471,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_rule",
         "description": "Create a specific role-rule relation. One role may have multiple security rules",
         "summary": "Add security rules to role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":role_id",
@@ -11144,7 +11523,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.add_rule",
         "description": "Add a new security rule",
         "summary": "Add security rule",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -11166,7 +11547,10 @@
         "body": [
           {
             "type": "object",
-            "required": ["name", "rule"],
+            "required": [
+              "name",
+              "rule"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -11187,7 +11571,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
         "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "raw",
@@ -11204,7 +11590,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.run_as_login",
         "description": "This method should be called to get an API token using an authorization context body. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login auth_context",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "raw",
@@ -11221,7 +11609,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.create_user",
         "description": "Add a new API user to the system",
         "summary": "Add user",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -11255,7 +11645,10 @@
                 "format": "password"
               }
             },
-            "required": ["username", "password"]
+            "required": [
+              "username",
+              "password"
+            ]
           }
         ]
       },
@@ -11264,7 +11657,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.set_user_role",
         "description": "Create a specified relation role-policy, one user may have multiples roles",
         "summary": "Add roles to user",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":user_id",
@@ -11328,7 +11723,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_agents",
         "description": "Delete all agents or a list of them based on optional criteria",
         "summary": "Delete agents",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -11491,7 +11888,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_multiple_groups",
         "description": "Remove the agent from all groups or a list of them. The agent will automatically revert to the default group if it is removed from all its assigned groups",
         "summary": "Remove agent from groups",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -11541,7 +11940,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_single_group",
         "description": "Remove an agent from a specified group. If the agent belongs to several groups, only the specified group will be deleted.",
         "summary": "Remove agent from group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -11589,7 +11990,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_multiple_agent_single_group",
         "description": "Remove all agents assignment or a list of them from the specified group",
         "summary": "Remove agents from group",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -11638,7 +12041,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.decoder_controller.delete_file",
         "description": "Delete a specified decoder file",
         "summary": "Delete decoders file",
-        "tags": ["Decoders"],
+        "tags": [
+          "Decoders"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -11682,7 +12087,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_rootcheck_database",
         "description": "Clear rootcheck database for all agents or a list of them",
         "summary": "Clear rootcheck results",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -11721,7 +12128,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_syscheck_database",
         "description": "Clear the syscheck database for all agents or a list of them",
         "summary": "Clear agents FIM results",
-        "tags": ["Experimental"],
+        "tags": [
+          "Experimental"
+        ],
         "query": [
           {
             "name": "agents_list",
@@ -11760,7 +12169,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_groups",
         "description": "Delete all groups or a list of them",
         "summary": "Delete groups",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "query": [
           {
             "name": "groups_list",
@@ -11799,7 +12210,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.delete_file",
         "description": "Delete a specified CDB list file. Only the filename can be specified. It will be searched recursively if not found",
         "summary": "Delete CDB list file",
-        "tags": ["Lists"],
+        "tags": [
+          "Lists"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -11835,7 +12248,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.logtest_controller.end_logtest_session",
         "description": "Delete the saved logtest session corresponding to {token}",
         "summary": "End session",
-        "tags": ["Logtest"],
+        "tags": [
+          "Logtest"
+        ],
         "args": [
           {
             "name": ":token",
@@ -11871,7 +12286,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.delete_rootcheck",
         "description": "Clear an agent's rootcheck database",
         "summary": "Clear results",
-        "tags": ["Rootcheck"],
+        "tags": [
+          "Rootcheck"
+        ],
         "args": [
           {
             "name": ":agent_id",
@@ -11909,7 +12326,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.rule_controller.delete_file",
         "description": "Delete a specified rule file",
         "summary": "Delete rules file",
-        "tags": ["Rules"],
+        "tags": [
+          "Rules"
+        ],
         "args": [
           {
             "name": ":filename",
@@ -11953,7 +12372,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_security_config",
         "description": "Replaces the security configuration with the original one",
         "summary": "Restore default security config",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -11978,7 +12399,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_policies",
         "description": "Delete a list of policies or all policies in the system, roles linked to policies are not going to be removed",
         "summary": "Delete policies",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "policy_ids",
@@ -12016,7 +12439,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_roles",
         "description": "Policies linked to roles are not going to be removed",
         "summary": "Delete roles",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -12054,7 +12479,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_policy",
         "description": "Delete a specified relation role-policy",
         "summary": "Remove policies from role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":role_id",
@@ -12104,7 +12531,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_rule",
         "description": "Delete a specific role-rule relation",
         "summary": "Remove security rules from role",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":role_id",
@@ -12154,7 +12583,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_rules",
         "description": "Delete a list of security rules or all security rules in the system, roles linked to rules are not going to be deleted",
         "summary": "Delete security rules",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -12192,14 +12623,18 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.logout_user",
         "description": "This method should be called to invalidate all the current user's tokens",
         "summary": "Logout current user",
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       },
       {
         "name": "/security/users",
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_users",
         "description": "Delete a list of users by specifying their IDs",
         "summary": "Delete users",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "query": [
           {
             "name": "pretty",
@@ -12237,7 +12672,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_user_role",
         "description": "Delete a specified relation user-roles",
         "summary": "Remove roles from user",
-        "tags": ["Security"],
+        "tags": [
+          "Security"
+        ],
         "args": [
           {
             "name": ":user_id",
@@ -12287,7 +12724,9 @@
         "documentation": "https://documentation.wazuh.com/4.8/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.delete_syscheck_agent",
         "description": "Clear file integrity monitoring scan results for a specified agent. Only available for agents < 3.12.0, it doesn't apply for more recent ones",
         "summary": "Clear results",
-        "tags": ["Syscheck"],
+        "tags": [
+          "Syscheck"
+        ],
         "args": [
           {
             "name": ":agent_id",

--- a/plugins/main/common/api-info/security-actions.json
+++ b/plugins/main/common/api-info/security-actions.json
@@ -1,30 +1,57 @@
 {
   "active-response:command": {
     "description": "Execute active response commands in the agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["active-response:command"],
-      "resources": ["agent:id:001", "agent:group:atlantic"],
+      "actions": [
+        "active-response:command"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:group:atlantic"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /active-response"]
+    "related_endpoints": [
+      "PUT /active-response"
+    ]
   },
   "agent:delete": {
     "description": "Delete agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:delete"],
-      "resources": ["agent:id:010", "agent:group:pacific"],
+      "actions": [
+        "agent:delete"
+      ],
+      "resources": [
+        "agent:id:010",
+        "agent:group:pacific"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["DELETE /agents"]
+    "related_endpoints": [
+      "DELETE /agents"
+    ]
   },
   "agent:read": {
     "description": "Access agents information (id, name, group, last keep alive, etc)",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:read"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "agent:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -45,20 +72,38 @@
   },
   "agent:create": {
     "description": "Create new agents",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["agent:create"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "agent:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["POST /agents", "POST /agents/insert", "POST /agents/insert/quick"]
+    "related_endpoints": [
+      "POST /agents",
+      "POST /agents/insert",
+      "POST /agents/insert/quick"
+    ]
   },
   "agent:modify_group": {
     "description": "Change the group of agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:modify_group"],
-      "resources": ["agent:id:004", "agent:group:us-east"],
+      "actions": [
+        "agent:modify_group"
+      ],
+      "resources": [
+        "agent:id:004",
+        "agent:group:us-east"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -71,10 +116,16 @@
   },
   "group:modify_assignments": {
     "description": "Change the agents assigned to the group",
-    "resources": ["group:id"],
+    "resources": [
+      "group:id"
+    ],
     "example": {
-      "actions": ["group:modify_assignments"],
-      "resources": ["group:id:*"],
+      "actions": [
+        "group:modify_assignments"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -87,10 +138,18 @@
   },
   "agent:restart": {
     "description": "Restart agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:restart"],
-      "resources": ["agent:id:050", "agent:id:049"],
+      "actions": [
+        "agent:restart"
+      ],
+      "resources": [
+        "agent:id:050",
+        "agent:id:049"
+      ],
       "effect": "deny"
     },
     "related_endpoints": [
@@ -102,10 +161,18 @@
   },
   "agent:upgrade": {
     "description": "Upgrade the version of the agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:upgrade"],
-      "resources": ["agent:id:001", "agent:group:mediterranean"],
+      "actions": [
+        "agent:upgrade"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:group:mediterranean"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -116,20 +183,34 @@
   },
   "group:delete": {
     "description": "Delete agent groups",
-    "resources": ["group:id"],
+    "resources": [
+      "group:id"
+    ],
     "example": {
-      "actions": ["group:delete"],
-      "resources": ["group:id:*"],
+      "actions": [
+        "group:delete"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["DELETE /groups"]
+    "related_endpoints": [
+      "DELETE /groups"
+    ]
   },
   "group:read": {
     "description": "Access agent groups information (id, name, agents, etc)",
-    "resources": ["group:id"],
+    "resources": [
+      "group:id"
+    ],
     "example": {
-      "actions": ["group:create"],
-      "resources": ["group:id:*"],
+      "actions": [
+        "group:create"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -144,30 +225,53 @@
   },
   "group:create": {
     "description": "Create new agent groups",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["group:create"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "group:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["POST /groups"]
+    "related_endpoints": [
+      "POST /groups"
+    ]
   },
   "group:update_config": {
     "description": "Change the configuration of agent groups",
-    "resources": ["group:id"],
+    "resources": [
+      "group:id"
+    ],
     "example": {
-      "actions": ["group:update_config"],
-      "resources": ["group:id:*"],
+      "actions": [
+        "group:update_config"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["PUT /groups/{group_id}/configuration"]
+    "related_endpoints": [
+      "PUT /groups/{group_id}/configuration"
+    ]
   },
   "cluster:read": {
     "description": "Read Wazuh's cluster nodes configuration",
-    "resources": ["node:id"],
+    "resources": [
+      "node:id"
+    ],
     "example": {
-      "actions": ["cluster:read"],
-      "resources": ["node:id:worker1", "node:id:worker3"],
+      "actions": [
+        "cluster:read"
+      ],
+      "resources": [
+        "node:id:worker1",
+        "node:id:worker3"
+      ],
       "effect": "deny"
     },
     "related_endpoints": [
@@ -195,110 +299,207 @@
   },
   "agent:reconnect": {
     "description": "Force reconnect agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["agent:reconnect"],
-      "resources": ["agent:id:050", "agent:id:049"],
+      "actions": [
+        "agent:reconnect"
+      ],
+      "resources": [
+        "agent:id:050",
+        "agent:id:049"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["PUT /agents/reconnect"]
+    "related_endpoints": [
+      "PUT /agents/reconnect"
+    ]
   },
   "ciscat:read": {
     "description": "Access CIS-CAT results for agents",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["ciscat:read"],
-      "resources": ["agent:id:001", "agent:id:003", "agent:group:default"],
+      "actions": [
+        "ciscat:read"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:id:003",
+        "agent:group:default"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["GET /ciscat/{agent_id}/results", "GET /experimental/ciscat/results"]
+    "related_endpoints": [
+      "GET /ciscat/{agent_id}/results",
+      "GET /experimental/ciscat/results"
+    ]
   },
   "cluster:status": {
     "description": "Check Wazuh's cluster general status",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["cluster:status"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "cluster:status"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /cluster/status"]
+    "related_endpoints": [
+      "GET /cluster/status"
+    ]
   },
   "cluster:read_api_config": {
     "description": "Check Wazuh's cluster nodes API configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["cluster:read_api_config"],
-      "resources": ["node:id:worker1", "node:id:worker3"],
+      "actions": [
+        "cluster:read_api_config"
+      ],
+      "resources": [
+        "node:id:worker1",
+        "node:id:worker3"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /cluster/api/config"]
+    "related_endpoints": [
+      "GET /cluster/api/config"
+    ]
   },
   "cluster:update_config": {
     "description": "Change the Wazuh's cluster node configuration",
-    "resources": ["node:id"],
+    "resources": [
+      "node:id"
+    ],
     "example": {
-      "actions": ["cluster:update_config"],
-      "resources": ["node:id:worker1"],
+      "actions": [
+        "cluster:update_config"
+      ],
+      "resources": [
+        "node:id:worker1"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /cluster/{node_id}/configuration"]
+    "related_endpoints": [
+      "PUT /cluster/{node_id}/configuration"
+    ]
   },
   "cluster:restart": {
     "description": "Restart Wazuh's cluster nodes",
-    "resources": ["node:id"],
+    "resources": [
+      "node:id"
+    ],
     "example": {
-      "actions": ["cluster:restart"],
-      "resources": ["node:id:worker1"],
+      "actions": [
+        "cluster:restart"
+      ],
+      "resources": [
+        "node:id:worker1"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /cluster/restart"]
+    "related_endpoints": [
+      "PUT /cluster/restart"
+    ]
   },
   "lists:read": {
     "description": "Read cdb lists files",
-    "resources": ["list:file"],
+    "resources": [
+      "list:file"
+    ],
     "example": {
-      "actions": ["lists:read"],
-      "resources": ["list:file:audit-keys"],
+      "actions": [
+        "lists:read"
+      ],
+      "resources": [
+        "list:file:audit-keys"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["GET /lists", "GET /lists/files/{filename}", "GET /lists/files"]
+    "related_endpoints": [
+      "GET /lists",
+      "GET /lists/files/{filename}",
+      "GET /lists/files"
+    ]
   },
   "lists:update": {
     "description": "Update or upload cdb lists files",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["lists:update"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "lists:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /lists/files/{filename}"]
+    "related_endpoints": [
+      "PUT /lists/files/{filename}"
+    ]
   },
   "lists:delete": {
     "description": "Delete cdb lists files",
-    "resources": ["list:file"],
+    "resources": [
+      "list:file"
+    ],
     "example": {
-      "actions": ["lists:delete"],
-      "resources": ["list:file:audit-keys"],
+      "actions": [
+        "lists:delete"
+      ],
+      "resources": [
+        "list:file:audit-keys"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["PUT /lists/files/{filename}", "DELETE /lists/files/{filename}"]
+    "related_endpoints": [
+      "PUT /lists/files/{filename}",
+      "DELETE /lists/files/{filename}"
+    ]
   },
   "logtest:run": {
     "description": "Run logtest tool or end a logtest session",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["logtest:run"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "logtest:run"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /logtest", "DELETE /logtest/sessions/{token}"]
+    "related_endpoints": [
+      "PUT /logtest",
+      "DELETE /logtest/sessions/{token}"
+    ]
   },
   "manager:read": {
     "description": "Read Wazuh manager configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["manager:read"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "manager:read"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -315,46 +516,75 @@
       "GET /manager/logs/summary",
       "PUT /manager/restart",
       "GET /manager/configuration/validation",
-      "GET /manager/configuration/{component}/{configuration}",
-      "GET /manager/version/check"
+      "GET /manager/configuration/{component}/{configuration}"
     ]
   },
   "manager:update_config": {
     "description": "Update current Wazuh manager configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["manager:update_config"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "manager:update_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /manager/configuration"]
+    "related_endpoints": [
+      "PUT /manager/configuration"
+    ]
   },
   "manager:read_api_config": {
     "description": "Read Wazuh manager API configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["manager:read_api_config"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "manager:read_api_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /manager/api/config"]
+    "related_endpoints": [
+      "GET /manager/api/config"
+    ]
   },
   "manager:restart": {
     "description": "Restart Wazuh managers",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["manager:restart"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "manager:restart"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["PUT /manager/restart"]
+    "related_endpoints": [
+      "PUT /manager/restart"
+    ]
   },
   "mitre:read": {
     "description": "Access information from MITRE database",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["mitre:read"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "mitre:read"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -369,40 +599,75 @@
   },
   "rootcheck:run": {
     "description": "Run agents rootcheck scan",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["rootcheck:run"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "rootcheck:run"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /rootcheck"]
+    "related_endpoints": [
+      "PUT /rootcheck"
+    ]
   },
   "rootcheck:read": {
     "description": "Access information from agents rootcheck database",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["rootcheck:read"],
-      "resources": ["agent:id:011"],
+      "actions": [
+        "rootcheck:read"
+      ],
+      "resources": [
+        "agent:id:011"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /rootcheck/{agent_id}", "GET /rootcheck/{agent_id}/last_scan"]
+    "related_endpoints": [
+      "GET /rootcheck/{agent_id}",
+      "GET /rootcheck/{agent_id}/last_scan"
+    ]
   },
   "rootcheck:clear": {
     "description": "Clear the agents rootcheck database",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["rootcheck:clear"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "rootcheck:clear"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["DELETE /rootcheck/{agent_id}", "DELETE /experimental/rootcheck"]
+    "related_endpoints": [
+      "DELETE /rootcheck/{agent_id}",
+      "DELETE /experimental/rootcheck"
+    ]
   },
   "rules:read": {
     "description": "Read rules files",
-    "resources": ["rule:file"],
+    "resources": [
+      "rule:file"
+    ],
     "example": {
-      "actions": ["rules:read"],
-      "resources": ["rule:file:0610-win-ms_logs_rules.xml"],
+      "actions": [
+        "rules:read"
+      ],
+      "resources": [
+        "rule:file:0610-win-ms_logs_rules.xml"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -415,70 +680,133 @@
   },
   "rules:update": {
     "description": "Update or upload custom rule files",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["rules:update"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "rules:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /rules/files/{filename}"]
+    "related_endpoints": [
+      "PUT /rules/files/{filename}"
+    ]
   },
   "rules:delete": {
     "description": "Delete custom rule files",
-    "resources": ["rule:file"],
+    "resources": [
+      "rule:file"
+    ],
     "example": {
-      "actions": ["rules:delete"],
-      "resources": ["rule:file:0610-win-ms_logs_rules.xml"],
+      "actions": [
+        "rules:delete"
+      ],
+      "resources": [
+        "rule:file:0610-win-ms_logs_rules.xml"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /rules/files/{filename}", "DELETE /rules/files/{filename}"]
+    "related_endpoints": [
+      "PUT /rules/files/{filename}",
+      "DELETE /rules/files/{filename}"
+    ]
   },
   "sca:read": {
     "description": "Access agents security configuration assessment",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["sca:read"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "sca:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /sca/{agent_id}", "GET /sca/{agent_id}/checks/{policy_id}"]
+    "related_endpoints": [
+      "GET /sca/{agent_id}",
+      "GET /sca/{agent_id}/checks/{policy_id}"
+    ]
   },
   "syscheck:run": {
     "description": "Run agents syscheck scan",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["syscheck:run"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "syscheck:run"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /syscheck"]
+    "related_endpoints": [
+      "PUT /syscheck"
+    ]
   },
   "syscheck:read": {
     "description": "Access information from agents syscheck database",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["syscheck:read"],
-      "resources": ["agent:id:011", "agent:group:us-west"],
+      "actions": [
+        "syscheck:read"
+      ],
+      "resources": [
+        "agent:id:011",
+        "agent:group:us-west"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /syscheck/{agent_id}", "GET /syscheck/{agent_id}/last_scan"]
+    "related_endpoints": [
+      "GET /syscheck/{agent_id}",
+      "GET /syscheck/{agent_id}/last_scan"
+    ]
   },
   "syscheck:clear": {
     "description": "Clear the agents syscheck database",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["syscheck:clear"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "syscheck:clear"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["DELETE /syscheck/{agent_id}", "DELETE /experimental/syscheck"]
+    "related_endpoints": [
+      "DELETE /syscheck/{agent_id}",
+      "DELETE /experimental/syscheck"
+    ]
   },
   "decoders:read": {
     "description": "Read decoders files",
-    "resources": ["decoder:file"],
+    "resources": [
+      "decoder:file"
+    ],
     "example": {
-      "actions": ["decoders:read"],
-      "resources": ["decoder:file:*"],
+      "actions": [
+        "decoders:read"
+      ],
+      "resources": [
+        "decoder:file:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -490,30 +818,54 @@
   },
   "decoders:update": {
     "description": "Update or upload custom decoder files",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["decoders:update"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "decoders:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /decoders/files/{filename}"]
+    "related_endpoints": [
+      "PUT /decoders/files/{filename}"
+    ]
   },
   "decoders:delete": {
     "description": "Delete custom decoder files",
-    "resources": ["decoder:file"],
+    "resources": [
+      "decoder:file"
+    ],
     "example": {
-      "actions": ["decoders:delete"],
-      "resources": ["decoder:file:local_decoder.xml"],
+      "actions": [
+        "decoders:delete"
+      ],
+      "resources": [
+        "decoder:file:local_decoder.xml"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /decoders/files/{filename}", "DELETE /decoders/files/{filename}"]
+    "related_endpoints": [
+      "PUT /decoders/files/{filename}",
+      "DELETE /decoders/files/{filename}"
+    ]
   },
   "syscollector:read": {
     "description": "Access agents syscollector information",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["syscollector:read"],
-      "resources": ["agent:id:*"],
+      "actions": [
+        "syscollector:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -539,20 +891,40 @@
   },
   "security:edit_run_as": {
     "description": "Change the value of the allow_run_as flag for a user",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["security:edit_run_as"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "security:edit_run_as"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /security/users/{user_id}/run_as"]
+    "related_endpoints": [
+      "PUT /security/users/{user_id}/run_as"
+    ]
   },
   "security:read": {
     "description": "Access information about system security resources",
-    "resources": ["policy:id", "role:id", "user:id", "rule:id"],
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
     "example": {
-      "actions": ["security:read"],
-      "resources": ["policy:id:*", "role:id:2", "user:id:5", "rule:id:3"],
+      "actions": [
+        "security:read"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:2",
+        "user:id:5",
+        "rule:id:3"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [
@@ -564,20 +936,40 @@
   },
   "security:create_user": {
     "description": "Create new system users",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["security:create_user"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "security:create_user"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["POST /security/users"]
+    "related_endpoints": [
+      "POST /security/users"
+    ]
   },
   "security:delete": {
     "description": "Delete system security resources",
-    "resources": ["policy:id", "role:id", "user:id", "rule:id"],
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
     "example": {
-      "actions": ["security:update"],
-      "resources": ["policy:id:*", "role:id:3", "user:id:4", "rule:id:2"],
+      "actions": [
+        "security:update"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:3",
+        "user:id:4",
+        "rule:id:2"
+      ],
       "effect": "deny"
     },
     "related_endpoints": [
@@ -592,10 +984,22 @@
   },
   "security:update": {
     "description": "Update the information of system security resources",
-    "resources": ["policy:id", "role:id", "user:id", "rule:id"],
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
     "example": {
-      "actions": ["security:update"],
-      "resources": ["policy:id:*", "role:id:4", "user:id:3", "rule:id:4"],
+      "actions": [
+        "security:update"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:4",
+        "user:id:3",
+        "rule:id:4"
+      ],
       "effect": "deny"
     },
     "related_endpoints": [
@@ -610,60 +1014,111 @@
   },
   "security:create": {
     "description": "Create new system security resources",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["security:create"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "security:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["POST /security/roles", "POST /security/rules", "POST /security/policies"]
+    "related_endpoints": [
+      "POST /security/roles",
+      "POST /security/rules",
+      "POST /security/policies"
+    ]
   },
   "security:read_config": {
     "description": "Read current system security configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["security:read_config"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "security:read_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["GET /security/config"]
+    "related_endpoints": [
+      "GET /security/config"
+    ]
   },
   "security:update_config": {
     "description": "Update current system security configuration",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["security:update_config"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "security:update_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /security/config", "DELETE /security/config"]
+    "related_endpoints": [
+      "PUT /security/config",
+      "DELETE /security/config"
+    ]
   },
   "task:status": {
     "description": "Access task's status information",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["task:status"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "task:status"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "deny"
     },
-    "related_endpoints": ["GET /tasks/status"]
+    "related_endpoints": [
+      "GET /tasks/status"
+    ]
   },
   "vulnerability:run": {
     "description": "Allow running a vulnerability detector scan",
-    "resources": ["*:*"],
+    "resources": [
+      "*:*"
+    ],
     "example": {
-      "actions": ["vulnerability:run"],
-      "resources": ["*:*:*"],
+      "actions": [
+        "vulnerability:run"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
       "effect": "allow"
     },
-    "related_endpoints": ["PUT /vulnerability"]
+    "related_endpoints": [
+      "PUT /vulnerability"
+    ]
   },
   "vulnerability:read": {
     "description": "Allow reading agents' vulnerabilities information",
-    "resources": ["agent:id", "agent:group"],
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
     "example": {
-      "actions": ["vulnerability:read"],
-      "resources": ["agent:id:011", "agent:group:us-west"],
+      "actions": [
+        "vulnerability:read"
+      ],
+      "resources": [
+        "agent:id:011",
+        "agent:group:us-west"
+      ],
       "effect": "allow"
     },
     "related_endpoints": [

--- a/plugins/main/opensearch_dashboards.json
+++ b/plugins/main/opensearch_dashboards.json
@@ -1,8 +1,10 @@
 {
   "id": "wazuh",
-  "version": "4.8.0-00",
+  "version": "4.8.1-00",
   "opensearchDashboardsVersion": "opensearchDashboards",
-  "configPath": ["wazuh"],
+  "configPath": [
+    "wazuh"
+  ],
   "requiredPlugins": [
     "navigation",
     "data",
@@ -19,7 +21,12 @@
     "opensearchDashboardsLegacy",
     "wazuhCheckUpdates"
   ],
-  "optionalPlugins": ["security", "securityDashboards", "searchguard", "telemetry"],
+  "optionalPlugins": [
+    "security",
+    "securityDashboards",
+    "searchguard",
+    "telemetry"
+  ],
   "server": true,
   "ui": true
 }

--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "revision": "00",
   "pluginPlatform": {
     "version": "2.10.0"

--- a/plugins/wazuh-check-updates/opensearch_dashboards.json
+++ b/plugins/wazuh-check-updates/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "wazuhCheckUpdates",
-  "version": "4.8.0-00",
+  "version": "4.8.1-00",
   "opensearchDashboardsVersion": "opensearchDashboards",
   "server": true,
   "ui": true,

--- a/plugins/wazuh-check-updates/package.json
+++ b/plugins/wazuh-check-updates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh-check-updates",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "revision": "00",
   "pluginPlatform": {
     "version": "2.10.0"

--- a/plugins/wazuh-core/opensearch_dashboards.json
+++ b/plugins/wazuh-core/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "wazuhCore",
-  "version": "4.8.0-00",
+  "version": "4.8.1-00",
   "opensearchDashboardsVersion": "opensearchDashboards",
   "server": true,
   "ui": true,

--- a/plugins/wazuh-core/package.json
+++ b/plugins/wazuh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh-core",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "revision": "00",
   "pluginPlatform": {
     "version": "2.10.0"


### PR DESCRIPTION
### Description
This pull request bumps Wazuh version to 4.8.1 revision 00 to add support to the new version.

This change was made running this command:
```console
$ node scripts/release/bump.js --plugins-directory ./plugins --manifest-changelog ./CHANGELOG.md --plugin-main-generate-api-data-spec https://raw.githubusercontent.com/wazuh/wazuh/4.8.0/api/api/spec/spec.yaml --manifest-package ./plugins/main/package.json --revision 00 --version 4.8.1
```

Closes #6139 

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
