### PR TITLE
Fix server stat Archives queue usage is picking the wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
 - Fixed a problem with the address validation on Deploy New Agent [#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 - Fixed a typo in an abbreviation for Fully Qualified Domain Name [#6333](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6333)
+- Fixed wrong value at server stat Archives queue usage [#6342](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6342)
 
 ### Removed
 

--- a/plugins/main/server/integration-files/visualizations/cluster/statistics.ts
+++ b/plugins/main/server/integration-files/visualizations/cluster/statistics.ts
@@ -2537,7 +2537,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.event_queue_size',
+              field: 'analysisd.event_queue_usage',
               customLabel: 'Event queue usage',
             },
             schema: 'metric',
@@ -2547,7 +2547,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.rule_matching_queue_size',
+              field: 'analysisd.rule_matching_queue_usage',
               customLabel: 'Rule matching queue usage',
             },
             schema: 'metric',
@@ -2557,7 +2557,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.alerts_queue_size',
+              field: 'analysisd.alerts_queue_usage',
               customLabel: 'Alerts log queue usage',
             },
             schema: 'metric',
@@ -2567,7 +2567,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.firewall_queue_size',
+              field: 'analysisd.firewall_queue_usage',
               customLabel: 'Firewall log queue usage',
             },
             schema: 'metric',
@@ -2577,7 +2577,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.statistical_queue_size',
+              field: 'analysisd.statistical_queue_usage',
               customLabel: 'Statistical log queue usage',
             },
             schema: 'metric',
@@ -2587,7 +2587,7 @@ export default [
             enabled: true,
             type: 'avg',
             params: {
-              field: 'analysisd.archives_queue_size',
+              field: 'analysisd.archives_queue_usage',
               customLabel: 'Archives queue usage',
             },
             schema: 'metric',


### PR DESCRIPTION
### Description
This PR fixes the `Queue Usage` stat. It was picking the max value instead of the current value in the visualization on the stats page.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6340

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/8500db0a-ba5a-4bad-a1b6-73064de459cc)

### Test
1. Navigate to Server management -> Statistics -> Analysis Engine tab
2. Examine the Queue usage visualization

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
