### PR TITLE
Fix links las registered agent and agent most active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Moved the plugin menu to platform applications into the side menu [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840) [#6226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6226)
+- Moved the plugin menu to platform applications into the side menu [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840) [#6226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6226) [#6244](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6244)
 - Changed dashboards. [#6035](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6035)
 - Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 - Upgraded the `axios` dependency to `1.6.1` [#5062](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5062)
@@ -27,7 +27,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a problem with the agent menu header when the side menu is docked [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Fixed how the query filters apply on the Security Alerts table [#6102](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6102)
 - Fixed exception in IT-Hygiene when an agent doesn't have policies [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
-- Fixed exception in Inventory when agents don't have S.O. information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
+- Fixed exception in Inventory when agents don't have OS information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
 

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -315,6 +315,7 @@ export const AgentsPreview = compose(
                       <EuiFlexGroup className='mt-0'>
                         <EuiFlexItem className='agents-link-item'>
                           <EuiStat
+                            titleElement='div'
                             className='euiStatLink last-agents-link'
                             isLoading={this.state.loadingAgents}
                             title={
@@ -350,6 +351,7 @@ export const AgentsPreview = compose(
                         {
                           <EuiFlexItem className='agents-link-item'>
                             <EuiStat
+                              titleElement='div'
                               className={
                                 this.state.agentMostActive?.name
                                   ? 'euiStatLink'

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -24,6 +24,7 @@ import {
   EuiCard,
   EuiLink,
   EuiProgress,
+  EuiText,
 } from '@elastic/eui';
 import { AgentsTable } from './agents-table';
 import { WzRequest } from '../../../react-services/wz-request';
@@ -54,8 +55,9 @@ import {
   agentStatusColorByAgentStatus,
   agentStatusLabelByAgentStatus,
 } from '../../../../common/services/wz_agent_status';
-import { AppNavigate } from '../../../react-services/app-navigate.js';
-import { endpointSumary } from '../../../utils/applications';
+import { endpointSumary, itHygiene } from '../../../utils/applications';
+import { getCore } from '../../../kibana-services';
+import { RedirectAppLinks } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 
 export const AgentsPreview = compose(
   withErrorBoundary,
@@ -316,23 +318,29 @@ export const AgentsPreview = compose(
                             className='euiStatLink last-agents-link'
                             isLoading={this.state.loadingAgents}
                             title={
-                              <EuiToolTip
-                                position='top'
-                                content='View agent details'
-                              >
-                                <EuiLink
-                                  onClick={ev => {
-                                    ev.stopPropagation();
-                                    AppNavigate.navigateToModule(ev, 'agents', {
-                                      tab: 'welcome',
-                                      agent: this.state.lastRegisteredAgent?.id,
-                                    });
-                                  }
-                                  }
+                              this.state.lastRegisteredAgent?.id ? (
+                                <EuiToolTip
+                                  position='top'
+                                  content='View agent details'
                                 >
-                                  {this.state.lastRegisteredAgent?.name || '-'}
-                                </EuiLink>
-                              </EuiToolTip>
+                                  <RedirectAppLinks
+                                    application={getCore().application}
+                                  >
+                                    <EuiLink
+                                      href={getCore().application.getUrlForApp(
+                                        itHygiene.id,
+                                        {
+                                          path: `#/agents?tab=welcome&agent=${this.state.lastRegisteredAgent?.id}`,
+                                        },
+                                      )}
+                                    >
+                                      {this.state.lastRegisteredAgent?.name}
+                                    </EuiLink>
+                                  </RedirectAppLinks>
+                                </EuiToolTip>
+                              ) : (
+                                <EuiText>-</EuiText>
+                              )
                             }
                             titleSize='s'
                             description='Last registered agent'
@@ -349,23 +357,29 @@ export const AgentsPreview = compose(
                               }
                               isLoading={this.state.loadingAgents}
                               title={
-                                <EuiToolTip
-                                  position='top'
-                                  content='View agent details'
-                                >
-                                  <EuiLink
-                                    onClick={ev => {
-                                      ev.stopPropagation();
-                                      AppNavigate.navigateToModule(ev, 'agents', {
-                                        tab: 'welcome',
-                                        agent: this.state.agentMostActive?.id,
-                                      });
-                                    }
-                                    }
+                                this.state.agentMostActive?.id ? (
+                                  <EuiToolTip
+                                    position='top'
+                                    content='View agent details'
                                   >
-                                    {this.state.agentMostActive?.name || '-'}
-                                  </EuiLink>
-                                </EuiToolTip>
+                                    <RedirectAppLinks
+                                      application={getCore().application}
+                                    >
+                                      <EuiLink
+                                        href={getCore().application.getUrlForApp(
+                                          itHygiene.id,
+                                          {
+                                            path: `#/agents?tab=welcome&agent=${this.state.agentMostActive?.id}`,
+                                          },
+                                        )}
+                                      >
+                                        {this.state.agentMostActive?.name}
+                                      </EuiLink>
+                                    </RedirectAppLinks>
+                                  </EuiToolTip>
+                                ) : (
+                                  <EuiText>-</EuiText>
+                                )
                               }
                               titleSize='s'
                               description='Most active agent'


### PR DESCRIPTION
### Description
Fix the links of the last registered agent and the most active agent.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/94

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/82c64ca5-2b36-4346-b69d-d442f2c7556b)

### Test

1. Navigate to `summary endpoints`
2. Test the links of the last registered agent and the most active agent, if you don't have agents in those fields it should not be a link. (the application to which you are redirected should be it hygiene) 

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
