### PR TITLE
Fix error navigating back to agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed Agents preview page load when there are no registered agents [#6185](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6185)
 - Fixed the endpoint to get Wazuh server auth configuration [#6206](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6206) [#6213](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6213)
+- Fixed error navigating back to agent in some scenarios [#6224](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6224)
 
 ## Wazuh v4.7.1 - OpenSearch Dashboards 2.8.0 - Revision 01
 

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -54,6 +54,7 @@ import {
   agentStatusColorByAgentStatus,
   agentStatusLabelByAgentStatus,
 } from '../../../../common/services/wz_agent_status';
+import { AppNavigate } from '../../../react-services/app-navigate.js';
 
 export const AgentsPreview = compose(
   withErrorBoundary,
@@ -319,10 +320,13 @@ export const AgentsPreview = compose(
                                 content='View agent details'
                               >
                                 <EuiLink
-                                  onClick={() =>
-                                    this.showAgent(
-                                      this.state.lastRegisteredAgent,
-                                    )
+                                  onClick={ev => {
+                                    ev.stopPropagation();
+                                    AppNavigate.navigateToModule(ev, 'agents', {
+                                      tab: 'welcome',
+                                      agent: this.state.lastRegisteredAgent?.id,
+                                    });
+                                  }
                                   }
                                 >
                                   {this.state.lastRegisteredAgent?.name || '-'}
@@ -349,8 +353,13 @@ export const AgentsPreview = compose(
                                   content='View agent details'
                                 >
                                   <EuiLink
-                                    onClick={() =>
-                                      this.showAgent(this.state.agentMostActive)
+                                    onClick={ev => {
+                                      ev.stopPropagation();
+                                      AppNavigate.navigateToModule(ev, 'agents', {
+                                        tab: 'welcome',
+                                        agent: this.state.agentMostActive?.id,
+                                      });
+                                    }
                                     }
                                   >
                                     {this.state.agentMostActive?.name || '-'}


### PR DESCRIPTION
### Description
This PR aims to solve a problem with the agents. When a user access an agent information clicking on `Most active agent` or `Last registered agent`, after navigating to another site on the app it can't return with the browser's `back` button. 
This doesn't happen when the agent is accessed through the agents table
 
### Issues Resolved
#6211 

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/530adda1-0169-4aae-90b0-5d5a1e68b91a







### Test
1. Have an environment with a real manager and an agent registered
2. Navigate to `Wazuh/Agents` and click on the `Last registered agent`
3. Navigate to `Wazuh/Tools/Api console` and run any query
4. Click the browser's back button. It should return to the agent detail. 
5. Repeat steps 2 to 4, clicking on the `Most active agent` instead of last registered
6. Repeat steps 2 to 4, clicking on an agent in the agents table. 


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
