### PR TITLE
Fix invalid date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed exception in IT-Hygiene when an agent doesn't have policies [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed exception in Inventory when agents don't have S.O. information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
+- Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
 
 ### Removed
 

--- a/plugins/main/public/controllers/agent/components/agents-table.js
+++ b/plugins/main/public/controllers/agent/components/agents-table.js
@@ -233,6 +233,7 @@ export const AgentsTable = compose(
             />
           </span>
         ),
+        render: dateAdd => formatUIDate(dateAdd),
         sortable: true,
         show: false,
         searchable: false,
@@ -250,6 +251,7 @@ export const AgentsTable = compose(
             />
           </span>
         ),
+        render: lastKeepAlive => formatUIDate(lastKeepAlive),
         sortable: true,
         show: false,
         searchable: false,
@@ -334,12 +336,6 @@ export const AgentsTable = compose(
                 return {
                   ...item,
                   ...(item.ip ? { ip: item.ip } : { ip: '-' }),
-                  ...(typeof item.dateAdd === 'string'
-                    ? { dateAdd: formatUIDate(item.dateAdd) }
-                    : { dateAdd: '-' }),
-                  ...(typeof item.lastKeepAlive === 'string'
-                    ? { lastKeepAlive: formatUIDate(item.lastKeepAlive) }
-                    : { lastKeepAlive: '-' }),
                   ...(item.node_name !== 'unknown'
                     ? { node_name: item.node_name }
                     : { node_name: '-' }),

--- a/plugins/main/public/controllers/settings/settings.js
+++ b/plugins/main/public/controllers/settings/settings.js
@@ -472,7 +472,7 @@ export class SettingsController {
       const response = data.data.data;
       this.appInfo = {
         'app-version': response['app-version'],
-        installationDate: formatUIDate(response['installationDate']),
+        installationDate: response['installationDate'],
         revision: response['revision'],
       };
 

--- a/plugins/main/public/react-services/time-service.js
+++ b/plugins/main/public/react-services/time-service.js
@@ -12,15 +12,18 @@
 import moment from 'moment-timezone';
 import { getUiSettings } from '../kibana-services';
 
-export const formatUIDate = (date) => {
+export const formatUIDate = date => {
+  if (typeof date !== 'string') {
+    return '-';
+  }
   const dateFormat = getUiSettings().get('dateFormat');
   const timezone = getTimeZone();
   const momentDate = moment(date);
   momentDate.tz(timezone);
   return momentDate.format(dateFormat);
-}
+};
 const getTimeZone = () => {
   const dateFormatTZ = getUiSettings().get('dateFormat:tz');
   const detectedTimezone = moment.tz.guess();
   return dateFormatTZ === 'Browser' ? detectedTimezone : dateFormatTZ;
-}
+};

--- a/plugins/wazuh-core/public/utils/time.ts
+++ b/plugins/wazuh-core/public/utils/time.ts
@@ -2,6 +2,9 @@ import moment from 'moment-timezone';
 import { getUiSettings } from '../plugin-services';
 
 export const formatUIDate = (date: Date) => {
+  if (typeof date !== 'string') {
+    return '-';
+  }
   const dateFormat = getUiSettings().get('dateFormat');
   const timezone = getTimeZone();
   const momentDate = moment(date);


### PR DESCRIPTION
### Description
This PR fixes a few redundant date formats. This was caused by some components trying to format dates already formatted.

It also improves the validation of the date parameter in the `formatUIDate` service.

> [!IMPORTANT]  
> The issue can only be replicated in Firefox. Nevertheless, it should be tested in all browsers with a real manager.
 
### Issues Resolved
Closes #6207 #6212 #6220 

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/1c0375ee-e922-44a9-ab55-45d94f6ecab5)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/7ad4389f-3e31-4a46-8bd6-3423946257b6)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/873cfe4f-8ffa-4eb4-a3af-8f4d9b1fb48f)


### Test
- Go to _About_ page and check the date renders properly
- Register an agent in a Wazuh server
- Go to Endpoints Summart and check the date values are rendered properly
- Select an agent in the table and verify `Registration date` and `Last keep alive` values render a valid date

### Check List
- [x] All tests pass
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
