### PR TITLE
Fix unnecessary scroll in Vulnerability inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed script to install agents on macOS when you have password to deploy [#6305](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6305)
 - Fixed a problem with the address validation on Deploy New Agent [#6327](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6327)
 - Fixed a typo in an abbreviation for Fully Qualified Domain Name [#6333](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6333)
+- Fixed unnecessary scrolling in Vulnerability Inventory table [#6345](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6345)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
@@ -1,14 +1,17 @@
 .vulsInventoryContainer {
-    height: calc(100vh - 104px);
-}
+  height: calc(100vh - 104px);
 
+  .euiDataGrid__virtualized {
+    height: calc(100vh - 345px) !important;
+  }
 
-.headerIsExpanded .vulsInventoryContainer {
-    height: calc(100vh - 153px);
-}
-
-.vulsInventoryContainer .euiDataGrid--fullScreen {
+  .euiDataGrid--fullScreen {
     height: calc(100vh - 49px);
     bottom: 0;
     top: auto;
+  }
+}
+
+.headerIsExpanded .vulsInventoryContainer {
+  height: calc(100vh - 153px);
 }

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
@@ -1,6 +1,7 @@
 .vulsInventoryContainer {
   height: calc(100vh - 104px);
 
+  // This makes the table not generate an unnecessary scroll when filtering data from 1 page and then do another search for more pages.
   .euiDataGrid__virtualized {
     height: calc(100vh - 345px) !important;
   }


### PR DESCRIPTION
### Description
Fixes the unnecessary scrolling that occurs when you search for something that results in 1 page and then return to a multi-page result.
 
### Issues Resolved
#6324 

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/776cd9c6-8d09-4949-a100-3630f470fad2

### Test
1. Navigate to 'Vunerability/Inventory'
2. Filter table to have 1 page of results
3. Remove filter to have more than 1 page of results
4. Should not be able to scroll the page


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
