### PR TITLE
Create new plugin wazuh-endpoints

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -64,6 +64,11 @@ jobs:
               path: 'wazuh/plugins/wazuh-core',
               container_path: 'wazuh-core',
             },
+            {
+              name: 'Wazuh Endpoints',
+              path: 'wazuh/plugins/wazuh-endpoints',
+              container_path: 'wazuh-endpoints',
+            },
           ]
 
     steps:

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -64,11 +64,6 @@ jobs:
               path: 'wazuh/plugins/wazuh-core',
               container_path: 'wazuh-core',
             },
-            {
-              name: 'Wazuh Endpoints',
-              path: 'wazuh/plugins/wazuh-endpoints',
-              container_path: 'wazuh-endpoints',
-            },
           ]
 
     steps:

--- a/docker/osd-dev/dev.yml
+++ b/docker/osd-dev/dev.yml
@@ -231,6 +231,7 @@ services:
       - '${SRC}/main:/home/node/kbn/plugins/wazuh'
       - '${SRC}/wazuh-core:/home/node/kbn/plugins/wazuh-core'
       - '${SRC}/wazuh-check-updates:/home/node/kbn/plugins/wazuh-check-updates'
+      - '${SRC}/wazuh-endpoints:/home/node/kbn/plugins/wazuh-endpoints'
       - wd_certs:/home/node/kbn/certs/
       - ${WAZUH_DASHBOARD_CONF}:/home/node/kbn/config/opensearch_dashboards.yml
       - ./config/${OSD_MAJOR}/osd/wazuh.yml:/home/node/kbn/data/wazuh/config/wazuh.yml

--- a/plugins/main/opensearch_dashboards.json
+++ b/plugins/main/opensearch_dashboards.json
@@ -17,9 +17,15 @@
     "opensearchDashboardsReact",
     "opensearchDashboardsUtils",
     "opensearchDashboardsLegacy",
-    "wazuhCheckUpdates"
+    "wazuhCheckUpdates",
+    "wazuhEndpoints"
   ],
-  "optionalPlugins": ["security", "securityDashboards", "searchguard", "telemetry"],
+  "optionalPlugins": [
+    "security",
+    "securityDashboards",
+    "searchguard",
+    "telemetry"
+  ],
   "server": true,
   "ui": true
 }

--- a/plugins/main/public/types.ts
+++ b/plugins/main/public/types.ts
@@ -12,6 +12,7 @@ import { SecurityOssPluginStart } from '../../../src/plugins/security_oss/public
 import { SavedObjectsStart } from '../../../src/plugins/saved_objects/public';
 import { TelemetryPluginStart, TelemetryPluginSetup } from '../../../src/plugins/telemetry/public';
 import { WazuhCheckUpdatesPluginStart } from '../../wazuh-check-updates/public';
+import { WazuhEndpointsPluginStart } from '../../wazuh-endpoints/public';
 import { DashboardStart } from '../../../src/plugins/dashboard/public';
 
 export interface AppPluginStartDependencies {
@@ -24,6 +25,7 @@ export interface AppPluginStartDependencies {
   savedObjects: SavedObjectsStart;
   telemetry: TelemetryPluginStart;
   wazuhCheckUpdates: WazuhCheckUpdatesPluginStart;
+  wazuhEndpoints: WazuhEndpointsPluginStart;
   dashboard: DashboardStart;
 }
 export interface AppDependencies {

--- a/plugins/wazuh-endpoints/.i18nrc.json
+++ b/plugins/wazuh-endpoints/.i18nrc.json
@@ -1,0 +1,7 @@
+{
+  "prefix": "wazuhEndpoints",
+  "paths": {
+    "wazuhEndpoints": "."
+  },
+  "translations": ["translations/en-US.json"]
+}

--- a/plugins/wazuh-endpoints/common/constants.ts
+++ b/plugins/wazuh-endpoints/common/constants.ts
@@ -1,0 +1,4 @@
+export const PLUGIN_ID = 'wazuhEndpoints';
+export const PLUGIN_NAME = 'wazuh_endpoints';
+
+export enum routes {}

--- a/plugins/wazuh-endpoints/opensearch_dashboards.json
+++ b/plugins/wazuh-endpoints/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "wazuhEndpoints",
+  "version": "4.9.0-00",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "server": true,
+  "ui": true,
+  "requiredPlugins": ["navigation"],
+  "optionalPlugins": []
+}

--- a/plugins/wazuh-endpoints/package.json
+++ b/plugins/wazuh-endpoints/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wazuh-endpoints",
+  "version": "4.9.0",
+  "revision": "00",
+  "pluginPlatform": {
+    "version": "2.10.0"
+  },
+  "description": "Wazuh Endpoints",
+  "private": true,
+  "scripts": {
+    "build": "yarn plugin-helpers build --opensearch-dashboards-version=$OPENSEARCH_DASHBOARDS_VERSION",
+    "plugin-helpers": "node ../../scripts/plugin_helpers",
+    "osd": "node ../../scripts/osd",
+    "test:ui:runner": "node ../../scripts/functional_test_runner.js",
+    "test:server": "plugin-helpers test:server",
+    "test:browser": "plugin-helpers test:browser",
+    "test:jest": "node scripts/jest --runInBand",
+    "test:jest:runner": "node scripts/runner test"
+  }
+}

