### PR TITLE
Add tooltip to most active agent label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added an agent selector to the IT Hygiene application [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Added query results limit when the search exceed 10000 hits [#6106](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6106)
 - Added a redirection button to Endpoint Summary from IT Hygiene application [6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
+- Added information icon with tooltip on the most active agent in the endpoint summary view [#6364](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6364)
 
 ### Changed
 

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -344,7 +344,7 @@ export const AgentsPreview = compose(
                               )
                             }
                             titleSize='s'
-                            description='Last registered agent'
+                            description='Last enrolled agent'
                             titleColor='primary'
                           />
                         </EuiFlexItem>

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -25,6 +25,7 @@ import {
   EuiLink,
   EuiProgress,
   EuiText,
+  EuiIconTip,
 } from '@elastic/eui';
 import { AgentsTable } from './agents-table';
 import { WzRequest } from '../../../react-services/wz-request';
@@ -384,7 +385,16 @@ export const AgentsPreview = compose(
                                 )
                               }
                               titleSize='s'
-                              description='Most active agent'
+                              description={
+                                <>
+                                  Most active agent{' '}
+                                  <EuiIconTip
+                                    type='iInCircle'
+                                    color='primary'
+                                    content='Agent with more alerts in the last 24 hours'
+                                  />
+                                </>
+                              }
                               titleColor='primary'
                             />
                           </EuiFlexItem>


### PR DESCRIPTION
### Description

The label of the last registered agent is changed to the Last enrolled agent
 
An information icon with a tooltip is added to the most active agent

### Issues Resolved
- #6358

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/197e306a-b0fa-47df-afc1-6eaea210a280)


### Test

1. Navigate to Endpoint summary
2. Look at the label change 
3. Look at the icon and the tooltip


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
