### PR TITLE
Fix inventory data table full screen side menu dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
 - Fixed a problem with the address validation on Deploy New Agent [#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 - Fixed a typo in an abbreviation for Fully Qualified Domain Name [#6333](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6333)
+- Fixed the inventory data table when maximized and the docked menu [#6344](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6344)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { getPlugins } from '../../../../../kibana-services';
+import { getPlugins, getWazuhCorePlugin } from '../../../../../kibana-services';
 import useSearchBarConfiguration from '../../search_bar/use_search_bar_configuration';
 import { IntlProvider } from 'react-intl';
 import {
@@ -54,6 +54,8 @@ const InventoryVulsComponent = () => {
   );
   const [isSearching, setIsSearching] = useState<boolean>(false);
   const [isExporting, setIsExporting] = useState<boolean>(false);
+
+  const sideNavDocked = getWazuhCorePlugin().hooks.useDockedSideNav();
 
   const onClickInspectDoc = useMemo(
     () => (index: number) => {
@@ -197,6 +199,7 @@ const InventoryVulsComponent = () => {
           results?.hits?.total > 0 ? (
             <EuiDataGrid
               {...dataGridProps}
+              className={sideNavDocked ? 'dataGridDockedNav' : ''}
               toolbarVisibility={{
                 additionalControls: (
                   <>

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -1858,3 +1858,11 @@ iframe.width-changed {
   left: 0;
   z-index: 9999;
 }
+
+/* OSD Data grid full screen with dock navigation left sidebar */
+
+.dataGridDockedNav {
+  &.euiDataGrid--fullScreen {
+    left: 320px;
+  }
+}


### PR DESCRIPTION
### Description
In the Inventory tab of the Vulnerabilities module, when the table is maximized and the left main navigation menu is docked, the table is rendered by adjusting its width accordingly.
 
### Issues Resolved
- #6323

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/6d8cc7a7-65dd-469e-916b-59ee742be304

### Test

1. Dock the main left navigation menu
2. Navigate to Vulnerabilities / Inventory
3. Click on the maximize button of the table

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
