### PR TITLE
Ignore uuid field in GET /manager/version/check response

### DIFF
--- a/docker/imposter/manager/version/check.json
+++ b/docker/imposter/manager/version/check.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "uuid": "7f828fd6-ef68-4656-b363-247b5861b84c",
     "last_check_date": "2023-10-04T14:52:07.319561Z",
     "current_version": "v4.8.0",
     "update_check": true,

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -370,7 +370,7 @@ export const ApiTable = compose(
                           color="primary"
                           iconType="questionInCircle"
                           aria-label="Info about the error"
-                          onClick={() => this.props.copyToClipBoard(item.downReason)}
+                          onClick={() => this.props.copyToClipBoard(api.error.detail)}
                         />
                       </EuiToolTip>
                     </EuiFlexItem>

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -76,7 +76,9 @@ describe('getUpdates function', () => {
     mockedGetWazuhCore.mockImplementation(() => ({
       controllers: {
         WazuhHostsCtrl: jest.fn().mockImplementation(() => ({
-          getHostsEntries: jest.fn().mockImplementation(() => [{ id: 'api id' }]),
+          getHostsEntries: jest
+            .fn()
+            .mockImplementation(() => [{ id: 'api id' }]),
         })),
       },
       services: {
@@ -86,6 +88,7 @@ describe('getUpdates function', () => {
               request: jest.fn().mockImplementation(() => ({
                 data: {
                   data: {
+                    uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
                     current_version: '4.3.1',
                     last_available_patch: {
                       description:

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -28,10 +28,10 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
       hosts?.map(async (api) => {
         const data = {};
         const method = 'GET';
-        const path = '/manager/version/check';
+        const path = '/manager/version/check?force_query=true';
         const options = {
           apiHostID: api.id,
-          force_query: true,
+          forceRefresh: true,
         };
         try {
           const response = await wazuhApiClient.client.asInternalUser.request(

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -31,7 +31,7 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
         const path = '/manager/version/check';
         const options = {
           apiHostID: api.id,
-          forceRefresh: true,
+          force_query: true,
         };
         try {
           const response = await wazuhApiClient.client.asInternalUser.request(

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -6,6 +6,7 @@ import {
 import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 import { getSavedObject, setSavedObject } from '../saved-object';
 import { getWazuhCore } from '../../plugin-services';
+import _ from 'lodash';
 
 export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<AvailableUpdates> => {
   try {
@@ -51,8 +52,10 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
               ? API_UPDATES_STATUS.AVAILABLE_UPDATES
               : API_UPDATES_STATUS.UP_TO_DATE;
 
+          const updateWithoutUUID = _.omit(update, 'uuid');
+
           return {
-            ...update,
+            ...updateWithoutUUID,
             api_id: api.id,
             status,
           };


### PR DESCRIPTION
### Description

- Ignore uuid field in GET /manager/version/check response to return the available updates from the service
- Fix copy error on `Updates status` column.

 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6156

### Evidence
#### Ignore uuid field
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/a0f6b00e-37e0-4d18-9f72-87b550dc4dfd)

#### Fix copy error
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/47dc13c2-c912-4a4d-838a-6b2ae7ec886a)

### Test
Test with an imposter or a real service with the endpoint `manager/version/check` and make sure that the `endpoint` returns `uuid` field.
#### Ignore uuid field with Imposter
- Go to the file `docker/imposter/wazuh-config.yml`
- Replace line 3 with: `specFile: https://raw.githubusercontent.com/wazuh/wazuh/dev-14153-vulndet-refactor/api/api/spec/spec.yaml`
- Restart imposter

#### Fix copy error
Go to the server APIs page, look for a column `Updates status` and a manager with and error. Click on the (?) icon. Check if the clipboard content match with the error.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
