### PR TITLE
Add pinned agent to vulnerability section

### DIFF
--- a/plugins/main/public/components/common/modules/modules-defaults.js
+++ b/plugins/main/public/components/common/modules/modules-defaults.js
@@ -21,7 +21,7 @@ import ButtonModuleExploreAgent from '../../../controllers/overview/components/o
 import { ButtonModuleGenerateReport } from '../modules/buttons';
 import { OfficePanel } from '../../overview/office-panel';
 import { GitHubPanel } from '../../overview/github-panel';
-import { DashboardVuls, InventoryVuls } from '../../overview/vulnerabilities'
+import { DashboardVuls, InventoryVuls } from '../../overview/vulnerabilities';
 import { withModuleNotForAgent, withModuleTabLoader } from '../hocs';
 
 const DashboardTab = {
@@ -151,17 +151,19 @@ export const ModulesDefaults = {
       {
         id: 'dashboard',
         name: 'Dashboard',
-        component: withModuleNotForAgent(DashboardVuls),
+        component: DashboardVuls,
+        buttons: [ButtonModuleExploreAgent],
       },
       {
         id: 'inventory',
         name: 'Inventory',
-        component: withModuleNotForAgent(InventoryVuls),
+        component: InventoryVuls,
+        buttons: [ButtonModuleExploreAgent],
       },
       EventsTab,
     ],
     buttons: ['settings'],
-    availableFor: ['manager'],
+    availableFor: ['manager', 'agent'],
   },
   mitre: {
     init: 'dashboard',

--- a/scripts/vulnerabilities-events-injector/dataInjectScript.py
+++ b/scripts/vulnerabilities-events-injector/dataInjectScript.py
@@ -15,7 +15,7 @@ def generateRandomDate():
 def generateRandomAgent():
     agent={}
     agent['build'] = {'original':'build{}'.format(random.randint(0, 9999))}
-    agent['id'] = 'agent{}'.format(random.randint(0, 99))
+    agent['id'] = '00{}'.format(random.randint(1, 99))
     agent['name'] = 'Agent{}'.format(random.randint(0, 99))
     agent['version'] = 'v{}-stable'.format(random.randint(0, 9))
     agent['ephemeral_id'] = '{}'.format(random.randint(0, 99999))


### PR DESCRIPTION
## Description
This pull request adds the functionality to pin an agent in the vulnerabilities section.
The searchBar functionality is also updated so that it maintains the functionality of not allowing editing of this filter added from the `Explore agent` button.
In order to be able to test better, the possible agent names generated by the script that injects random data into the vulnerability index were updated.
 
## Issues Resolved
- #6359 

## Evidence
[Provide screenshots or videos to prove this PR solves the issues]

## Test
> [!NOTE]  
> This test needs to have the vulnerability module activated from `appSettings` and insert data into the vulnerabilities index using the script `dataInjectScript.py` which is in `scripts/vulnerabilities-events-injector`

### Steps to test:
- Go to Vulnerability detection module
- Pin an agent with the Explore agent button
- Change tabs and check that the agent is still pinned and cannot be modified. Also check, if there were implicit filters, that they are still not implicit.
- Change module and check that the agent is still pinned
- Unpin the agent and check that both when changing tabs and modules the agent is no longer pinned.
- Try alternatives by switching between tabs and modules, pinning and unpinning agents.

## Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
