### PR TITLE
Fix maximize in embeddable vulnerability panel

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
@@ -10,5 +10,8 @@
     .react-grid-layout {
       height: auto !important;
     }
+    .dshLayout-isMaximizedPanel {
+      height: 100% !important;
+    }
   }
 }

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/vulnerability_detector_filters.scss
@@ -3,6 +3,9 @@
   .euiDataGrid__pagination {
     display: none !important;
   }
+  .visTable {
+    overflow: hidden !important;
+  }
 }
 
 .vulnerability-dashboard-responsive {

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -306,7 +306,7 @@
 
 /* Custom input filter box styles */
 
-input[type="search"].euiFieldSearch {
+input[type='search'].euiFieldSearch {
   box-sizing: inherit !important;
 }
 
@@ -365,7 +365,9 @@ input[type="search"].euiFieldSearch {
   box-shadow: none;
 }
 
-:focus:not(.wz-button):not(.input-filter-box):not(.kuiLocalSearchInput):not(.euiTextArea):not(.euiPanel.euiPopover__panel.euiPopover__panel-isOpen) {
+:focus:not(.wz-button):not(.input-filter-box):not(.kuiLocalSearchInput):not(
+    .euiTextArea
+  ):not(.euiPanel.euiPopover__panel.euiPopover__panel-isOpen) {
   box-shadow: none !important;
 }
 
@@ -443,7 +445,7 @@ md-content {
   color: black !important;
 }
 
-.table-hover>tbody>tr:hover {
+.table-hover > tbody > tr:hover {
   background-color: #fafbfd !important;
 }
 
@@ -777,7 +779,7 @@ md-switch.md-checked .md-thumb {
   min-height: 300px;
 }
 
-.nav-bar-white-bg>div {
+.nav-bar-white-bg > div {
   background: #fff;
 }
 
@@ -803,7 +805,7 @@ md-switch.md-checked .md-thumb {
  * https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
  * Handling long URLs on error toasts.
  */
-.euiGlobalToastList>.euiToast>.euiToastHeader>.euiToastHeader__title {
+.euiGlobalToastList > .euiToast > .euiToastHeader > .euiToastHeader__title {
   overflow-wrap: break-word;
   word-wrap: break-word;
   -ms-word-break: break-all;
@@ -866,34 +868,34 @@ wz-xml-file-editor {
   background: #ecf6fb !important;
 }
 
-.table-striped>tbody>tr:nth-of-type(odd) {
+.table-striped > tbody > tr:nth-of-type(odd) {
   background-color: transparent !important;
 }
 
-.table-striped>tbody>tr:nth-of-type(odd):hover {
+.table-striped > tbody > tr:nth-of-type(odd):hover {
   background-color: #fafbfd !important;
 }
 
-.table-striped-duo>tbody tr:not(.euiTableRow):nth-child(2n + 1):not(:hover),
-.table-striped-duo>tbody tr:not(.euiTableRow):nth-child(2n + 2):not(:hover) {
+.table-striped-duo > tbody tr:not(.euiTableRow):nth-child(2n + 1):not(:hover),
+.table-striped-duo > tbody tr:not(.euiTableRow):nth-child(2n + 2):not(:hover) {
   background: #f9f9f9;
 }
 
-.table-striped-duo>tbody tr:not(.euiTableRow):nth-child(4n + 1):not(:hover),
-.table-striped-duo>tbody tr:not(.euiTableRow):nth-child(4n + 2):not(:hover) {
+.table-striped-duo > tbody tr:not(.euiTableRow):nth-child(4n + 1):not(:hover),
+.table-striped-duo > tbody tr:not(.euiTableRow):nth-child(4n + 2):not(:hover) {
   background: #fff;
 }
 
-.table-resizable>thead th:not(:first-child) {
+.table-resizable > thead th:not(:first-child) {
   border-left: 1px dashed #dfeff8;
   overflow: hidden;
 }
 
-.table-resizable>thead th:last-child .ui-resizable-handle {
+.table-resizable > thead th:last-child .ui-resizable-handle {
   display: none !important;
 }
 
-.table-resizable td+td {
+.table-resizable td + td {
   width: auto;
 }
 
@@ -944,7 +946,7 @@ wz-xml-file-editor {
   display: block !important;
 }
 
-.sca-vis .visWrapper .visWrapper__chart>div>svg>g>text:nth-child(2) {
+.sca-vis .visWrapper .visWrapper__chart > div > svg > g > text:nth-child(2) {
   font-size: 10px !important;
 }
 
@@ -1033,7 +1035,7 @@ wz-xml-file-editor {
   white-space: nowrap;
 }
 
-.health-check dl.euiDescriptionList dd>span:first-child {
+.health-check dl.euiDescriptionList dd > span:first-child {
   display: inline-block;
   width: 26px;
 }
@@ -1111,7 +1113,7 @@ wz-xml-file-editor {
 
 .wz-link {
   cursor: pointer;
-  color: #006BB4;
+  color: #006bb4;
   text-decoration: none;
 }
 
@@ -1168,7 +1170,7 @@ wz-xml-file-editor {
   margin: 0px;
 }
 
-.header-global-wrapper+.app-wrapper:not(.hidden-chrome) {
+.header-global-wrapper + .app-wrapper:not(.hidden-chrome) {
   top: 48px !important;
   left: 48px !important;
 }
@@ -1180,7 +1182,8 @@ wz-xml-file-editor {
 .reqCard:hover,
 .reqCard:focus {
   transform: translateY(0px) !important;
-  box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3), 0 1px 5px -2px rgba(152, 162, 179, 0.3) !important;
+  box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3),
+    0 1px 5px -2px rgba(152, 162, 179, 0.3) !important;
 }
 
 .reqCard:hover .euiCard__title,
@@ -1240,7 +1243,6 @@ wz-xml-file-editor {
   background: white !important;
   color: #377dbb !important;
 }
-
 
 .list-of-files-fail {
   margin-top: 10px;
@@ -1312,8 +1314,8 @@ md-chips .md-chips {
 .title-pin:hover:after {
   padding-left: 5px;
   font-size: 12px;
-  content: "\f00e";
-  font-family: "FontAwesome";
+  content: '\f00e';
+  font-family: 'FontAwesome';
   color: #0b6bb4;
   position: absolute;
 }
@@ -1323,15 +1325,15 @@ md-chips .md-chips {
 //   margin-top: 50px;
 // }
 
-.wz-markdown-margin>p {
+.wz-markdown-margin > p {
   margin-top: 5px;
 }
 
-.wz-markdown-margin>ul {
+.wz-markdown-margin > ul {
   list-style: disc;
 }
 
-.wz-markdown-margin>ul>li {
+.wz-markdown-margin > ul > li {
   margin-left: 25px;
 }
 
@@ -1369,7 +1371,7 @@ md-chips .md-chips {
   border: solid 1px #d9d9d9;
 }
 
-.react-code-mirror>.CodeMirror.CodeMirror-wrap.cm-s-default {
+.react-code-mirror > .CodeMirror.CodeMirror-wrap.cm-s-default {
   height: 100% !important;
 }
 
@@ -1441,7 +1443,6 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   padding-right: 0;
 }
 
-
 .euiSuggestItem .euiSuggestItem__label {
   flex-basis: 25%;
   min-width: 25%;
@@ -1468,7 +1469,7 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
 }
 
 .euiCodeBlock.euiCodeBlock-isFullScreen {
-  border: 1px solid #D3DAE6;
+  border: 1px solid #d3dae6;
   border-radius: 4px;
   margin: 22px;
 }
@@ -1488,7 +1489,7 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   margin-left: 24px;
   width: 100%;
   height: 2px;
-  background-color: #006BB4;
+  background-color: #006bb4;
   -webkit-animation: euiBasicTableLoading 1000ms linear;
   animation: euiBasicTableLoading 1000ms linear;
   -webkit-animation-iteration-count: infinite;
@@ -1523,7 +1524,12 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
 }
 
 /* Change custom discover size */
-.wz-discover>.globalQueryBar>.kbnQueryBar--withDatePicker>.euiFlexItem.euiFlexItem--flexGrowZero>.euiFlexGroup>.euiFlexItem.kbnQueryBar__datePickerWrapper {
+.wz-discover
+  > .globalQueryBar
+  > .kbnQueryBar--withDatePicker
+  > .euiFlexItem.euiFlexItem--flexGrowZero
+  > .euiFlexGroup
+  > .euiFlexItem.kbnQueryBar__datePickerWrapper {
   max-width: 300px;
 }
 
@@ -1533,13 +1539,18 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   }
 
   /* Change custom discover size */
-  .wz-discover>.globalQueryBar>.euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker {
+  .wz-discover
+    > .globalQueryBar
+    > .euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker {
     flex-wrap: wrap;
     margin-left: 0;
     margin-right: 0;
   }
 
-  .wz-discover>.globalQueryBar>.euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker>.euiFlexItem {
+  .wz-discover
+    > .globalQueryBar
+    > .euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker
+    > .euiFlexItem {
     width: 100% !important;
     -ms-flex-preferred-size: 100% !important;
     flex-basis: 100% !important;
@@ -1548,16 +1559,27 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
     margin-bottom: 16px !important;
   }
 
-  .wz-discover>.globalQueryBar>.kbnQueryBar--withDatePicker> :first-child {
+  .wz-discover > .globalQueryBar > .kbnQueryBar--withDatePicker > :first-child {
     order: 1;
     margin-top: -8px;
   }
 
-  .wz-discover>.globalQueryBar>.kbnQueryBar--withDatePicker>.euiFlexItem.euiFlexItem--flexGrowZero>.euiFlexGroup>.euiFlexItem.kbnQueryBar__datePickerWrapper>.euiFlexGroup {
+  .wz-discover
+    > .globalQueryBar
+    > .kbnQueryBar--withDatePicker
+    > .euiFlexItem.euiFlexItem--flexGrowZero
+    > .euiFlexGroup
+    > .euiFlexItem.kbnQueryBar__datePickerWrapper
+    > .euiFlexGroup {
     width: 100%;
   }
 
-  .wz-discover>.globalQueryBar>.kbnQueryBar--withDatePicker>.euiFlexItem.euiFlexItem--flexGrowZero>.euiFlexGroup>.euiFlexItem.kbnQueryBar__datePickerWrapper {
+  .wz-discover
+    > .globalQueryBar
+    > .kbnQueryBar--withDatePicker
+    > .euiFlexItem.euiFlexItem--flexGrowZero
+    > .euiFlexGroup
+    > .euiFlexItem.kbnQueryBar__datePickerWrapper {
     flex-grow: 1 !important;
     max-width: none;
   }
@@ -1587,7 +1609,6 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   .agents-details-card {
     width: 55vw;
   }
-
 }
 
 @media (max-width: 1599px) {
@@ -1624,7 +1645,7 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   }
 }
 
-.chrHeaderWrapper--navIsLocked~.app-wrapper .wz-module-header-agent-wrapper {
+.chrHeaderWrapper--navIsLocked ~ .app-wrapper .wz-module-header-agent-wrapper {
   padding-left: 320px;
 }
 
@@ -1641,7 +1662,6 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
 .no-focus:focus {
   background-color: transparent !important;
 }
-
 
 .ace_scrollbar-v {
   margin-top: -10px !important;
@@ -1660,7 +1680,6 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   height: 24px;
   text-decoration: none !important;
 }
-
 
 .history-list {
   background-color: white;
@@ -1720,7 +1739,7 @@ iframe.width-changed {
 }
 
 .code-block-log-viewer-container {
-  max-width: calc(100vw - 41*2px);
+  max-width: calc(100vw - 41 * 2px);
 }
 
 .dscFieldDetails__barContainer {
@@ -1768,7 +1787,6 @@ iframe.width-changed {
 }
 
 .wz-euiCard-no-title {
-
   .euiCard__title,
   .euiCard__description {
     display: none;
@@ -1793,7 +1811,7 @@ iframe.width-changed {
 }
 
 @media only screen and (max-width: 767px) {
-  .header-global-wrapper+.app-wrapper:not(.hidden-chrome) {
+  .header-global-wrapper + .app-wrapper:not(.hidden-chrome) {
     left: 0 !important;
   }
 
@@ -1817,19 +1835,26 @@ iframe.width-changed {
 }
 
 .wz-flex {
-    display: flex;
+  display: flex;
 }
 
 .wz-callout-message {
-    margin-top: 10px;
-    display: flex;
-    flex-direction: row;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: row;
 }
 
-.wz-overflow-auto{
+.wz-overflow-auto {
   overflow: auto;
 }
 
 .wz-vertical-align-middle {
   vertical-align: middle !important;
+}
+
+/* Workaround to fix maximize embeddable dashboard */
+.wz-app .dshLayout-isMaximizedPanel {
+  top: 0;
+  left: 0;
+  z-index: 9999;
 }


### PR DESCRIPTION
## Description
This pull request fix maximize in embeddable dashboards panels.
`dshLayout-isMaximizedPanel` is a specific class that adds OSD to the ResponsiveGrid component when a panel is expanded.
Since this fix is needed in more than one embedded dashboard, it was decided to apply the CSS at the highest possible level but within the context of Wazuh.
 
## Issues Resolved
- #6322 

## Evidence
[Evidence.webm](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/ac1d3ce0-e223-462c-9456-a30d3396b92d)

## Test
> [!NOTE]
> This test requires data to be inserted into the vulnerability index via the dataInjectScript.py script located in scripts/vulnerabilities-events-injector

### Steps to test:
- Go to vulnerability module.
- Go to panel actions of a panel ("···" button)
- Select maximize panel.
- The panel occupy the entire space of the module.
- Check correct operation with the menu bar


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
