### PR TITLE
Hide discover deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the ability to configure the visibility of modules and removed `extensions.*` settings [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Removed the application menu in the IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
 - Removed the implicit filter of WQL language of the search bar UI [#6174](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6174)
+- Removed notice of Discover deprecation [#6341](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6341)
 
 ## Wazuh v4.7.2 - OpenSearch Dashboards 2.8.0 - Revision 02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the ability to configure the visibility of modules and removed `extensions.*` settings [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Removed the application menu in the IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
 - Removed the implicit filter of WQL language of the search bar UI [#6174](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6174)
-- Removed notice of Discover deprecation [#6341](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6341)
+- Removed notice of old Discover deprecation [#6341](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6341)
 
 ## Wazuh v4.7.2 - OpenSearch Dashboards 2.8.0 - Revision 02
 

--- a/plugins/main/public/plugin.ts
+++ b/plugins/main/public/plugin.ts
@@ -57,6 +57,10 @@ export class WazuhPlugin
   private innerAngularInitialized: boolean = false;
   private hideTelemetryBanner?: () => void;
   public async setup(core: CoreSetup, plugins: WazuhSetupPlugins): WazuhSetup {
+    // Hide the discover deprecation notice
+    // After opensearch version 2.11.0 this line may be deleted
+    localStorage.setItem('discover:deprecation-notice:show', 'false');
+
     // Get custom logos configuration to start up the app with the correct logos
     let logosInitialState = {};
     try {


### PR DESCRIPTION
### Description
The Discover deprecation warning is hidden.
 
### Issues Resolved
- #6314 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/374232cb-5586-40ea-b08e-ac0444f48fbf)


### Test
1. Navigate to the Discover plugin
2. The Discover deprecation warning should not appear.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