--- a/plugins/wazuh-endpoints/public/index.ts
+++ b/plugins/wazuh-endpoints/public/index.ts
@@ -1,0 +1,8 @@
+import { WazuhEndpointsPlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+export function plugin() {
+  return new WazuhEndpointsPlugin();
+}
+export { WazuhEndpointsPluginSetup, WazuhEndpointsPluginStart } from './types';

--- a/plugins/wazuh-endpoints/public/plugin.ts
+++ b/plugins/wazuh-endpoints/public/plugin.ts
@@ -1,0 +1,23 @@
+import { CoreSetup, CoreStart, Plugin } from 'opensearch-dashboards/public';
+import {
+  AppPluginStartDependencies,
+  WazuhEndpointsPluginSetup,
+  WazuhEndpointsPluginStart,
+} from './types';
+
+export class WazuhEndpointsPlugin
+  implements Plugin<WazuhEndpointsPluginSetup, WazuhEndpointsPluginStart>
+{
+  public setup(core: CoreSetup): WazuhEndpointsPluginSetup {
+    return {};
+  }
+
+  public start(
+    core: CoreStart,
+    plugins: AppPluginStartDependencies,
+  ): WazuhEndpointsPluginStart {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/plugins/wazuh-endpoints/public/types.ts
+++ b/plugins/wazuh-endpoints/public/types.ts
@@ -1,0 +1,5 @@
+export interface WazuhEndpointsPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WazuhEndpointsPluginStart {}
+
+export interface AppPluginStartDependencies {}

--- a/plugins/wazuh-endpoints/scripts/jest.js
+++ b/plugins/wazuh-endpoints/scripts/jest.js
@@ -1,0 +1,19 @@
+// # Run Jest tests
+//
+// All args will be forwarded directly to Jest, e.g. to watch tests run:
+//
+//     node scripts/jest --watch
+//
+// or to build code coverage:
+//
+//     node scripts/jest --coverage
+//
+// See all cli options in https://facebook.github.io/jest/docs/cli.html
+
+const path = require('path');
+process.argv.push('--config', path.resolve(__dirname, '../test/jest/config.js'));
+
+require('../../../src/setup_node_env');
+const jest = require('../../../node_modules/jest');
+
+jest.run(process.argv.slice(2));

--- a/plugins/wazuh-endpoints/scripts/manifest.js
+++ b/plugins/wazuh-endpoints/scripts/manifest.js
@@ -1,0 +1,17 @@
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const fs = require('fs');
+
+/**
+ * Reads the package.json file.
+ * @returns {Object} JSON object.
+ */
+function loadPackageJson() {
+  const packageJson = fs.readFileSync('./package.json');
+  return JSON.parse(packageJson);
+}
+
+module.exports = {
+  loadPackageJson
+};

--- a/plugins/wazuh-endpoints/scripts/runner.js
+++ b/plugins/wazuh-endpoints/scripts/runner.js
@@ -1,0 +1,148 @@
+/* eslint-disable array-element-newline */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/**
+Runs yarn commands using a Docker container.
+
+Intended to test and build locally.
+
+Uses development images. Must be executed from the root folder of the project.
+
+See /docker/runner/docker-compose.yml for available environment variables.
+
+# Usage:
+# -------------
+#   - node scripts/runner <command> [<command_args>]
+#   - yarn test:jest:runner [<jest_args>]
+#   - yarn build:runner
+*/
+
+const childProcess = require('child_process');
+const { loadPackageJson } = require('./manifest');
+
+const COMPOSE_DIR = '../../docker/runner';
+
+function getProjectInfo() {
+  const manifest = loadPackageJson();
+
+  return {
+    app: 'osd',
+    version: manifest['pluginPlatform']['version'],
+    repo: process.cwd(),
+  };
+}
+
+function getBuildArgs({ app, version }) {
+  return `--opensearch-dashboards-version=${version}`;
+}
+
+/**
+ * Transforms the Jest CLI options from process.argv back to a string.
+ * If no options are provided, default ones are generated.
+ * @returns {String} Space separated string with all Jest CLI options provided.
+ */
+function getJestArgs() {
+  // Take args only after `test` word
+  const index = process.argv.indexOf('test');
+  const args = process.argv.slice(index + 1);
+  // Remove duplicates using set
+  return Array.from(new Set([...args, '--runInBand'])).join(' ');
+}
+
+/**
+ * Generates the execution parameters if they are not set.
+ * @returns {Object} Default environment variables.
+ */
+const buildEnvVars = ({ app, version, repo, cmd, args }) => {
+  return {
+    APP: app,
+    VERSION: version,
+    REPO: repo,
+    CMD: cmd,
+    ARGS: args,
+  };
+};
+
+/**
+ * Captures the SIGINT signal (Ctrl + C) to stop the container and exit.
+ */
+function setupAbortController() {
+  process.on('SIGINT', () => {
+    childProcess.spawnSync('docker', [
+      'compose',
+      '--project-directory',
+      COMPOSE_DIR,
+      'stop',
+    ]);
+    process.exit();
+  });
+}
+
+/**
+ * Start the container.
+ */
+function startRunner() {
+  const runner = childProcess.spawn('docker', [
+    'compose',
+    '--project-directory',
+    COMPOSE_DIR,
+    'up',
+  ]);
+
+  runner.stdout.on('data', data => {
+    console.log(`${data}`);
+  });
+
+  runner.stderr.on('data', data => {
+    console.error(`${data}`);
+  });
+}
+
+/**
+ * Main function
+ */
+function main() {
+  if (process.argv.length < 2) {
+    process.stderr.write('Required parameters not provided');
+    process.exit(-1);
+  }
+
+  const projectInfo = getProjectInfo();
+  let envVars = {};
+
+  switch (process.argv[2]) {
+    case 'build':
+      envVars = buildEnvVars({
+        ...projectInfo,
+        cmd: 'plugin-helpers build',
+        args: getBuildArgs({ ...projectInfo }),
+      });
+      break;
+
+    case 'test':
+      envVars = buildEnvVars({
+        ...projectInfo,
+        cmd: 'test:jest',
+        args: getJestArgs(),
+      });
+      break;
+
+    default:
+      // usage();
+      console.error('Unsupported or invalid yarn command.');
+      process.exit(-1);
+  }
+
+  // Check the required environment variables are set
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+    console.log(`${key}: ${process.env[key]}`);
+  }
+
+  setupAbortController();
+  startRunner();
+}
+
+main();

--- a/plugins/wazuh-endpoints/server/index.ts
+++ b/plugins/wazuh-endpoints/server/index.ts
@@ -1,0 +1,11 @@
+import { PluginInitializerContext } from '../../../src/core/server';
+import { WazuhEndpointsPlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new WazuhEndpointsPlugin(initializerContext);
+}
+
+export { WazuhEndpointsPluginSetup, WazuhEndpointsPluginStart } from './types';

--- a/plugins/wazuh-endpoints/server/plugin.ts
+++ b/plugins/wazuh-endpoints/server/plugin.ts
@@ -1,0 +1,38 @@
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+} from 'opensearch-dashboards/server';
+
+import {
+  PluginSetup,
+  WazuhEndpointsPluginSetup,
+  WazuhEndpointsPluginStart,
+  AppPluginStartDependencies,
+} from './types';
+import { ISecurityFactory } from '../../wazuh-core/server/services/security-factory';
+
+export class WazuhEndpointsPlugin
+  implements Plugin<WazuhEndpointsPluginSetup, WazuhEndpointsPluginStart> {
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public async setup(core: CoreSetup, plugins: PluginSetup) {
+    this.logger.debug('wazuh_endpoints: Setup');
+
+    return {};
+  }
+
+  public start(core: CoreStart, plugins: AppPluginStartDependencies): WazuhEndpointsPluginStart {
+    this.logger.debug('wazuh_endpoints: Started');
+
+    return {};
+  }
+
+  public stop() {}
+}

--- a/plugins/wazuh-endpoints/server/plugin.ts
+++ b/plugins/wazuh-endpoints/server/plugin.ts
@@ -12,7 +12,6 @@ import {
   WazuhEndpointsPluginStart,
   AppPluginStartDependencies,
 } from './types';
-import { ISecurityFactory } from '../../wazuh-core/server/services/security-factory';
 
 export class WazuhEndpointsPlugin
   implements Plugin<WazuhEndpointsPluginSetup, WazuhEndpointsPluginStart> {

--- a/plugins/wazuh-endpoints/server/types.ts
+++ b/plugins/wazuh-endpoints/server/types.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AppPluginStartDependencies {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WazuhEndpointsPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WazuhEndpointsPluginStart {}
+
+export type PluginSetup = {};
+
+export interface AppPluginStartDependencies {}

--- a/plugins/wazuh-endpoints/test/jest/config.js
+++ b/plugins/wazuh-endpoints/test/jest/config.js
@@ -1,0 +1,41 @@
+import path from 'path';
+
+const kbnDir = path.resolve(__dirname, '../../../../');
+
+export default {
+  rootDir: path.resolve(__dirname, '../..'),
+  roots: ['<rootDir>/public', '<rootDir>/server', '<rootDir>/common'],
+  modulePaths: [`${kbnDir}/node_modules`],
+  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', './!**/node_modules/**'],
+  moduleNameMapper: {
+    '^ui/(.*)': `${kbnDir}/src/ui/public/$1`,
+    // eslint-disable-next-line max-len
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': `${kbnDir}/src/dev/jest/mocks/file_mock.js`,
+    '\\.(css|less|scss)$': `${kbnDir}/src/dev/jest/mocks/style_mock.js`,
+    axios: 'axios/dist/node/axios.cjs',
+  },
+  setupFiles: [
+    `${kbnDir}/src/dev/jest/setup/babel_polyfill.js`,
+    `${kbnDir}/src/dev/jest/setup/enzyme.js`,
+  ],
+  collectCoverage: true,
+  coverageDirectory: './target/test-coverage',
+  coverageReporters: ['html', 'text-summary', 'json-summary'],
+  globals: {
+    'ts-jest': {
+      skipBabel: true,
+    },
+  },
+  moduleFileExtensions: ['js', 'json', 'ts', 'tsx', 'html'],
+  modulePathIgnorePatterns: ['__fixtures__/', 'target/'],
+  testMatch: ['**/*.test.{js,ts,tsx}'],
+  transform: {
+    '^.+\\.js$': `${kbnDir}/src/dev/jest/babel_transform.js`,
+    '^.+\\.tsx?$': `${kbnDir}/src/dev/jest/babel_transform.js`,
+    '^.+\\.html?$': `${kbnDir}/src/dev/jest/babel_transform.js`,
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.js$'],
+  snapshotSerializers: [`${kbnDir}/node_modules/enzyme-to-json/serializer`],
+  testEnvironment: 'jest-environment-jsdom',
+  reporters: ['default', `${kbnDir}/src/dev/jest/junit_reporter.js`],
+};

--- a/plugins/wazuh-endpoints/translations/en-US.json
+++ b/plugins/wazuh-endpoints/translations/en-US.json
@@ -1,0 +1,79 @@
+{
+  "formats": {
+    "number": {
+      "currency": {
+        "style": "currency"
+      },
+      "percent": {
+        "style": "percent"
+      }
+    },
+    "date": {
+      "short": {
+        "month": "numeric",
+        "day": "numeric",
+        "year": "2-digit"
+      },
+      "medium": {
+        "month": "short",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "long": {
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "full": {
+        "weekday": "long",
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      }
+    },
+    "time": {
+      "short": {
+        "hour": "numeric",
+        "minute": "numeric"
+      },
+      "medium": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric"
+      },
+      "long": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      },
+      "full": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      }
+    },
+    "relative": {
+      "years": {
+        "units": "year"
+      },
+      "months": {
+        "units": "month"
+      },
+      "days": {
+        "units": "day"
+      },
+      "hours": {
+        "units": "hour"
+      },
+      "minutes": {
+        "units": "minute"
+      },
+      "seconds": {
+        "units": "second"
+      }
+    }
+  },
+  "messages": {}
+}

--- a/plugins/wazuh-endpoints/tsconfig.json
+++ b/plugins/wazuh-endpoints/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./target",
+    "skipLibCheck": true
+  },
+  "include": [
+    "index.ts",
+    "common/**/*.ts",
+    "public/**/*.ts",
+    "public/**/*.tsx",
+    "server/**/*.ts",
+    "../../typings/**/*",
+    "public/hooks"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
### Description
Create new plugin wazuh-endpoints to manage the endpoint fleet page components.
This issue is only for the plugin creation without any functionality.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6141

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/359ce89b-5431-46d2-98bd-d508ae4735c0)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/50e73eee-2401-434f-9160-b52709f9b0b4)

### Test

- Check if there is a new `wazuh-endpoints` plugin inside the `plugins` folder in the osd docker container.
- Check if the dashboard load ok

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
