### PR TITLE
Remove compilation date from dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the application menu in the IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
 - Removed the implicit filter of WQL language of the search bar UI [#6174](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6174)
 - Removed notice of old Discover deprecation [#6341](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6341)
+- Remove compilation date field from the app [#6366](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6366)
 
 ## Wazuh v4.7.2 - OpenSearch Dashboards 2.8.0 - Revision 02
 

--- a/plugins/main/public/controllers/management/components/management/status/status-node-info.js
+++ b/plugins/main/public/controllers/management/components/management/status/status-node-info.js
@@ -32,13 +32,19 @@ export class WzStatusNodeInfo extends Component {
 
   render() {
     const { stats, nodeInfo, selectedNode, clusterEnabled } = this.props.state;
-    const agentsNodeCount = clusterEnabled ? (stats.agentsCountByManagerNodes.find(node => node.node_name === selectedNode) || {}).count || 0 : stats.agentsCount.total;
+    const agentsNodeCount = clusterEnabled
+      ? (
+          stats.agentsCountByManagerNodes.find(
+            node => node.node_name === selectedNode,
+          ) || {}
+        ).count || 0
+      : stats.agentsCount.total;
     const title = selectedNode
       ? selectedNode + ' information'
       : 'Manager information';
 
     const greyStyle = {
-      color: 'grey'
+      color: 'grey',
     };
 
     return (
@@ -47,7 +53,7 @@ export class WzStatusNodeInfo extends Component {
           <EuiFlexItem>
             <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiTitle size="m">
+                <EuiTitle size='m'>
                   <h2>{title}</h2>
                 </EuiTitle>
               </EuiFlexItem>
@@ -57,12 +63,6 @@ export class WzStatusNodeInfo extends Component {
         <EuiFlexGroup>
           <EuiFlexItem>Version</EuiFlexItem>
           <EuiFlexItem style={greyStyle}>{nodeInfo.version}</EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiFlexGroup>
-          <EuiFlexItem>Compilation date</EuiFlexItem>
-          <EuiFlexItem style={greyStyle}>
-            {formatUIDate(nodeInfo.compilation_date)}
-          </EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexGroup>
           <EuiFlexItem>Installation path</EuiFlexItem>
@@ -83,7 +83,7 @@ export class WzStatusNodeInfo extends Component {
 
 const mapStateToProps = state => {
   return {
-    state: state.statusReducers
+    state: state.statusReducers,
   };
 };
 


### PR DESCRIPTION
### Description
This pull request  removes all uses of the `compilation_date` field, because these API endpoints will no longer contain the field:

> GET /cluster/{node_id}/info
> GET /manager/info

 
### Issues Resolved
Closes #6365 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/e04a21ad-1fe4-427d-8684-0defe4b0961e)


### Test

- Check the **_Compilation Date_** is no longer present in the Status view.
- Check the compilation_date field is not used anywhere in the app


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
