### PR TITLE
Fix last_check_date mapping when check updates service is disabled

### DIFF
--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -6,7 +6,6 @@ import {
 import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 import { getSavedObject, setSavedObject } from '../saved-object';
 import { getWazuhCore } from '../../plugin-services';
-import _ from 'lodash';
 
 export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<AvailableUpdates> => {
   try {
@@ -43,15 +42,24 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
 
           const update = response.data.data as ResponseApiAvailableUpdates;
 
+          const {
+            current_version,
+            update_check,
+            last_available_major,
+            last_available_minor,
+            last_available_patch,
+            last_check_date,
+          } = update;
+
           const getStatus = () => {
-            if (update?.update_check === false) {
+            if (update_check === false) {
               return API_UPDATES_STATUS.DISABLED;
             }
 
             if (
-              update?.last_available_patch?.tag ||
-              update?.last_available_minor?.tag ||
-              update?.last_available_patch?.tag
+              last_available_major?.tag ||
+              last_available_minor?.tag ||
+              last_available_patch?.tag
             ) {
               return API_UPDATES_STATUS.AVAILABLE_UPDATES;
             }
@@ -59,10 +67,13 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
             return API_UPDATES_STATUS.UP_TO_DATE;
           };
 
-          const updateWithoutUUID = _.omit(update, 'uuid');
-
           return {
-            ...updateWithoutUUID,
+            current_version,
+            update_check,
+            last_available_major,
+            last_available_minor,
+            last_available_patch,
+            last_check_date: last_check_date || undefined,
             api_id: api.id,
             status: getStatus(),
           };


### PR DESCRIPTION
### Description
This PR solves the error that produces the API endpoint `manager/version/check` response when the check updates service is disabled and the field `last_check_date` is an empty string.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6168

### Evidence

#### Service disabled
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/6c8cedc6-c3b6-4a28-8648-a5f7ec93887a)

#### Up to date
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/01add604-6b70-4b85-bce6-637bf7c983a4)

#### Availabel updates
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/fb529d73-a658-4785-80e2-76cea9fc0c25)

### Test
1. Go to the file `docker/imposter/wazuh-config.yml`
2. Replace line 3 with: `specFile: https://raw.githubusercontent.com/wazuh/wazuh/dev-14153-vulndet-refactor/api/api/spec/spec.yaml`
3. Go to the file `docker/imposter/manager/version/check.json` and replace content with:
```console
{
  "data": {
    "last_check_date": "",
    "current_version": "4.8.0",
    "update_check": false,
    "last_available_major": {},
    "last_available_minor": {},
    "last_available_patch": {}
  },
  "error": 0
}
```
5. Restart imposter

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
