### PR TITLE
Change the endpoint to get Wazuh manager auth configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed Agents preview page load when there are no registered agents [#6185](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6185)
+- Fixed the endpoint to get Wazuh server auth configuration [#6206](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6206)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/plugins/main/public/components/security/policies/create-policy.tsx
+++ b/plugins/main/public/components/security/policies/create-policy.tsx
@@ -110,23 +110,25 @@ export const CreatePolicyFlyout = ({ closeFlyout }) => {
 
     const actionsData = actionsRequest?.data?.data || {};
     setAvailableActions(actionsData);
-    const actions = Object.keys(actionsData).map((x, idx) => {
-      return {
-        id: idx,
-        value: x,
-        inputDisplay: x,
-        dropdownDisplay: (
-          <>
-            <strong>{x}</strong>
-            <EuiText size='s' color='subdued'>
-              <p className='euiTextColor--subdued'>
-                {actionsData[x].description}
-              </p>
-            </EuiText>
-          </>
-        ),
-      };
-    });
+    const actions = Object.keys(actionsData)
+      .map((x, idx) => {
+        return {
+          id: idx,
+          value: x,
+          inputDisplay: x,
+          dropdownDisplay: (
+            <>
+              <strong>{x}</strong>
+              <EuiText size='s' color='subdued'>
+                <p className='euiTextColor--subdued'>
+                  {actionsData[x].description}
+                </p>
+              </EuiText>
+            </>
+          ),
+        };
+      })
+      .sort((a, b) => a.value.localeCompare(b.value));
     setActions(actions);
   }
 
@@ -137,23 +139,25 @@ export const CreatePolicyFlyout = ({ closeFlyout }) => {
       allResources = allResources.concat(res);
     });
     const allResourcesSet = new Set(allResources);
-    const resources = Array.from(allResourcesSet).map((x, idx) => {
-      return {
-        id: idx,
-        value: x,
-        inputDisplay: x,
-        dropdownDisplay: (
-          <>
-            <strong>{x}</strong>
-            <EuiText size='s' color='subdued'>
-              <p className='euiTextColor--subdued'>
-                {availableResources[x].description}
-              </p>
-            </EuiText>
-          </>
-        ),
-      };
-    });
+    const resources = Array.from(allResourcesSet)
+      .map((x, idx) => {
+        return {
+          id: idx,
+          value: x,
+          inputDisplay: x,
+          dropdownDisplay: (
+            <>
+              <strong>{x}</strong>
+              <EuiText size='s' color='subdued'>
+                <p className='euiTextColor--subdued'>
+                  {availableResources[x].description}
+                </p>
+              </EuiText>
+            </>
+          ),
+        };
+      })
+      .sort((a, b) => a.value.localeCompare(b.value));
     setResources(resources);
   };
 

--- a/plugins/main/public/components/security/policies/edit-policy.tsx
+++ b/plugins/main/public/components/security/policies/edit-policy.tsx
@@ -112,23 +112,25 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
 
     const actionsData = actionsRequest?.data?.data || {};
     setAvailableActions(actionsData);
-    const actions = Object.keys(actionsData).map((x, idx) => {
-      return {
-        id: idx,
-        value: x,
-        inputDisplay: x,
-        dropdownDisplay: (
-          <>
-            <strong>{x}</strong>
-            <EuiText size='s' color='subdued'>
-              <p className='euiTextColor--subdued'>
-                {actionsData[x].description}
-              </p>
-            </EuiText>
-          </>
-        ),
-      };
-    });
+    const actions = Object.keys(actionsData)
+      .map((x, idx) => {
+        return {
+          id: idx,
+          value: x,
+          inputDisplay: x,
+          dropdownDisplay: (
+            <>
+              <strong>{x}</strong>
+              <EuiText size='s' color='subdued'>
+                <p className='euiTextColor--subdued'>
+                  {actionsData[x].description}
+                </p>
+              </EuiText>
+            </>
+          ),
+        };
+      })
+      .sort((a, b) => a.value.localeCompare(b.value));
     setActions(actions);
   }
 
@@ -139,23 +141,25 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
       allResources = allResources.concat(res);
     });
     const allResourcesSet = new Set(allResources);
-    const resources = Array.from(allResourcesSet).map((x, idx) => {
-      return {
-        id: idx,
-        value: x,
-        inputDisplay: x,
-        dropdownDisplay: (
-          <>
-            <strong>{x}</strong>
-            <EuiText size='s' color='subdued'>
-              <p className='euiTextColor--subdued'>
-                {(availableResources[x] || {}).description}
-              </p>
-            </EuiText>
-          </>
-        ),
-      };
-    });
+    const resources = Array.from(allResourcesSet)
+      .map((x, idx) => {
+        return {
+          id: idx,
+          value: x,
+          inputDisplay: x,
+          dropdownDisplay: (
+            <>
+              <strong>{x}</strong>
+              <EuiText size='s' color='subdued'>
+                <p className='euiTextColor--subdued'>
+                  {(availableResources[x] || {}).description}
+                </p>
+              </EuiText>
+            </>
+          ),
+        };
+      })
+      .sort((a, b) => a.value.localeCompare(b.value));
     setResources(resources);
   };
 

