### PR TITLE
Fix default filters per tab in vulnerabilities module

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -29,7 +29,6 @@ const DashboardVulsComponent: React.FC = () => {
     appConfig.data['vulnerabilities.pattern'];
   const { searchBarProps } = useSearchBarConfiguration({
     defaultIndexPatternID: VULNERABILITIES_INDEX_PATTERN_ID,
-    filters: [],
   });
   const {
     isLoading: isLoadingSearchbar,


### PR DESCRIPTION
### Description
This pull request solves the problem of maintaining filters between the Dashboard and Inventory tabs in the vulnerabilities module.
In the case of the Events tab, when the use_search_bar_configuration hook of the other tabs is unmounted, the applied filters that do not correspond to the wazuh-alerts index used by the Events tab are cleaned.
 
### Issues Resolved
- #6165 

### Evidence
[Evidence.webm](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/b8dc3b35-2b34-4eb9-a14d-d8c58a359627)

### Test
- Navigate to Threat intelligence -> Vulnerability Detection
- Add/remove filters between Dashboard and Inventory tab. Filters must be kept between these tabs.
- Go to the Events tab and verify that the vulnerability filters have been removed. You should see the cluster.name and rule.groups filters.
- When returning to the Dashboard or Inventory tab from Events tba, the filters will be empty.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
