### PR TITLE
Script for installing agents on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed exception in Inventory when agents don't have OS information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
+- Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
 
 ### Removed
 

--- a/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
+++ b/plugins/main/public/controllers/register-agent/components/command-output/command-output.tsx
@@ -84,14 +84,18 @@ export default function CommandOutput(props: ICommandSectionProps) {
             </EuiCopy>
           )}
         </div>
-        <EuiSpacer size='s' />
         {showCommand && havePassword ? (
-          <EuiSwitch
-            checked={showPassword}
-            label='Show password'
-            onChange={onChangeShowPassword}
-          />
-        ) : null}
+          <>
+            <EuiSwitch
+              checked={showPassword}
+              label='Show password'
+              onChange={onChangeShowPassword}
+            />
+            <EuiSpacer size='l' />
+          </>
+        ) : (
+          <EuiSpacer size='s' />
+        )}
       </EuiText>
     </Fragment>
   );

--- a/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.test.ts
@@ -1,0 +1,227 @@
+import {
+  getAllOptionals,
+  getAllOptionalsMacos,
+  getDEBAMD64InstallCommand,
+  getDEBARM64InstallCommand,
+  getLinuxStartCommand,
+  getMacOsInstallCommand,
+  getMacosStartCommand,
+  getRPMAMD64InstallCommand,
+  getRPMARM64InstallCommand,
+  getWindowsInstallCommand,
+  getWindowsStartCommand,
+  transformOptionalsParamatersMacOSCommand,
+} from './register-agent-os-commands-services';
+
+let test: any;
+
+beforeEach(() => {
+  test = {
+    optionals: {
+      agentGroups: "WAZUH_AGENT_GROUP='default'",
+      agentName: "WAZUH_AGENT_NAME='test'",
+      serverAddress: "WAZUH_MANAGER='1.1.1.1'",
+      wazuhPassword: "WAZUH_REGISTRATION_PASSWORD='<CUSTOM_PASSWORD>'",
+    },
+    urlPackage: 'https://test.com/agent.deb',
+    wazuhVersion: '4.8.0',
+  };
+});
+
+describe('getAllOptionals', () => {
+  it('should return empty string if optionals is falsy', () => {
+    const result = getAllOptionals(null);
+    expect(result).toBe('');
+  });
+
+  it('should return the correct paramsText', () => {
+    const optionals = {
+      serverAddress: 'localhost',
+      wazuhPassword: 'password',
+      agentGroups: 'group1',
+      agentName: 'agent1',
+      protocol: 'http',
+    };
+    const result = getAllOptionals(optionals, 'linux');
+    expect(result).toBe('localhost password group1 agent1 http ');
+  });
+});
+
+describe('getDEBAMD64InstallCommand', () => {
+  it('should return the correct install command', () => {
+    const props = {
+      optionals: {
+        serverAddress: 'localhost',
+        wazuhPassword: 'password',
+        agentGroups: 'group1',
+        agentName: 'agent1',
+        protocol: 'http',
+      },
+      urlPackage: 'https://example.com/package.deb',
+      wazuhVersion: '4.0.0',
+    };
+    const result = getDEBAMD64InstallCommand(props);
+    expect(result).toBe(
+      'wget https://example.com/package.deb && sudo localhost password group1 agent1 http dpkg -i ./wazuh-agent_4.0.0-1_amd64.deb',
+    );
+  });
+});
+
+describe('getDEBAMD64InstallCommand', () => {
+  it('should return the correct command', () => {
+    let expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} dpkg -i ./wazuh-agent_${test.wazuhVersion}-1_amd64.deb`;
+    const withAllOptionals = getDEBAMD64InstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+
+    expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.agentGroups} dpkg -i ./wazuh-agent_${test.wazuhVersion}-1_amd64.deb`;
+    const withServerAddresAndAgentGroupsOptions =
+      getDEBAMD64InstallCommand(test);
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getDEBARM64InstallCommand', () => {
+  it('should return the correct command', () => {
+    let expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} dpkg -i ./wazuh-agent_${test.wazuhVersion}-1_arm64.deb`;
+    const withAllOptionals = getDEBARM64InstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+
+    expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.agentGroups} dpkg -i ./wazuh-agent_${test.wazuhVersion}-1_arm64.deb`;
+    const withServerAddresAndAgentGroupsOptions =
+      getDEBARM64InstallCommand(test);
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getRPMAMD64InstallCommand', () => {
+  it('should return the correct command', () => {
+    let expected = `curl -o wazuh-agent-4.8.0-1.x86_64.rpm ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} rpm -ihv wazuh-agent-${test.wazuhVersion}-1.x86_64.rpm`;
+    const withAllOptionals = getRPMAMD64InstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+
+    expected = `curl -o wazuh-agent-4.8.0-1.x86_64.rpm ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.agentGroups} rpm -ihv wazuh-agent-${test.wazuhVersion}-1.x86_64.rpm`;
+    const withServerAddresAndAgentGroupsOptions =
+      getRPMAMD64InstallCommand(test);
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getRPMARM64InstallCommand', () => {
+  it('should return the correct command', () => {
+    let expected = `curl -o wazuh-agent-4.8.0-1.aarch64.rpm ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} rpm -ihv wazuh-agent-${test.wazuhVersion}-1.aarch64.rpm`;
+    const withAllOptionals = getRPMARM64InstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+
+    expected = `curl -o wazuh-agent-4.8.0-1.aarch64.rpm ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.agentGroups} rpm -ihv wazuh-agent-${test.wazuhVersion}-1.aarch64.rpm`;
+    const withServerAddresAndAgentGroupsOptions =
+      getRPMARM64InstallCommand(test);
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getLinuxStartCommand', () => {
+  it('returns the correct start command for Linux', () => {
+    const startCommand = getLinuxStartCommand({});
+    const expectedCommand =
+      'sudo systemctl daemon-reload\nsudo systemctl enable wazuh-agent\nsudo systemctl start wazuh-agent';
+
+    expect(startCommand).toEqual(expectedCommand);
+  });
+});
+
+// Windows
+
+describe('getWindowsInstallCommand', () => {
+  it('should return the correct install command', () => {
+    let expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \${env.tmp}\\wazuh-agent; msiexec.exe /i \${env.tmp}\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} `;
+
+    const withAllOptionals = getWindowsInstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+
+    expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \${env.tmp}\\wazuh-agent; msiexec.exe /i \${env.tmp}\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.agentGroups} `;
+    const withServerAddresAndAgentGroupsOptions =
+      getWindowsInstallCommand(test);
+
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getWindowsStartCommand', () => {
+  it('should return the correct start command', () => {
+    const expectedCommand = 'NET START WazuhSvc';
+
+    const result = getWindowsStartCommand({});
+
+    expect(result).toEqual(expectedCommand);
+  });
+});
+
+// MacOS
+
+describe('getAllOptionalsMacos', () => {
+  it('should return empty string if optionals is falsy', () => {
+    const result = getAllOptionalsMacos(null);
+    expect(result).toBe('');
+  });
+
+  it('should return the correct paramsValueList', () => {
+    const optionals = {
+      serverAddress: 'localhost',
+      agentGroups: 'group1',
+      agentName: 'agent1',
+      protocol: 'http',
+      wazuhPassword: 'password',
+    };
+    const result = getAllOptionalsMacos(optionals);
+    expect(result).toBe('localhost && group1 && agent1 && http && password');
+  });
+});
+
+describe('transformOptionalsParamatersMacOSCommand', () => {
+  it('should transform the command correctly', () => {
+    const command =
+      "' serverAddress && agentGroups && agentName && protocol && wazuhPassword";
+    const result = transformOptionalsParamatersMacOSCommand(command);
+    expect(result).toBe(
+      "' && serverAddress && agentGroups && agentName && protocol && wazuhPassword",
+    );
+  });
+});
+
+describe('getMacOsInstallCommand', () => {
+  it('should return the correct macOS installation script', () => {
+    let expected = `curl -so wazuh-agent.pkg ${test.urlPackage} && echo "${test.optionals.serverAddress} && ${test.optionals.agentGroups} && ${test.optionals.agentName} && ${test.optionals.wazuhPassword}\\n\" > /tmp/wazuh_envs && sudo installer -pkg ./wazuh-agent.pkg -target /`;
+
+    const withAllOptionals = getMacOsInstallCommand(test);
+    expect(withAllOptionals).toEqual(expected);
+
+    delete test.optionals.wazuhPassword;
+    delete test.optionals.agentName;
+    expected = `curl -so wazuh-agent.pkg ${test.urlPackage} && echo "${test.optionals.serverAddress} && ${test.optionals.agentGroups}" > /tmp/wazuh_envs && sudo installer -pkg ./wazuh-agent.pkg -target /`;
+
+    const withServerAddresAndAgentGroupsOptions = getMacOsInstallCommand(test);
+    expect(withServerAddresAndAgentGroupsOptions).toEqual(expected);
+  });
+});
+
+describe('getMacosStartCommand', () => {
+  it('returns the correct start command for macOS', () => {
+    const startCommand = getMacosStartCommand({});
+    expect(startCommand).toEqual('sudo /Library/Ossec/bin/wazuh-control start');
+  });
+});

--- a/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
@@ -6,7 +6,7 @@ import {
 } from '../core/register-commands/types';
 import { tOperatingSystem } from '../hooks/use-register-agent-commands.test';
 
-const getAllOptionals = (
+export const getAllOptionals = (
   optionals: IOptionalParameters<tOptionalParameters>,
   osName?: tOperatingSystem['name'],
 ) => {
@@ -38,7 +38,7 @@ const getAllOptionals = (
   return paramsText;
 };
 
-const getAllOptionalsMacos = (
+export const getAllOptionalsMacos = (
   optionals: IOptionalParameters<tOptionalParameters>,
 ) => {
   // create paramNameOrderList, which is an array of the keys of optionals add interface

--- a/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
@@ -43,7 +43,7 @@ const getAllOptionalsMacos = (
 ) => {
   // create paramNameOrderList, which is an array of the keys of optionals add interface
   const paramNameOrderList: (keyof IOptionalParameters<tOptionalParameters>)[] =
-    ['serverAddress', 'agentGroups', 'agentName', 'protocol'];
+    ['serverAddress', 'agentGroups', 'agentName', 'protocol', 'wazuhPassword'];
 
   if (!optionals) return '';
 
@@ -145,29 +145,33 @@ export const getMacOsInstallCommand = (
   props: tOSEntryInstallCommand<tOptionalParameters>,
 ) => {
   const { optionals, urlPackage } = props;
-  // Set macOS installation script with environment variables
-  const optionalsText = optionals && getAllOptionalsMacos(optionals);
-  const macOSInstallationOptions = transformOptionalsParamatersMacOSCommand(
-    optionalsText || '',
-  );
-  let wazuhPasswordParamWithValue = '';
-  if (optionals?.wazuhPassword) {
+
+  let optionalsForCommand = { ...optionals };
+  if (optionalsForCommand?.wazuhPassword) {
     /**
      * We use the JSON.stringify to prevent that the scaped specials characters will be removed
      * and mantain the format of the password
       The JSON.stringify mantain the password format but adds " to wrap the characters
     */
     const scapedPasswordLength = JSON.stringify(
-      optionals?.wazuhPassword,
+      optionalsForCommand?.wazuhPassword,
     ).length;
     // We need to remove the " added by JSON.stringify
-    wazuhPasswordParamWithValue = `${JSON.stringify(
-      optionals?.wazuhPassword,
+    optionalsForCommand.wazuhPassword = `${JSON.stringify(
+      optionalsForCommand?.wazuhPassword,
     ).substring(1, scapedPasswordLength - 1)}\\n`;
   }
+
+  // Set macOS installation script with environment variables
+  const optionalsText =
+    optionalsForCommand && getAllOptionalsMacos(optionalsForCommand);
+  const macOSInstallationOptions = transformOptionalsParamatersMacOSCommand(
+    optionalsText || '',
+  );
+
   // If no variables are set, the echo will be empty
   const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions
-    ? `echo "${macOSInstallationOptions}${wazuhPasswordParamWithValue}" > /tmp/wazuh_envs && `
+    ? `echo "${macOSInstallationOptions}" > /tmp/wazuh_envs && `
     : ``;
 
   // Merge environment variables with installation script


### PR DESCRIPTION
### Description
when using the password to install agents in macos, the installation script was generated incorrectly without space or &&
 
### Issues Resolved
- #6294

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/5a33410a-0ab8-4891-9b52-eaf0c8a4486c)

### Test

You need a real manage

1. Set the [password for deploy agent](https://documentation.wazuh.com/current/user-manual/agent-enrollment/security-options/using-password-authentication.html#using-password-authentication)
2. See that the macOS install command is rendered correctly

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
