### PR TITLE
Add overview home last 24 hours KPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added the ability to check if there are available updates from the UI. [#6093](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6093) [#6256](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6256) [#6328](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6328)
 - Added remember server address check [#5791](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5791)
 - Added the ssl_agent_ca configuration to the SSL Settings form [#6083](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6083)
-- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896) [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179) [#6173](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6173) [#6147](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6147) [#6231](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6231) [#6246](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6246) [#6321](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6321) [#6338] (https://github.com/wazuh/wazuh-dashboard-plugins/pull/6338) [#6356](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6356)
+- Added global vulnerabilities dashboards [#5896](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5896) [#6179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6179) [#6173](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6173) [#6147](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6147) [#6231](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6231) [#6246](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6246) [#6321](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6321) [#6338](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6338) [#6356](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6356)
 - Added an agent selector to the IT Hygiene application [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Added query results limit when the search exceed 10000 hits [#6106](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6106)
 - Added a redirection button to Endpoint Summary from IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 - Upgraded the `axios` dependency to `1.6.1` [#5062](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5062)
 - Changed the api configuration title in the Server APIs section. [#6373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6373)
+- Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379)
 
 ### Fixed
 

--- a/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
+++ b/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
@@ -1,487 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Stats component renders correctly to match the snapshot 1`] = `
-<Component>
-  <ErrorBoundary>
-    <withErrorBoundary(Stats)>
-      <EuiPage>
+<div>
+  <div
+    class="euiPage euiPage--paddingMedium euiPage--grow"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem"
+      />
+      <div
+        class="euiFlexItem"
+      >
         <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
+          class="euiStat euiStat--centerAligned"
         >
-          <EuiFlexGroup>
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <div
+            class="euiText euiText--small euiStat__description"
+          >
+            <p
+              aria-hidden="true"
             >
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                />
-              </EuiFlexItem>
-              <EuiFlexItem
-                key="agent-status-total"
+              Active agents
+            </p>
+          </div>
+          <p
+            aria-hidden="true"
+            class="euiTitle euiTitle--large euiStat__title"
+            style="color: rgb(0, 120, 113);"
+          >
+            <span
+              class="euiToolTipAnchor"
+            >
+              <span
+                class="statWithLink"
+                style="cursor: pointer;"
               >
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiStat
-                    description="Total agents"
-                    textAlign="center"
-                    title={
-                      <EuiToolTip
-                        content="Go to total agents"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="statWithLink"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                            }
-                          }
-                        >
-                          -
-                        </span>
-                      </EuiToolTip>
-                    }
-                    titleColor="primary"
-                  >
-                    <div
-                      className="euiStat euiStat--centerAligned"
-                    >
-                      <EuiText
-                        className="euiStat__description"
-                        size="s"
-                      >
-                        <div
-                          className="euiText euiText--small euiStat__description"
-                        >
-                          <p
-                            aria-hidden={true}
-                          >
-                            Total agents
-                          </p>
-                        </div>
-                      </EuiText>
-                      <EuiTitle
-                        className="euiStat__title euiStat__title--primary"
-                        size="l"
-                      >
-                        <p
-                          aria-hidden={true}
-                          className="euiTitle euiTitle--large euiStat__title euiStat__title--primary"
-                        >
-                          <EuiToolTip
-                            content="Go to total agents"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <span
-                                className="statWithLink"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                  }
-                                }
-                              >
-                                -
-                              </span>
-                            </span>
-                          </EuiToolTip>
-                        </p>
-                      </EuiTitle>
-                    </div>
-                  </EuiStat>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                key="agent-status-active"
-              >
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiStat
-                    description="Active agents"
-                    textAlign="center"
-                    title={
-                      <EuiToolTip
-                        content="Go to active agents"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="statWithLink"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                            }
-                          }
-                        >
-                          -
-                        </span>
-                      </EuiToolTip>
-                    }
-                    titleColor="#007871"
-                  >
-                    <div
-                      className="euiStat euiStat--centerAligned"
-                    >
-                      <EuiText
-                        className="euiStat__description"
-                        size="s"
-                      >
-                        <div
-                          className="euiText euiText--small euiStat__description"
-                        >
-                          <p
-                            aria-hidden={true}
-                          >
-                            Active agents
-                          </p>
-                        </div>
-                      </EuiText>
-                      <EuiTitle
-                        className="euiStat__title"
-                        size="l"
-                      >
-                        <p
-                          aria-hidden={true}
-                          className="euiTitle euiTitle--large euiStat__title"
-                          style={
-                            Object {
-                              "color": "#007871",
-                            }
-                          }
-                        >
-                          <EuiToolTip
-                            content="Go to active agents"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <span
-                                className="statWithLink"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                  }
-                                }
-                              >
-                                -
-                              </span>
-                            </span>
-                          </EuiToolTip>
-                        </p>
-                      </EuiTitle>
-                    </div>
-                  </EuiStat>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                key="agent-status-disconnected"
-              >
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiStat
-                    description="Disconnected agents"
-                    textAlign="center"
-                    title={
-                      <EuiToolTip
-                        content="Go to disconnected agents"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="statWithLink"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                            }
-                          }
-                        >
-                          -
-                        </span>
-                      </EuiToolTip>
-                    }
-                    titleColor="#BD271E"
-                  >
-                    <div
-                      className="euiStat euiStat--centerAligned"
-                    >
-                      <EuiText
-                        className="euiStat__description"
-                        size="s"
-                      >
-                        <div
-                          className="euiText euiText--small euiStat__description"
-                        >
-                          <p
-                            aria-hidden={true}
-                          >
-                            Disconnected agents
-                          </p>
-                        </div>
-                      </EuiText>
-                      <EuiTitle
-                        className="euiStat__title"
-                        size="l"
-                      >
-                        <p
-                          aria-hidden={true}
-                          className="euiTitle euiTitle--large euiStat__title"
-                          style={
-                            Object {
-                              "color": "#BD271E",
-                            }
-                          }
-                        >
-                          <EuiToolTip
-                            content="Go to disconnected agents"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <span
-                                className="statWithLink"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                  }
-                                }
-                              >
-                                -
-                              </span>
-                            </span>
-                          </EuiToolTip>
-                        </p>
-                      </EuiTitle>
-                    </div>
-                  </EuiStat>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                key="agent-status-pending"
-              >
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiStat
-                    description="Pending agents"
-                    textAlign="center"
-                    title={
-                      <EuiToolTip
-                        content="Go to pending agents"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="statWithLink"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                            }
-                          }
-                        >
-                          -
-                        </span>
-                      </EuiToolTip>
-                    }
-                    titleColor="#FEC514"
-                  >
-                    <div
-                      className="euiStat euiStat--centerAligned"
-                    >
-                      <EuiText
-                        className="euiStat__description"
-                        size="s"
-                      >
-                        <div
-                          className="euiText euiText--small euiStat__description"
-                        >
-                          <p
-                            aria-hidden={true}
-                          >
-                            Pending agents
-                          </p>
-                        </div>
-                      </EuiText>
-                      <EuiTitle
-                        className="euiStat__title"
-                        size="l"
-                      >
-                        <p
-                          aria-hidden={true}
-                          className="euiTitle euiTitle--large euiStat__title"
-                          style={
-                            Object {
-                              "color": "#FEC514",
-                            }
-                          }
-                        >
-                          <EuiToolTip
-                            content="Go to pending agents"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <span
-                                className="statWithLink"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                  }
-                                }
-                              >
-                                -
-                              </span>
-                            </span>
-                          </EuiToolTip>
-                        </p>
-                      </EuiTitle>
-                    </div>
-                  </EuiStat>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                key="agent-status-never_connected"
-              >
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiStat
-                    description="Never connected agents"
-                    textAlign="center"
-                    title={
-                      <EuiToolTip
-                        content="Go to never connected agents"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="statWithLink"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                            }
-                          }
-                        >
-                          -
-                        </span>
-                      </EuiToolTip>
-                    }
-                    titleColor="#646A77"
-                  >
-                    <div
-                      className="euiStat euiStat--centerAligned"
-                    >
-                      <EuiText
-                        className="euiStat__description"
-                        size="s"
-                      >
-                        <div
-                          className="euiText euiText--small euiStat__description"
-                        >
-                          <p
-                            aria-hidden={true}
-                          >
-                            Never connected agents
-                          </p>
-                        </div>
-                      </EuiText>
-                      <EuiTitle
-                        className="euiStat__title"
-                        size="l"
-                      >
-                        <p
-                          aria-hidden={true}
-                          className="euiTitle euiTitle--large euiStat__title"
-                          style={
-                            Object {
-                              "color": "#646A77",
-                            }
-                          }
-                        >
-                          <EuiToolTip
-                            content="Go to never connected agents"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <span
-                                className="statWithLink"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                  }
-                                }
-                              >
-                                -
-                              </span>
-                            </span>
-                          </EuiToolTip>
-                        </p>
-                      </EuiTitle>
-                    </div>
-                  </EuiStat>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                />
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
+                -
+              </span>
+            </span>
+          </p>
         </div>
