### PR TITLE
Remove WAZUH_REGISTRATION_SERVER from the windows command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the application menu in the IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
 - Removed the implicit filter of WQL language of the search bar UI [#6174](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6174)
 - Removed notice of old Discover deprecation [#6341](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6341)
+- Removed WAZUH_REGISTRATION_SERVER from Windows agent deployment command [#6361](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6361)
 
 ## Wazuh v4.7.2 - OpenSearch Dashboards 2.8.0 - Revision 02
 

--- a/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
@@ -25,16 +25,6 @@ export const getAllOptionals = (
     '',
   );
 
-  if (osName && osName.toLowerCase() === 'windows' && optionals.serverAddress) {
-    // when os is windows we must to add wazuh registration server with server address
-    paramsText =
-      paramsText +
-      `WAZUH_REGISTRATION_SERVER=${optionals.serverAddress.replace(
-        'WAZUH_MANAGER=',
-        '',
-      )} `;
-  }
-
   return paramsText;
 };
 


### PR DESCRIPTION
### Description
This PR removes `WAZUH_REGISTRATION_SERVER` from the windows agent installation command. This is because the address in this variable is the same as the `WAZUH_MANAGER` therefore it's redundant.
 
### Issues Resolved
#6348 

### Screenshot

<details>

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/51e02dce-1781-4fc4-a2c0-3fe4b4d6e1cf)


</details>

### Test

Verify the installation script for windows doesn't include WAZUH_REGISTRATION_SERVER:

Eg.
```
Invoke-WebRequest -Uri https://packages.wazuh.com/4.x/windows/wazuh-agent-4.8.0-1.msi -OutFile ${env.tmp}\wazuh-agent; msiexec.exe /i ${env.tmp}\wazuh-agent /q WAZUH_MANAGER='server.com' WAZUH_AGENT_GROUP='windows' WAZUH_AGENT_NAME='new-agent'
```

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
