### PR TITLE
Fix error when a column with no value is selected to show in the vulnerabilities inventory table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added the ability to check if there are available updates from the UI. [#6093](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6093)
 - Added remember server address check [#5791](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5791)
 - Added the ssl_agent_ca configuration to the SSL Settings form [#6083](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6083)
-- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896)
+- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896) [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179)
 - Added an agent selector to the IT Hygiene application [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Added query results limit when the search exceed 10000 hits [#6106](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6106)
 
@@ -25,7 +25,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed a problem with the agent menu header when the side menu is docked [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Fixed how the query filters apply on the Security Alerts table [#6102](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6102)
-- Fixed error when a column with no value is selected to show in the vulnerabilities inventory table [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed a problem with the agent menu header when the side menu is docked [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Fixed how the query filters apply on the Security Alerts table [#6102](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6102)
+- Fixed error when a column with no value is selected to show in the vulnerabilities inventory table [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory_service.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory_service.ts
@@ -80,7 +80,7 @@ export const parseData = (resultsHits: SearchResponse['hits']['hits']): any[] =>
 }
 
 
-export const getFieldFormatted = (rowIndex, columnId, indexPattern, rowsParsed) => {
+export const getFieldValueFormatted = (rowIndex, columnId, indexPattern, rowsParsed) => {
     const field = indexPattern.fields.find((field) => field.name === columnId);
     let fieldValue = null;
     if (columnId.includes('.')) {
@@ -93,13 +93,19 @@ export const getFieldFormatted = (rowIndex, columnId, indexPattern, rowsParsed) 
                 fieldValue = fieldValue[field];
             }
         });
-
     } else {
-        fieldValue = rowsParsed[rowIndex][columnId].formatted
-            ? rowsParsed[rowIndex][columnId].formatted
-            : rowsParsed[rowIndex][columnId];
+        const rowValue = rowsParsed[rowIndex];
+        // when not exist the column in the row value then the value is null
+        if(!rowValue.hasOwnProperty(columnId)){
+            fieldValue = null;
+        }else{
+            fieldValue = rowValue[columnId]?.formatted || rowValue[columnId];
+        }
     }
-
+    // when fieldValue is null or undefined then return a empty string
+    if (fieldValue === null || fieldValue === undefined) {
+        return '';
+    }
     // if is date field
     if (field?.type === 'date') {
         // @ts-ignore

--- a/plugins/main/public/components/overview/vulnerabilities/data_grid/use_data_grid.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/data_grid/use_data_grid.ts
@@ -2,7 +2,7 @@ import { EuiDataGridCellValueElementProps, EuiDataGridColumn, EuiDataGridProps, 
 import { useEffect, useMemo, useState, Fragment } from "react";
 import { SearchResponse } from "@opensearch-project/opensearch/api/types";
 import { IFieldType, IndexPattern } from "../../../../../../../src/plugins/data/common";
-import { parseData, getFieldFormatted } from '../dashboards/inventory/inventory_service';
+import { parseData, getFieldValueFormatted } from '../dashboards/inventory/inventory_service';
 import { MAX_ENTRIES_PER_QUERY } from "../dashboards/inventory/config";
 
 type tDataGridProps = {
@@ -72,7 +72,7 @@ export const useDataGrid = (props: tDataGridProps): EuiDataGridProps => {
         // then the rowIndex is relative to the current page
         const relativeRowIndex = rowIndex % pagination.pageSize;        
         return rowsParsed.hasOwnProperty(relativeRowIndex)
-            ? getFieldFormatted(relativeRowIndex, columnId, indexPattern, rowsParsed)
+            ? getFieldValueFormatted(relativeRowIndex, columnId, indexPattern, rowsParsed)
             : null;
     };
 


### PR DESCRIPTION
### Description
This PR, 
solves an error when clicking on the `show all` button from the inventory columns selector.

The error was triggered when the column didn't have a value (empty value) to show.

Solves #6164 
 
### Test

- Go to the Vulnerabilities `Inventory` tab
- Open the columns selector
- Click on the `show all` button
- Check if all the columns are shown and not throw error

### Before

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/6089438/a266252e-9c9d-4a9e-8dc5-2d1b59376bf3)


### After

https://github.com/wazuh/wazuh-dashboard-plugins/assets/6089438/d56f0c69-3541-4d1b-ba22-6778588b10ee


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