-      </EuiPage>
-    </withErrorBoundary(Stats)>
-  </ErrorBoundary>
-</Component>
+      </div>
+      <div
+        class="euiFlexItem"
+      >
+        <div
+          class="euiStat euiStat--centerAligned"
+        >
+          <div
+            class="euiText euiText--small euiStat__description"
+          >
+            <p
+              aria-hidden="true"
+            >
+              Disconnected agents
+            </p>
+          </div>
+          <p
+            aria-hidden="true"
+            class="euiTitle euiTitle--large euiStat__title"
+            style="color: rgb(189, 39, 30);"
+          >
+            <span
+              class="euiToolTipAnchor"
+            >
+              <span
+                class="statWithLink"
+                style="cursor: pointer;"
+              >
+                -
+              </span>
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem"
+      >
+        <div
+          class="osdRedirectCrossAppLinks"
+        >
+          <div
+            class="euiStat euiStat--centerAligned"
+          >
+            <div
+              class="euiText euiText--small euiStat__description"
+            >
+              <p
+                aria-hidden="true"
+              >
+                Last 24 hours alerts
+              </p>
+            </div>
+            <p
+              aria-hidden="true"
+              class="euiTitle euiTitle--large euiStat__title"
+              style="color: rgb(0, 120, 113);"
+            >
+              <span
+                class="euiToolTipAnchor"
+              >
+                <a
+                  class="euiLink euiLink--primary statWithLink"
+                  href=""
+                  rel="noreferrer"
+                  style="font-weight: normal;"
+                >
+                  -
+                </a>
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem"
+      />
+    </div>
+  </div>
+</div>
 `;

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/index.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/index.ts
@@ -1,0 +1,1 @@
+export * from './last-alerts-stat';

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-query.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-query.ts
@@ -19,9 +19,6 @@ export const getLastAlertsQuery = (
     },
     filters: [
       {
-        match_all: {},
-      },
-      {
         range: {
           timestamp: {
             gte: 'now-24h',
@@ -35,19 +32,6 @@ export const getLastAlertsQuery = (
           match: {
             [clusterField]: {
               query: clusterValue,
-              type: 'phrase',
-            },
-          },
-        },
-        $state: {
-          store: 'appState',
-        },
-      },
-      {
-        query: {
-          match: {
-            'rule.groups': {
-              query: 'office365',
               type: 'phrase',
             },
           },

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-query.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-query.ts
@@ -1,0 +1,61 @@
+export const getLastAlertsQuery = (
+  currentIndexPattern: string,
+  isClusterEnabled: boolean,
+  clusterValue: string,
+) => {
+  const clusterField = isClusterEnabled ? 'cluster.name' : 'manager.name';
+  return {
+    indexPattern: currentIndexPattern,
+    aggs: {
+      buckets: {
+        terms: {
+          field: clusterField,
+          size: 5,
+          order: {
+            _count: 'desc',
+          },
+        },
+      },
+    },
+    filters: [
+      {
+        match_all: {},
+      },
+      {
+        range: {
+          timestamp: {
+            gte: 'now-24h',
+            lte: 'now',
+            format: 'epoch_millis',
+          },
+        },
+      },
+      {
+        query: {
+          match: {
+            [clusterField]: {
+              query: clusterValue,
+              type: 'phrase',
+            },
+          },
+        },
+        $state: {
+          store: 'appState',
+        },
+      },
+      {
+        query: {
+          match: {
+            'rule.groups': {
+              query: 'office365',
+              type: 'phrase',
+            },
+          },
+        },
+        $state: {
+          store: 'appState',
+        },
+      },
+    ],
+  };
+};

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
@@ -4,10 +4,20 @@ import { getSettingDefaultValue } from '../../../../../common/services/settings'
 import { getDataPlugin } from '../../../../kibana-services';
 import { getLastAlertsQuery } from './last-alerts-query';
 
+interface Last24HoursAlerts {
+  count: number;
+  cluster: {
+    field: string;
+    name: string;
+  };
+  indexPatternName: string;
+}
+
 /**
  * This fetch the last 24 hours alerts from the selected cluster
+ * TODO: The search function should be moved to a common place
  */
-export const getLast24HoursAlerts = async (): Promise<number> => {
+export const getLast24HoursAlerts = async (): Promise<Last24HoursAlerts> => {
   try {
     const currentIndexPattern = await getDataPlugin().indexPatterns.get(
       AppState.getCurrentPattern() || getSettingDefaultValue('pattern'),
@@ -22,8 +32,17 @@ export const getLast24HoursAlerts = async (): Promise<number> => {
       isCluster,
       clusterValue,
     );
+
     const result = await search(lastAlertsQuery);
-    return result?.hits?.total;
+    const count = result?.hits?.total;
+    return {
+      count,
+      cluster: {
+        field: isCluster ? 'cluster.name' : 'manager.name',
+        name: clusterValue,
+      },
+      indexPatternName: currentIndexPattern.title,
+    };
   } catch (error) {
     return Promise.reject(error);
   }

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
@@ -1,0 +1,30 @@
+import { AppState } from '../../../../react-services/app-state';
+import { search } from '../../../../components/overview/vulnerabilities/dashboards/inventory/inventory_service';
+import { getSettingDefaultValue } from '../../../../../common/services/settings';
+import { getDataPlugin } from '../../../../kibana-services';
+import { getLastAlertsQuery } from './last-alerts-query';
+
+/**
+ * This fetch the last 24 hours alerts from the selected cluster
+ */
+export const getLast24HoursAlerts = async (): Promise<number> => {
+  try {
+    const currentIndexPattern = await getDataPlugin().indexPatterns.get(
+      AppState.getCurrentPattern() || getSettingDefaultValue('pattern'),
+    );
+    const isCluster = AppState.getClusterInfo().status == 'enabled';
+    const clusterValue = isCluster
+      ? AppState.getClusterInfo().cluster
+      : AppState.getClusterInfo().manager;
+
+    const lastAlertsQuery = getLastAlertsQuery(
+      currentIndexPattern,
+      isCluster,
+      clusterValue,
+    );
+    const result = await search(lastAlertsQuery);
+    return result?.hits?.total;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { EuiStat, EuiFlexItem, EuiLink, EuiToolTip } from '@elastic/eui';
+import { getLast24HoursAlerts } from './last-alerts-service';
+import { UI_COLOR_AGENT_STATUS } from '../../../../../common/constants';
+import { getCore } from '../../../../kibana-services';
+import { RedirectAppLinks } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+export function LastAlertsStat() {
+  const [countLastAlerts, setCountLastAlerts] = useState<number | null>(null);
+  const [discoverLocation, setDiscoverLocation] = useState<string>('');
+
+  useEffect(() => {
+    const getCountLastAlerts = async () => {
+      const count = await getLast24HoursAlerts();
+      setCountLastAlerts(count);
+      const urlSearchParams = new URLSearchParams(location.href);
+      //`#/search?_a=(query:(language:kuery,query:'alert.id:%20"${urlSearchParams.get('alert.id')}"'))`
+      const destURL = getCore().application.getUrlForApp('discover', {
+        path: urlSearchParams,
+      });
+      setDiscoverLocation(destURL);
+    };
+    getCountLastAlerts();
+  }, []);
+  return (
+    <EuiFlexItem>
+      <RedirectAppLinks application={getCore().application}>
+        <EuiStat
+          title={
+            <EuiToolTip position='top' content={`See alerts`}>
+              <EuiLink
+                className='statWithLink'
+                style={{ fontWeight: 'normal' }}
+                href={discoverLocation}
+              >
+                {countLastAlerts || '-'}
+              </EuiLink>
+            </EuiToolTip>
+          }
+          description={`Last 24 hour alerts`}
+          titleColor={UI_COLOR_AGENT_STATUS.active}
+          textAlign='center'
+        />
+      </RedirectAppLinks>
+    </EuiFlexItem>
+  );
+}

