### PR TITLE
Fix reports path in toast

### DIFF
--- a/plugins/main/public/react-services/reporting.js
+++ b/plugins/main/public/react-services/reporting.js
@@ -82,7 +82,7 @@ export class ReportingService {
       const visualizationIDList = [];
       for (const item of idArray) {
         const tmpHTMLElement = $(`#${item}`);
-        if(tmpHTMLElement[0]){
+        if (tmpHTMLElement[0]) {
           this.vis2png.assignHTMLItem(item, tmpHTMLElement);
           visualizationIDList.push(item);
         }
@@ -120,7 +120,7 @@ export class ReportingService {
       this.showToast(
         'success',
         'Created report',
-        'Success. Go to Wazuh > Management > Reporting',
+        'Success. Go to Indexer/dashboard management > Reporting',
         4000
       );
       return;
@@ -167,7 +167,7 @@ export class ReportingService {
       this.showToast(
         'success',
         'Created report',
-        'Success. Go to Wazuh > Management > Reporting',
+        'Success. Go to Indexer/dashboard management > Reporting',
         4000
       );
       return;

--- a/plugins/main/public/services/reporting.js
+++ b/plugins/main/public/services/reporting.js
@@ -71,9 +71,8 @@ export class ReportingService {
       const appliedFilters = await this.visHandlers.getAppliedFilters(syscollectorFilters);
 
       const array = await this.vis2png.checkArray(idArray);
-      const name = `wazuh-${isAgents ? 'agents' : 'overview'}-${tab}-${
-        (Date.now() / 1000) | 0
-      }.pdf`;
+      const name = `wazuh-${isAgents ? 'agents' : 'overview'}-${tab}-${(Date.now() / 1000) | 0
+        }.pdf`;
 
       const browserTimezone = moment.tz.guess(true);
 
@@ -96,7 +95,7 @@ export class ReportingService {
       this.$rootScope.reportBusy = false;
       this.$rootScope.reportStatus = false;
       this.$rootScope.$applyAsync();
-      ErrorHandler.info('Success. Go to Wazuh > Management > Reporting', 'Reporting');
+      ErrorHandler.info('Success. Go to Indexer/dashboard management > Reporting', 'Reporting');
 
       return;
     } catch (error) {
@@ -134,7 +133,7 @@ export class ReportingService {
       this.$rootScope.reportBusy = false;
       this.$rootScope.reportStatus = false;
       this.$rootScope.$applyAsync();
-      ErrorHandler.info('Success. Go to Wazuh > Management > Reporting', 'Reporting');
+      ErrorHandler.info('Success. Go to Indexer/dashboard management > Reporting', 'Reporting');
 
       return;
     } catch (error) {


### PR DESCRIPTION
### Description
After the redesign of the application, the path of generated reports changed. This PR changes the toast that notifies the user where to find the reports to show the current path.
 
### Issues Resolved
#6215

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/54801186-648b-4f86-aaa4-09620d53b0e7)


### Test
 -  Navigate to IT Hygiene 
 - Select an agent
 - Go to Configuration option
 - Select Generate Report
 - Confirm that the toast shows the correct path
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
