### PR TITLE
Fix responsive view on vulnerability dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added the ability to check if there are available updates from the UI. [#6093](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6093)
 - Added remember server address check [#5791](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5791)
 - Added the ssl_agent_ca configuration to the SSL Settings form [#6083](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6083)
-- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896) [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179) [#6173](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6173) [#6147](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6147) [#6231](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6231)
+- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896) [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179) [#6173](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6173) [#6147](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6147) [#6231](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6231) [#6246](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6246)
 - Added an agent selector to the IT Hygiene application [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Added query results limit when the search exceed 10000 hits [#6106](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6106)
 - Added a redirection button to Endpoint Summary from IT Hygiene application [6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -72,7 +72,7 @@ const DashboardVulsComponent: React.FC = () => {
           isSuccess &&
           resultIndexData &&
           resultIndexData?.hits?.total !== 0 ? (
-            <>
+            <div className='vulnerability-dashboard-responsive'>
               <div className='vulnerability-dashboard-filters-wrapper'>
                 <DashboardByRenderer
                   input={{
@@ -144,7 +144,7 @@ const DashboardVulsComponent: React.FC = () => {
                   hidePanelTitles: false,
                 }}
               />
-            </>
+            </div>
           ) : null}
         </>
       </I18nProvider>

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
@@ -1,6 +1,14 @@
 .vulnerability-dashboard-filters-wrapper {
-  .euiDataGrid__controls,.euiDataGrid__pagination {
-    display: none!important;
+  .euiDataGrid__controls,
+  .euiDataGrid__pagination {
+    display: none !important;
   }
 }
 
+.vulnerability-dashboard-responsive {
+  @media (max-width: 767px) {
+    .react-grid-layout {
+      height: auto !important;
+    }
+  }
+}


### PR DESCRIPTION
### Description
Starting at breakpoint 767px, there is an overlap of the vulnerability dashboard panels.
The solution found to avoid overlapping panels is to add styles starting from the breakpoint where the overlap occurred (767px).
 
### Issues Resolved
- #6245 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/4d3c546f-bfcc-487d-9356-d25bfa00e30d)

### Test
Before remember to create the mapping of port `9200:9200` in `osd1` in the `dev.yml`

- Create the index (wazuh-states-vulnerabilities) in the manager and insert data and mapping (using [comment](https://github.com/wazuh/wazuh-dashboard-plugins/issues/5763#issuecomment-1779564103)). 
- Navigate to `Threat Hunting` -> `Vulnerability Detection` and Reduce window to less than 768px.
- The panels must be arranged one below the order..

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
