### PR TITLE
Avoid force check updates when user logins

### DIFF
--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -558,7 +558,7 @@ export const ApiTable = compose(
                   <span>
                     Check updates{' '}
                     <EuiToolTip
-                      title='Last check'
+                      title='Last dashboard check'
                       content={
                         this.state.availableUpdates?.last_check_date
                           ? getWazuhCorePlugin().utils.formatUIDate(

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -58,11 +58,14 @@ export const ApiTable = compose(
       };
     }
 
-    async getApisAvailableUpdates(forceUpdate = false) {
+    async getApisAvailableUpdates(queryApi = false, forceQuery = false) {
       try {
         this.setState({ refreshingAvailableUpdates: true });
         const availableUpdates =
-          await getWazuhCheckUpdatesPlugin().getAvailableUpdates(forceUpdate);
+          await getWazuhCheckUpdatesPlugin().getAvailableUpdates(
+            queryApi,
+            forceQuery,
+          );
         this.setState({ availableUpdates });
       } catch (error) {
         const options = {
@@ -548,7 +551,9 @@ export const ApiTable = compose(
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
                   iconType='refresh'
-                  onClick={async () => await this.getApisAvailableUpdates(true)}
+                  onClick={async () =>
+                    await this.getApisAvailableUpdates(true, true)
+                  }
                 >
                   <span>
                     Check updates{' '}

--- a/plugins/wazuh-check-updates/README.md
+++ b/plugins/wazuh-check-updates/README.md
@@ -28,7 +28,7 @@ The plugin provides a function for fetching the available updates for each API. 
 2.  The main Wazuh plugin is loaded and renders the UpdatesNotification component from the Check Updates plugin.
 3.  The `UpdatesNotification` component checks the user's preferences (stored in a saved object) to determine if the user has dismissed notifications about new updates. If the user has dismissed them, the component returns nothing; otherwise, it proceeds to the next steps.
 4.  The UpdatesNotification component checks the `checkUpdates` value in the browser's session storage to determine if a query about available updates from the Wazuh Server API has already been executed. Since the user has just logged in, this value will not exist in the session storage.
-5.  The component makes a request to the Check Updates plugin API with the `checkAvailableUpdates` parameter set to true. This indicates the plugin's API to check for updates on all configured APIs. The `checkUpdates` value in the session storage is updated to `true`.
+5.  The component makes a request to the Check Updates plugin API with the `query_api` parameter set to true. This indicates the plugin's API to check for updates on all configured APIs. The `checkUpdates` value in the session storage is updated to `true`.
 6.  The updates are stored in a saved object for future reference.
 7.  It's possible that the user has dismissed specific updates. In such cases, the dismissed updates are compared with the updates retrieved from the API. If they match, the component returns nothing; otherwise, it proceeds to the next steps.
 8.  The component displays a bottom bar to notify the user of the availability of new updates.

--- a/plugins/wazuh-check-updates/README.md
+++ b/plugins/wazuh-check-updates/README.md
@@ -13,6 +13,9 @@ Every time a page is loaded, the UpdatesNotification component is rendered. The 
 1.  **User Preferences:** It retrieves information from the saved object containing user preferences to determine if the user has chosen to display more notifications about new updates and to obtain the latest updates that the user dismissed in a notification.
 
 2.  **Available Updates:** It retrieves the available updates for each available API. To determine where to retrieve the information, it first checks the session storage for the key `checkUpdates`. If the value is `executed`, it then searches for available updates in a saved object; otherwise, it queries the Wazuh API and makes a request for each available API, finally saving the information in the saved object and setting the session storage `checkUpdates` to `executed`.
+    The endpoint has two parameters:
+    `query_api`: Determines whether the Check Updates plugin retrieves data from the Wazuh API or from a saved object.
+    `force_query`: When `query_api` is set to true, it determines whether the Wazuh API internally obtains the data or fetches it from the CTI Service.
 
 If the user had not chosen not to receive notifications of new updates and if the new updates are different from the last ones dismissed, then the component renders a bottom bar to notify that there are new updates.
 
@@ -28,7 +31,7 @@ The plugin provides a function for fetching the available updates for each API. 
 2.  The main Wazuh plugin is loaded and renders the UpdatesNotification component from the Check Updates plugin.
 3.  The `UpdatesNotification` component checks the user's preferences (stored in a saved object) to determine if the user has dismissed notifications about new updates. If the user has dismissed them, the component returns nothing; otherwise, it proceeds to the next steps.
 4.  The UpdatesNotification component checks the `checkUpdates` value in the browser's session storage to determine if a query about available updates from the Wazuh Server API has already been executed. Since the user has just logged in, this value will not exist in the session storage.
-5.  The component makes a request to the Check Updates plugin API with the `query_api` parameter set to true. This indicates the plugin's API to check for updates on all configured APIs. The `checkUpdates` value in the session storage is updated to `true`.
+5.  The component makes a request to the Check Updates plugin API with the `query_api` parameter set to true and `force_query` set to false. The `checkUpdates` value in the session storage is updated to `true`.
 6.  The updates are stored in a saved object for future reference.
 7.  It's possible that the user has dismissed specific updates. In such cases, the dismissed updates are compared with the updates retrieved from the API. If they match, the component returns nothing; otherwise, it proceeds to the next steps.
 8.  The component displays a bottom bar to notify the user of the availability of new updates.

--- a/plugins/wazuh-check-updates/public/services/available-updates.ts
+++ b/plugins/wazuh-check-updates/public/services/available-updates.ts
@@ -1,15 +1,18 @@
-import { useState, useEffect } from 'react';
-import { ApiAvailableUpdates, AvailableUpdates } from '../../common/types';
+import { AvailableUpdates } from '../../common/types';
 import { routes } from '../../common/constants';
 import { getCore } from '../plugin-services';
 
-export const getAvailableUpdates = async (forceUpdate = false): Promise<AvailableUpdates> => {
+export const getAvailableUpdates = async (
+  queryApi = false,
+  forceQuery = false,
+): Promise<AvailableUpdates> => {
   const checkUpdates = sessionStorage.getItem('checkUpdates');
   const alreadyCheckUpdates = checkUpdates === 'executed';
 
   const availableUpdates = await getCore().http.get(routes.checkUpdates, {
     query: {
-      checkAvailableUpdates: forceUpdate || !alreadyCheckUpdates,
+      query_api: queryApi || !alreadyCheckUpdates,
+      force_query: forceQuery,
     },
   });
 

--- a/plugins/wazuh-check-updates/public/types.ts
+++ b/plugins/wazuh-check-updates/public/types.ts
@@ -5,7 +5,10 @@ export interface WazuhCheckUpdatesPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WazuhCheckUpdatesPluginStart {
   UpdatesNotification: () => JSX.Element | null;
-  getAvailableUpdates: (forceUpdate: boolean) => Promise<AvailableUpdates>;
+  getAvailableUpdates: (
+    queryApi: boolean,
+    forceQuery: boolean,
+  ) => Promise<AvailableUpdates>;
   DismissNotificationCheck: () => JSX.Element | null;
 }
 

--- a/plugins/wazuh-check-updates/server/routes/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/routes/updates/get-updates.test.ts
@@ -100,7 +100,7 @@ describe(`[endpoint] GET ${routes.checkUpdates}`, () => {
 
     mockedGetUpdates.mockImplementation(() => mockResponse);
     const response = await supertest(innerServer.listener)
-      .get(`${routes.checkUpdates}?checkAvailableUpdates=true`)
+      .get(`${routes.checkUpdates}?query_api=true`)
       .send(mockResponse)
       .expect(200);
 

--- a/plugins/wazuh-check-updates/server/routes/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/routes/updates/get-updates.ts
@@ -9,14 +9,16 @@ export const getUpdatesRoute = (router: IRouter) => {
       path: routes.checkUpdates,
       validate: {
         query: schema.object({
-          checkAvailableUpdates: schema.maybe(schema.string()),
+          query_api: schema.maybe(schema.string()),
+          force_query: schema.maybe(schema.string()),
         }),
       },
     },
     async (context, request, response) => {
       try {
         const updates = await getUpdates(
-          request.query?.checkAvailableUpdates === 'true',
+          request.query?.query_api === 'true',
+          request.query?.force_query === 'true',
         );
         return response.ok({
           body: updates,

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -7,10 +7,15 @@ import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 import { getSavedObject, setSavedObject } from '../saved-object';
 import { getWazuhCore } from '../../plugin-services';
 
-export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<AvailableUpdates> => {
+export const getUpdates = async (
+  queryApi = false,
+  forceQuery = false,
+): Promise<AvailableUpdates> => {
   try {
-    if (!checkAvailableUpdates) {
-      const availableUpdates = (await getSavedObject(SAVED_OBJECT_UPDATES)) as AvailableUpdates;
+    if (!queryApi) {
+      const availableUpdates = (await getSavedObject(
+        SAVED_OBJECT_UPDATES,
+      )) as AvailableUpdates;
 
       return availableUpdates;
     }
@@ -21,13 +26,14 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
     } = getWazuhCore();
     const wazuhHostsController = new WazuhHostsCtrl();
 
-    const hosts: { id: string }[] = await wazuhHostsController.getHostsEntries();
+    const hosts: { id: string }[] =
+      await wazuhHostsController.getHostsEntries();
 
     const apisAvailableUpdates = await Promise.all(
-      hosts?.map(async (api) => {
+      hosts?.map(async api => {
         const data = {};
         const method = 'GET';
-        const path = '/manager/version/check?force_query=true';
+        const path = `/manager/version/check?force_query=${forceQuery}`;
         const options = {
           apiHostID: api.id,
           forceRefresh: true,
@@ -37,7 +43,7 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
             method,
             path,
             data,
-            options
+            options,
           );
 
           const update = response.data.data as ResponseApiAvailableUpdates;
@@ -89,7 +95,7 @@ export const getUpdates = async (checkAvailableUpdates?: boolean): Promise<Avail
             error,
           };
         }
-      })
+      }),
     );
 
     const savedObject = {


### PR DESCRIPTION
### Description
This PR prevents checking for updates with the force_query parameter set to true upon user login. Consequently, the Wazuh API will now return available updates without querying the CTI Service.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6308

### Evidence

`query_api`: Determines whether the Check Updates plugin retrieves data from the Wazuh API or from a saved object.
`force_query`: When `query_api` is set to true, it determines whether the Wazuh API internally obtains the data or fetches it from the CTI Service.

#### After user logins
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/aa253fcf-aa6e-4fa3-ae9c-de0e4a80cda3)

#### Server APIs page
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/9e5129f8-d8ba-40f3-8622-f2ad0ad02299)

#### Check updates button
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/4269f521-fbda-461d-afd3-5689ef3e046f)

#### Update Check updates button tooltip
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/81c988dc-f393-473b-89b9-b1161bc0714b)

### Test

1. Open brower inspectos to see network requests.
2. Logins and check the request: `/api/wazuh-check-updates/updates?query_api=true&force_query=false`
3. Navigate to `Indexer/dashboard management -> Server APIs` and check de request: `/api/wazuh-check-updates/updates?query_api=false&force_query=false`
4. Click `Check updates` button and check the request: `/api/wazuh-check-updates/updates?query_api=true&force_query=true`
5. Check the title of the Check updates button tooltip.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
