### PR TITLE
Standardize titles and subtitles in the register agent wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
+- Added contextual information in the register agent commands [#6208](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6208)
 - Support for Wazuh 4.7.2
 - Added host name and board serial information to Agents > Inventory data [#6191](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6191)
 

--- a/plugins/main/public/controllers/agent/components/agents-preview.scss
+++ b/plugins/main/public/controllers/agent/components/agents-preview.scss
@@ -57,7 +57,7 @@
     position: absolute;
     top: 0;
     width: 100%;
-    height: 90%;
+    height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
+++ b/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
@@ -10,6 +10,7 @@ import {
 import React, { Fragment, useEffect, useState } from 'react';
 import { tOperatingSystem } from '../../core/config/os-commands-definitions';
 import { osdfucatePasswordInCommand } from '../../services/wazuh-password-service';
+import OsCommandWarning from './os-warning';
 
 interface ICommandSectionProps {
   commandText: string;
@@ -55,7 +56,6 @@ export default function CommandOutput(props: ICommandSectionProps) {
   const onChangeShowPassword = (event: EuiSwitchEvent) => {
     setShowPassword(event.target.checked);
   };
-
   return (
     <Fragment>
       <EuiSpacer />
@@ -84,6 +84,7 @@ export default function CommandOutput(props: ICommandSectionProps) {
             </EuiCopy>
           )}
         </div>
+        <OsCommandWarning os={os} />
         <EuiSpacer size='s' />
         {showCommand && havePassword ? (
           <EuiSwitch

--- a/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
+++ b/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
@@ -63,6 +63,7 @@ export default function CommandOutput(props: ICommandSectionProps) {
           <EuiCodeBlock
             style={{
               zIndex: '100',
+              wordWrap: 'break-word',
             }}
             language='tsx'
           >

--- a/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
+++ b/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
@@ -10,7 +10,6 @@ import {
 import React, { Fragment, useEffect, useState } from 'react';
 import { tOperatingSystem } from '../../core/config/os-commands-definitions';
 import { osdfucatePasswordInCommand } from '../../services/wazuh-password-service';
-import OsCommandWarning from './os-warning';
 
 interface ICommandSectionProps {
   commandText: string;
@@ -84,7 +83,6 @@ export default function CommandOutput(props: ICommandSectionProps) {
             </EuiCopy>
           )}
         </div>
-        <OsCommandWarning os={os} />
         <EuiSpacer size='s' />
         {showCommand && havePassword ? (
           <EuiSwitch

--- a/plugins/main/public/controllers/register-agent/components/command-output/os-warning.tsx
+++ b/plugins/main/public/controllers/register-agent/components/command-output/os-warning.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { tOperatingSystem } from '../../core/config/os-commands-definitions';
+
+interface OsWarningProps {
+  os?: tOperatingSystem['name'];
+}
+
+export default function OsCommandWarning(props: OsWarningProps) {
+  const osSelector = {
+    WINDOWS: (
+      <EuiCallOut title='Requirements' iconType='iInCircle'>
+        <ul className='wz-callout-list'>
+          <li>
+            <span>
+              You will need administrator privileges to perform this
+              installation.
+            </span>
+          </li>
+          <li>
+            <span>PowerShell 3.0 or greater is required.</span>
+          </li>
+        </ul>
+        <p>
+          Keep in mind you need to run this command in a Windows PowerShell
+          terminal.
+        </p>
+      </EuiCallOut>
+    ),
+    LINUX: (
+      <EuiCallOut title='Requirements' iconType='iInCircle'>
+        <ul className='wz-callout-list'>
+          <li>
+            <span>
+              You will need administrator privileges to perform this
+              installation.
+            </span>
+          </li>
+          <li>
+            <span>Shell Bash is required.</span>
+          </li>
+        </ul>
+        <p>
+          Keep in mind you need to run this command in a Shell Bash terminal.
+        </p>
+      </EuiCallOut>
+    ),
+    macOS: (
+      <EuiCallOut title='Requirements' iconType='iInCircle'>
+        <ul className='wz-callout-list'>
+          <li>
+            <span>
+              You will need administrator privileges to perform this
+              installation.
+            </span>
+          </li>
+          <li>
+            <span>Shell Bash is required.</span>
+          </li>
+        </ul>
+        <p>
+          Keep in mind you need to run this command in a Shell Bash terminal.
+        </p>
+      </EuiCallOut>
+    ),
+  };
+
+  return osSelector[props?.os] || null;
+}

--- a/plugins/main/public/controllers/register-agent/components/group-input/group-input.tsx
+++ b/plugins/main/public/controllers/register-agent/components/group-input/group-input.tsx
@@ -45,7 +45,7 @@ const GroupInput = ({ value, options, onChange }) => {
       >
         <EuiFlexItem grow={false}>
           <p className='registerAgentLabels'>
-            Select one or more existing groups
+            Select one or more existing groups:
           </p>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/plugins/main/public/controllers/register-agent/components/optionals-inputs/optionals-inputs.tsx
+++ b/plugins/main/public/controllers/register-agent/components/optionals-inputs/optionals-inputs.tsx
@@ -27,7 +27,7 @@ const OptionalsInputs = (props: OptionalsInputsProps) => {
   const agentNameDocLink = webDocumentationLink(
     'user-manual/reference/ossec-conf/client.html#enrollment-agent-name',
     PLUGIN_VERSION_SHORT,
-  )
+  );
   const popoverAgentName = (
     <span>
       Learn about{' '}
@@ -64,7 +64,7 @@ const OptionalsInputs = (props: OptionalsInputsProps) => {
               gutterSize='s'
             >
               <EuiFlexItem grow={false}>
-                <p className='registerAgentLabels'>Assign an agent name</p>
+                <p className='registerAgentLabels'>Assign an agent name:</p>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
@@ -94,11 +94,16 @@ const OptionalsInputs = (props: OptionalsInputsProps) => {
       />
       <EuiCallOut
         color='warning'
-        title={<span>{warningForAgentName}<EuiLink
-          target='_blank'
-          href={agentNameDocLink}
-          rel='noopener noreferrer'
-        /></span>}
+        title={
+          <span>
+            {warningForAgentName}
+            <EuiLink
+              target='_blank'
+              href={agentNameDocLink}
+              rel='noopener noreferrer'
+            />
+          </span>
+        }
         iconType='iInCircle'
         className='warningForAgentName'
       />

--- a/plugins/main/public/controllers/register-agent/components/server-address/server-address.tsx
+++ b/plugins/main/public/controllers/register-agent/components/server-address/server-address.tsx
@@ -66,7 +66,7 @@ const ServerAddressInput = (props: ServerAddressInputProps) => {
             >
               <EuiFlexItem grow={false}>
                 <span className='registerAgentLabels'>
-                  Assign a server address
+                  Assign a server address:
                 </span>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>

--- a/plugins/main/public/controllers/register-agent/containers/steps/steps.scss
+++ b/plugins/main/public/controllers/register-agent/containers/steps/steps.scss
@@ -32,10 +32,6 @@
     margin-top: 10px;
   }
 
-  .euiToolTipAnchor {
-    margin-left: 7px;
-  }
-
   .subtitleAgentName {
     flex-direction: 'row';
     font-style: 'normal';

--- a/plugins/main/public/controllers/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/controllers/register-agent/containers/steps/steps.tsx
@@ -33,6 +33,7 @@ import {
   tFormStepsLabel,
 } from '../../services/register-agent-steps-status-services';
 import { webDocumentationLink } from '../../../../../common/services/web_documentation';
+import OsCommandWarning from '../../components/command-output/os-warning';
 
 interface IStepsProps {
   needsPassword: boolean;
@@ -207,13 +208,18 @@ export const Steps = ({
             />
           ) : null}
           {!missingStepsName?.length && !invalidFieldsName?.length ? (
-            <CommandOutput
-              commandText={installCommand}
-              showCommand={showCommandsSections(form.fields)}
-              os={registerAgentFormValues.operatingSystem.name}
-              onCopy={() => setInstallCommandWasCopied(true)}
-              password={registerAgentFormValues.optionalParams.wazuhPassword}
-            />
+            <>
+              <CommandOutput
+                commandText={installCommand}
+                showCommand={showCommandsSections(form.fields)}
+                os={registerAgentFormValues.operatingSystem.name}
+                onCopy={() => setInstallCommandWasCopied(true)}
+                password={registerAgentFormValues.optionalParams.wazuhPassword}
+              />
+              <OsCommandWarning
+                os={registerAgentFormValues.operatingSystem.name}
+              />
+            </>
           ) : null}
         </>
       ),

--- a/plugins/main/public/controllers/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/controllers/register-agent/containers/steps/steps.tsx
@@ -141,14 +141,14 @@ export const Steps = ({
       status: getOSSelectorStepStatus(form.fields),
     },
     {
-      title: 'Server address',
+      title: 'Server address:',
       children: <ServerAddress formField={form.fields.serverAddress} />,
       status: getServerAddressStepStatus(form.fields),
     },
     ...(needsPassword && !wazuhPassword
       ? [
           {
-            title: 'Wazuh password',
+            title: 'Wazuh password:',
             children: (
               <EuiCallOut
                 color='warning'
@@ -176,7 +176,7 @@ export const Steps = ({
         ]
       : []),
     {
-      title: 'Optional settings',
+      title: 'Optional settings:',
       children: <OptionalsInputs formFields={form.fields} />,
       status: getOptionalParameterStepStatus(
         form.fields,
@@ -184,8 +184,7 @@ export const Steps = ({
       ),
     },
     {
-      title:
-        'Run the following commands to download and install the Wazuh agent:',
+      title: 'Run the following commands to download and install the agent:',
       children: (
         <>
           {missingStepsName?.length ? (
@@ -221,7 +220,7 @@ export const Steps = ({
       status: installCommandStepStatus,
     },
     {
-      title: 'Start the Wazuh agent:',
+      title: 'Start the agent:',
       children: (
         <>
           {missingStepsName?.length ? (

--- a/plugins/main/public/controllers/register-agent/utils/register-agent-data.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/register-agent-data.tsx
@@ -34,7 +34,7 @@ export const SERVER_ADDRESS_TEXTS = [
   {
     title: 'Server address',
     subtitle:
-      'This is the address the agent uses to communicate with the Wazuh server. Enter an IP address or a fully qualified domain name (FDQN).',
+      'This is the address the agent uses to communicate with the server. Enter an IP address or a fully qualified domain name (FDQN).',
   },
 ];
 
@@ -42,6 +42,6 @@ export const OPTIONAL_PARAMETERS_TEXT = [
   {
     title: 'Optional settings',
     subtitle:
-      'The deployment sets the endpoint hostname as the agent name by default. Optionally, you can set your own name in the field below.',
+      'By default, the deployment uses the hostname as the agent name. Optionally, you can use a different agent name in the field below.',
   },
 ];


### PR DESCRIPTION
### Description
- Add colons `:` at the end of wizard titles
- Add colons `:` to input labels
- Add an info callout specifying if the script is in Powershell (Windows) or shell bash (Linux). It should also mention when administrator permissions are needed.
- Change the description of the optional setting
- Remove the word Wazuh each time an agent is mentioned
 
### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/6202


### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/a0b12d83-b552-407a-984c-5ec25b7a18d3)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/12f19f28-dfcb-4aa2-88d2-01cd8904725e)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/2ec1ee9e-9b1e-4e44-8312-78a0744658f7)


### Test

- [ ] Try all cases shown in evidence

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