--- a/plugins/main/public/components/security/policies/policies-table.tsx
+++ b/plugins/main/public/components/security/policies/policies-table.tsx
@@ -87,7 +87,7 @@ export const PoliciesTable = ({
       name: 'Actions',
       sortable: true,
       render: actions => {
-        return (actions || []).join(', ');
+        return (actions || []).sort((a, b) => a.localeCompare(b)).join(', ');
       },
       truncateText: true,
     },

--- a/plugins/main/public/controllers/register-agent/services/register-agent-services.tsx
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-services.tsx
@@ -92,6 +92,19 @@ async function getRemoteConfiguration(nodeName: string): Promise<RemoteConfig> {
     return config;
   }
 }
+/**
+ * Get the manager/cluster auth configuration from Wazuh API
+ * @param node
+ * @returns
+ */
+async function getAuthConfiguration(node?: string) {
+  const authConfigUrl = node
+    ? `/cluster/${node}/configuration/auth/auth`
+    : '/manager/configuration/auth/auth';
+  const result = await WzRequest.apiReq('GET', authConfigUrl, {});
+  const auth = result?.data?.data?.affected_items?.[0];
+  return auth;
+}
 
 /**
  * Get the remote protocol available from list of protocols
@@ -213,13 +226,18 @@ export const getMasterNode = (nodeIps: any[]): any[] => {
 };
 
 /**
- * Get the remote configuration from manager
+ * Get the remote and the auth configuration from manager
  * This function get the config from manager mode or cluster mode
  */
-export const getMasterRemoteConfiguration = async () => {
+export const getMasterConfiguration = async () => {
   const nodes = await fetchClusterNodesOptions();
   const masterNode = getMasterNode(nodes);
-  return await getRemoteConfiguration(masterNode[0].label);
+  const remote = await getRemoteConfiguration(masterNode[0].label);
+  const auth = await getAuthConfiguration(masterNode[0].label);
+  return {
+    remote,
+    auth,
+  };
 };
 
 export { getConnectionConfig, getRemoteConfiguration };
@@ -260,16 +278,18 @@ export interface IParseRegisterFormValues {
 export const parseRegisterAgentFormValues = (
   formValues: { name: keyof UseFormReturn['fields']; value: any }[],
   OSOptionsDefined: RegisterAgentData[],
-  initialValues?: IParseRegisterFormValues
+  initialValues?: IParseRegisterFormValues,
 ) => {
   // return the values form the formFields and the value property
-  const parsedForm = initialValues || {
-    operatingSystem: {
-      architecture: '',
-      name: '',
-    },
-    optionalParams: {},
-  } as IParseRegisterFormValues;
+  const parsedForm =
+    initialValues ||
+    ({
+      operatingSystem: {
+        architecture: '',
+        name: '',
+      },
+      optionalParams: {},
+    } as IParseRegisterFormValues);
   formValues.forEach(field => {
     if (field.name === 'operatingSystemSelection') {
       // search the architecture defined in architecture array and get the os name defined in title array in the same index
@@ -284,7 +304,9 @@ export const parseRegisterAgentFormValues = (
       }
     } else {
       if (field.name === 'agentGroups') {
-        parsedForm.optionalParams[field.name as any] = field.value.map(item => item.id)
+        parsedForm.optionalParams[field.name as any] = field.value.map(
+          item => item.id,
+        );
       } else {
         parsedForm.optionalParams[field.name as any] = field.value;
       }


### PR DESCRIPTION
### Description
This pull request aims to use a manager or cluster endpoint to get the authentication configuration of the Wazuh server. Previously it used the agent endpoint filtered by the manager ID `000`, which may cause RBAC issues.

It also fixes the order of the RBAC options in the create/edit policies view, so they appear in alphabetical order.
 
### Issues Resolved
Closes #6203 

### Evidence

#### GET auth request
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/ea47e1ca-b401-4078-8c15-fee7f3cbaf0c)

#### Ascending order of the RBAC options
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/d64cbc0a-12cf-4ab5-aee0-8b6006f28d3d)


### Test

- Check the manager auth configuration request uses either the manager or cluster endpoint:
https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_node_config

- Configure a password in the manager and check the register agent wizard sets the password properly in the script:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/1babc5a7-c2ac-4df2-9214-bbcd576cd299)

- Check the actions SuperSelect options are in alphabetical order:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/f6e061bb-8b37-4d00-a381-0ae0badc8045)


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
