### PR TITLE
Fix the register agent selected cluster/manager config endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
-- Added contextual information in the register agent commands [#6208](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6208)
 - Support for Wazuh 4.7.2
+- Added contextual information in the register agent commands [#6208](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6208)
 - Added host name and board serial information to Agents > Inventory data [#6191](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6191)
 
 ### Fixed
 
 - Fixed Agents preview page load when there are no registered agents [#6185](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6185)
-- Fixed the endpoint to get Wazuh server auth configuration [#6206](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6206)
+- Fixed the endpoint to get Wazuh server auth configuration [#6206](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6206) [#6213](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6213)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 01
 


### PR DESCRIPTION
### Description
This pull request fixes the conditional in the register agent service to determine if the app is in cluster mode or not.
 
### Issues Resolved
This is part of the issue #6203 

### Test

The requests made to get the node configuration must match the cluster or manager configuration.

- Configure the app in cluster mode
  - Go to modules > Overview and check no error toasts pop up
  - Go to Agents and check no error toasts pop up
- Configure the app in manager mode
  - Go to modules > Overview and check no error toasts pop up
  - Go to Agents and check no error toasts pop up
    
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/2095ebd9-0bf9-468f-af12-81d3ce7aa97f)



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
