### PR TITLE
Fix abbreviation for Fully Qualified Domain Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed invalid date format in about and agent views [#6234](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6234)
 - Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
 - Fixed a problem with the address validation on Deploy New Agent [#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
+- Fixed a typo in an abbreviation for Fully Qualified Domain Name [#6333](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6333)
 
 ### Removed
 

--- a/plugins/main/public/controllers/register-agent/utils/register-agent-data.tsx
+++ b/plugins/main/public/controllers/register-agent/utils/register-agent-data.tsx
@@ -34,7 +34,7 @@ export const SERVER_ADDRESS_TEXTS = [
   {
     title: 'Server address',
     subtitle:
-      'This is the address the agent uses to communicate with the server. Enter an IP address or a fully qualified domain name (FDQN).',
+      'This is the address the agent uses to communicate with the server. Enter an IP address or a fully qualified domain name (FQDN).',
   },
 ];
 


### PR DESCRIPTION
### Description

In the instructions to perform an agent deployment, the nomenclature FDQN has been changed to FQDN

### Issues Resolved

[Incorrect abbreviation for Fully Qualified Domain Name](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6310)

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/034d10dd-4d98-4502-9a0c-30ca0059b2e8)

# Tests

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| In the instructions to perform an agent deployment, the nomenclature should be FQDN | :black_circle: | :black_circle: | :black_circle: |

- In the instructions to perform an agent deployment, the nomenclature should be FQDN

<details>


</details>


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
