### PR TITLE
Add hostname board serial fields to agent inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.7.2
+- Added hostname and board serial to Agents > Inventory data [#6191](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6191)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.7.2
-- Added hostname and board serial to Agents > Inventory data [#6191](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6191)
+- Added host name and board serial information to Agents > Inventory data [#6191](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6191)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
+++ b/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
             <div
               class="euiText euiText--medium"
             >
-              Hostname: 
+              Host name: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />
@@ -2137,7 +2137,7 @@ exports[`Inventory component A Linux agent should be well rendered. 1`] = `
             <div
               class="euiText euiText--medium"
             >
-              Hostname: 
+              Host name: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />
@@ -4264,7 +4264,7 @@ exports[`Inventory component A Windows agent should be well rendered. 1`] = `
             <div
               class="euiText euiText--medium"
             >
-              Hostname: 
+              Host name: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />

--- a/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
+++ b/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
@@ -67,12 +67,36 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexItem"
+            class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiText euiText--medium"
             >
               CPU: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+           <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Hostname: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+           <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Board serial: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />

--- a/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
+++ b/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
               />
             </div>
           </div>
-            <div
+          <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
@@ -90,7 +90,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
               />
             </div>
           </div>
-            <div
+          <div
             class="euiFlexItem"
           >
             <div
@@ -2120,12 +2120,36 @@ exports[`Inventory component A Linux agent should be well rendered. 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexItem"
+            class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiText euiText--medium"
             >
               CPU: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Hostname: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Board serial: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />
@@ -4223,12 +4247,36 @@ exports[`Inventory component A Windows agent should be well rendered. 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexItem"
+            class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiText euiText--medium"
             >
               CPU: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Hostname: 
+              <span
+                class="euiLoadingSpinner euiLoadingSpinner--small"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiText euiText--medium"
+            >
+              Board serial: 
               <span
                 class="euiLoadingSpinner euiLoadingSpinner--small"
               />

--- a/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
+++ b/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
               />
             </div>
           </div>
-           <div
+            <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
@@ -90,7 +90,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
               />
             </div>
           </div>
-           <div
+            <div
             class="euiFlexItem"
           >
             <div

--- a/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
+++ b/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
@@ -105,6 +105,30 @@ export function InventoryMetrics({ agent }) {
             )}
           </EuiText>
         </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <EuiText>
+            Hostname:{' '}
+            {syscollector.isLoading ? (
+              <EuiLoadingSpinner size='s' />
+            ) : syscollector.data.os.hostname ? (
+              <strong>{syscollector.data.os.hostname}</strong>
+            ) : (
+              <strong>-</strong>
+            )}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <EuiText>
+            Board Serial:{' '}
+            {syscollector.isLoading ? (
+              <EuiLoadingSpinner size='s' />
+            ) : syscollector.data.hardware.board_serial ? (
+              <strong>{syscollector.data.hardware.board_serial}</strong>
+            ) : (
+              <strong>-</strong>
+            )}
+          </EuiText>
+        </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText>
             Last scan:{' '}

--- a/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
+++ b/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
@@ -93,7 +93,7 @@ export function InventoryMetrics({ agent }) {
             )}
           </EuiText>
         </EuiFlexItem>
-        <EuiFlexItem grow={true}>
+        <EuiFlexItem grow={false}>
           <EuiText>
             CPU:{' '}
             {syscollector.isLoading ? (
@@ -105,7 +105,7 @@ export function InventoryMetrics({ agent }) {
             )}
           </EuiText>
         </EuiFlexItem>
-        <EuiFlexItem grow={true}>
+        <EuiFlexItem grow={false}>
           <EuiText>
             Hostname:{' '}
             {syscollector.isLoading ? (
@@ -119,7 +119,7 @@ export function InventoryMetrics({ agent }) {
         </EuiFlexItem>
         <EuiFlexItem grow={true}>
           <EuiText>
-            Board Serial:{' '}
+            Board serial:{' '}
             {syscollector.isLoading ? (
               <EuiLoadingSpinner size='s' />
             ) : syscollector.data.hardware.board_serial ? (

--- a/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
+++ b/plugins/main/public/components/agents/syscollector/components/syscollector-metrics.tsx
@@ -107,7 +107,7 @@ export function InventoryMetrics({ agent }) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText>
-            Hostname:{' '}
+            Host name:{' '}
             {syscollector.isLoading ? (
               <EuiLoadingSpinner size='s' />
             ) : syscollector.data.os.hostname ? (


### PR DESCRIPTION
### Description
**Agent > Inventory** shows hostname and board serial fields
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6190

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/c04fc4de-96b8-419c-a81f-bb3370861571)


### Test
- [ ] Go to **Agent > Inventory** and check that shows the expected result

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