--- a/plugins/main/public/controllers/overview/components/stats.js
+++ b/plugins/main/public/controllers/overview/components/stats.js
@@ -20,13 +20,14 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { withErrorBoundary } from '../../../components/common/hocs';
-import { UI_ORDER_AGENT_STATUS } from '../../../../common/constants';
+import { API_NAME_AGENT_STATUS } from '../../../../common/constants';
 import {
   agentStatusLabelByAgentStatus,
   agentStatusColorByAgentStatus,
 } from '../../../../common/services/wz_agent_status';
 import { getCore } from '../../../kibana-services';
 import { endpointSummary } from '../../../utils/applications';
+import { LastAlertsStat } from './last-alerts-stat';
 
 export const Stats = withErrorBoundary(
   class Stats extends Component {
@@ -34,15 +35,14 @@ export const Stats = withErrorBoundary(
       super(props);
 
       this.state = {};
-      this.agentStatus = ['total', ...UI_ORDER_AGENT_STATUS].map(status => ({
+      this.agentStatus = [
+        API_NAME_AGENT_STATUS.ACTIVE,
+        API_NAME_AGENT_STATUS.DISCONNECTED,
+      ].map(status => ({
         status,
-        label:
-          status !== 'total' ? agentStatusLabelByAgentStatus(status) : 'Total',
-        onClick: () => this.goToAgents(status !== 'total' ? status : null),
-        color:
-          status !== 'total'
-            ? agentStatusColorByAgentStatus(status)
-            : 'primary',
+        label: agentStatusLabelByAgentStatus(status),
+        onClick: () => this.goToAgents(status),
+        color: agentStatusColorByAgentStatus(status),
       }));
     }
 
@@ -98,6 +98,7 @@ export const Stats = withErrorBoundary(
                 />
               </EuiFlexItem>
             ))}
+            <LastAlertsStat />
             <EuiFlexItem />
           </EuiFlexGroup>
         </EuiPage>
@@ -107,9 +108,6 @@ export const Stats = withErrorBoundary(
 );
 
 Stats.propTypes = {
-  total: PropTypes.any,
   active: PropTypes.any,
   disconnected: PropTypes.any,
-  pending: PropTypes.any,
-  never_connected: PropTypes.any,
 };

--- a/plugins/main/public/controllers/overview/components/stats.test.tsx
+++ b/plugins/main/public/controllers/overview/components/stats.test.tsx
@@ -13,13 +13,40 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { Stats } from './stats';
 
-describe('Stats component', () => {
-  it('renders correctly to match the snapshot', () => {
-    const wrapper = mount(<Stats />);
+jest.mock('react-use/lib/useObservable', () => () => {});
+jest.mock('./last-alerts-stat/last-alerts-service', () => ({
+  getLast24HoursAlerts: jest.fn().mockReturnValue({
+    count: 100,
+    cluster: {
+      field: 'cluster.name',
+      name: 'master',
+    },
+    indexPatternName: 'wazuh-alerts-*',
+  }),
+}));
 
-    expect(wrapper).toMatchSnapshot();
+jest.mock('../../../kibana-services', () => ({
+  getCore: jest.fn().mockReturnValue({
+    application: {
+      navigateToApp: () => 'http://url',
+      getUrlForApp: () => 'http://url',
+    },
+  }),
+}));
+
+jest.mock('../../../react-services/common-services', () => ({
+  getErrorOrchestrator: () => ({
+    handleError: options => {},
+  }),
+}));
+
+describe('Stats component', () => {
+  test('renders correctly to match the snapshot', async () => {
+    const { container } = render(<Stats />);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/plugins/main/public/controllers/overview/components/stats.test.tsx
+++ b/plugins/main/public/controllers/overview/components/stats.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Stats } from './stats';
 
@@ -46,7 +46,9 @@ jest.mock('../../../react-services/common-services', () => ({
 
 describe('Stats component', () => {
   test('renders correctly to match the snapshot', async () => {
-    const { container } = render(<Stats />);
-    expect(container).toMatchSnapshot();
+    await act(async () => {
+      const { container } = render(<Stats />);
+      expect(container).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
### Description
This pull request removes the pending and never connected agents KPIs from the home view and also adds a new last 24 hours alerts KPI.

The last 24 hours alerts KPI is a call to action that redirects to the Discover plugin with the predefined filters.
 
### Issues Resolved
- #6367 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/32f1e404-d0e1-450d-8988-17b7f1e61294)


### Test

- Go to Home -> Overview
- Check the only KPIs that exist are: `Active agents`, `Disconnected agents`, `Last 24 hours alerts`
- Check the `Last 24 hours alerts` is also a link to the Discover plugin
  - The Discover plugin must have the `cluster.name` or `manager.name` pre-filtered (whether the cluster mode is enabled or not)
  - The Discover plugin must be filtered by the last 24 hours
  - The Discover plugin must use `wazuh-alerts-*` index pattern
  - The results of the Discover plugin must match the _Last 24 hours alerts_ KPI count number
- All the cases should be tested with different APIs selected. Check the `cluster.name` or manager.name matches the API selected
  

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
