### PR TITLE
Fix deploy new agent filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
 - Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
-- Fixed a problem with the address validation on Deploy New Agent[#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
+- Fixed a problem with the address validation on Deploy New Agent [#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed exception in Inventory when agents don't have OS information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
-- Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)- Fixed a problem with the address validation on Deploy New Agent[#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
+- Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
+- Fixed a problem with the address validation on Deploy New Agent[#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed exception in Inventory when agents don't have OS information [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed pinned agent state in URL [#6177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6177)
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
-- Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
+- Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)- Fixed a problem with the address validation on Deploy New Agent[#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 
 ### Removed
 

--- a/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.test.tsx
@@ -12,24 +12,40 @@ describe('Validations', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined for a valid IP', () => {
+  it('should return undefined for a valid IPv4', () => {
     const validIP = '192.168.1.1';
     const result = validateServerAddress(validIP);
     expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for a valid IPv6', () => {
+    const validIP = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+    const result = validateServerAddress(validIP);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an error message for an invalid IPv6', () => {
+    const invalidIPV6 = '2001:db8:85a3::8a2e:370:7334';
+    const result = validateServerAddress(invalidIPV6);
+    expect(result).toBe(
+      'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6',
+    );
+  });
+
+  it('should return an error message for a compressed IPv6', () => {
+    const compressedIPV6 = '2001:0db8:85a3:0000:0000:8a2e:0370:7334:KL12';
+    const result = validateServerAddress(compressedIPV6);
+    expect(result).toBe(
+      'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6',
+    );
   });
 
   it('should return an error message for an invalid FQDN', () => {
     const invalidFQDN = 'example.';
     const result = validateServerAddress(invalidFQDN);
     expect(result).toBe(
-      'Each label must have a letter or number at the beginning. The maximum length is 63 characters.',
+      'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6',
     );
-  });
-
-  test('should return an error message for an invalid IP', () => {
-    const invalidIP = '999.999.999.999.999';
-    const result = validateServerAddress(invalidIP);
-    expect(result).toBe('Not a valid IP');
   });
 
   test('should return undefined for an empty value', () => {

--- a/plugins/main/public/controllers/register-agent/utils/validations.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/validations.tsx
@@ -1,41 +1,27 @@
-//IP: This is a set of four numbers, for example, 192.158.1.38. Each number in the set can range from 0 to 255. Therefore, the full range of IP addresses goes from 0.0.0.0 to 255.255.255.255
-// O ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+//IPv4: This is a set of four numbers, for example, 192.158.1.38. Each number in the set can range from 0 to 255. Therefore, the full range of IP addresses goes from 0.0.0.0 to 255.255.255.255
+//IPv6: This is a set or eight hexadecimal expressions, each from 0000 to FFFF. 2001:0db8:85a3:0000:0000:8a2e:0370:7334
 
 // FQDN: Maximum of 63 characters per label.
 // Can only contain numbers, letters and hyphens (-)
 // Labels cannot begin or end with a hyphen
 // Currently supports multilingual characters, i.e. letters not included in the English alphabet: e.g. á é í ó ú ü ñ.
 // Minimum 3 labels
-export const validateServerAddress = (value: any) => {
-  const isFQDN =
-    /^(?!-)(?!.*--)(?!.*\d$)[a-zA-Z0-9áéíóúüñ]{1,63}(?:-[a-zA-Z0-9áéíóúüñ]{1,63})*(?:\.[a-zA-Z0-9áéíóúüñ]{1,63}(?:-[a-zA-Z0-9áéíóúüñ]{1,63})*){1,}$/;
-  const isIP =
-    /^(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}|(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4})$/;
-  const numbersAndPoints = /^[0-9.]+$/;
-  const areLettersNumbersAndColons = /^[a-zA-Z0-9:]+$/;
-  const letters = /[a-zA-Z]/;
-  const isFQDNFormatValid = isFQDN.test(value);
-  const isIPFormatValid = isIP.test(value);
-  const areNumbersAndPoints = numbersAndPoints.test(value);
-  const hasLetters = letters.test(value);
-  const hasPoints = value.includes('.');
+// A label can contain only numbers
 
-  let validation = undefined;
-  if (value.length === 0) {
-    return validation;
-  } else if (isFQDNFormatValid && value !== '') {
-    return validation; // FQDN valid
-  } else if (isIPFormatValid && value !== '') {
-    return validation; // IP valid
-  } else if (hasPoints && hasLetters && !isFQDNFormatValid) {
-    return (validation =
-      'Each label must have a letter or number at the beginning. The maximum length is 63 characters.'); // FQDN invalid
-  } else if (
-    (areNumbersAndPoints || areLettersNumbersAndColons) &&
-    !isIPFormatValid
+// Hostname: Maximum of 63 characters per label. Same rules as FQDN apply.
+
+export const validateServerAddress = (value: string) => {
+  const isFQDNOrHostname =
+    /^(?!-)(?!.*--)[a-zA-Z0-9áéíóúüñ-]{0,62}[a-zA-Z0-9áéíóúüñ](?:\.[a-zA-Z0-9áéíóúüñ-]{0,62}[a-zA-Z0-9áéíóúüñ]){0,}$/;
+  const isIPv6 = /^(?:[0-9a-fA-F]{4}:){7}[0-9a-fA-F]{4}$/;
+
+  if (
+    value.length > 255 ||
+    (value.length > 0 && !isFQDNOrHostname.test(value) && !isIPv6.test(value))
   ) {
-    return (validation = 'Not a valid IP'); // IP invalid
+    return 'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6';
   }
+  return undefined;
 };
 
 export const validateAgentName = (value: any) => {


### PR DESCRIPTION
### Description
This PR aims to fix an error on which the `Deploy New Agent` section did not allow to specify a hostname as server address
 
### Issues Resolved
#6311

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/42900763/02c7fd01-e98e-4362-a678-9bc2194e4c42)


### Test
- Deploy a new environment
- Navigate to Endpoints Summary/Deploy new agent
- Verify that it allows all the possible options for Server Address, and shows errors on any non valid address. 

The allowed options are: 
  - Hostname from 1 to 63 alphanumeric characters
  - Domains up to 255 characters (up to 63 per label)
  - IPv4 
  - Uncompressed IPv6
  
  
  **Note**: A non valid IPv4 (i.e. 280.240.1.300) should be considered valid, as it matches the rules to be a domain (alphanumeric labels with 1-63 characters)
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
