### PR TITLE
Fix home view kpis styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed implicit filter close button in the search bar [#6346](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6346)
 - Fixed the help menu, to be consistent and avoid duplication [#6374](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6374)
 - Fixed the axis label visual bug from dashboards [#6378](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6378)
+- Fixed style and redirection problem in home page KPIs [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 - Upgraded the `axios` dependency to `1.6.1` [#5062](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5062)
 - Changed the api configuration title in the Server APIs section. [#6373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6373)
-- Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379)
+- Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379) [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408)
 
 ### Fixed
 
@@ -44,7 +44,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed implicit filter close button in the search bar [#6346](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6346)
 - Fixed the help menu, to be consistent and avoid duplication [#6374](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6374)
 - Fixed the axis label visual bug from dashboards [#6378](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6378)
-- Fixed style and redirection problem in home page KPIs [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408)
 
 ### Removed
 

--- a/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
+++ b/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
@@ -34,12 +34,13 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
             <span
               class="euiToolTipAnchor"
             >
-              <span
-                class="statWithLink"
-                style="cursor: pointer;"
+              <button
+                class="euiLink euiLink--primary statWithLink"
+                style="font-weight: normal;"
+                type="button"
               >
                 -
-              </span>
+              </button>
             </span>
           </p>
         </div>
@@ -67,12 +68,13 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
             <span
               class="euiToolTipAnchor"
             >
-              <span
-                class="statWithLink"
-                style="cursor: pointer;"
+              <button
+                class="euiLink euiLink--primary statWithLink"
+                style="font-weight: normal;"
+                type="button"
               >
                 -
-              </span>
+              </button>
             </span>
           </p>
         </div>

--- a/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
+++ b/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
             >
               <button
                 class="euiLink euiLink--primary statWithLink"
-                style="font-weight: normal;"
+                style="font-weight: normal; color: rgb(0, 120, 113);"
                 type="button"
               >
                 -
@@ -70,7 +70,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
             >
               <button
                 class="euiLink euiLink--primary statWithLink"
-                style="font-weight: normal;"
+                style="font-weight: normal; color: rgb(189, 39, 30);"
                 type="button"
               >
                 -
@@ -109,7 +109,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
                   class="euiLink euiLink--primary statWithLink"
                   href=""
                   rel="noreferrer"
-                  style="font-weight: normal;"
+                  style="font-weight: normal; color: rgb(0, 120, 113);"
                 >
                   -
                 </a>

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -46,7 +46,10 @@ export function LastAlertsStat() {
             <EuiToolTip position='top' content={`See alerts`}>
               <EuiLink
                 className='statWithLink'
-                style={{ fontWeight: 'normal' }}
+                style={{
+                  fontWeight: 'normal',
+                  color: UI_COLOR_AGENT_STATUS.active,
+                }}
                 href={discoverLocation}
               >
                 {countLastAlerts ?? '-'}

--- a/plugins/main/public/controllers/overview/components/stats.js
+++ b/plugins/main/public/controllers/overview/components/stats.js
@@ -84,7 +84,7 @@ export const Stats = withErrorBoundary(
                     >
                       <EuiLink
                         className='statWithLink'
-                        style={{ fontWeight: 'normal' }}
+                        style={{ fontWeight: 'normal', color }}
                         onClick={onClick}
                       >
                         {typeof this.props[status] !== 'undefined'

--- a/plugins/main/public/controllers/overview/components/stats.js
+++ b/plugins/main/public/controllers/overview/components/stats.js
@@ -57,7 +57,7 @@ export const Stats = withErrorBoundary(
         sessionStorage.removeItem('wz-agents-overview-table-filter');
       }
       getCore().application.navigateToApp(endpointSummary.id, {
-        path: '#/agents-preview',
+        path: `#${endpointSummary.redirectTo()}`,
       });
     }
 

--- a/plugins/main/public/controllers/overview/components/stats.js
+++ b/plugins/main/public/controllers/overview/components/stats.js
@@ -18,6 +18,7 @@ import {
   EuiFlexGroup,
   EuiPage,
   EuiToolTip,
+  EuiLink,
 } from '@elastic/eui';
 import { withErrorBoundary } from '../../../components/common/hocs';
 import { API_NAME_AGENT_STATUS } from '../../../../common/constants';
@@ -81,15 +82,15 @@ export const Stats = withErrorBoundary(
                       position='top'
                       content={`Go to ${label.toLowerCase()} agents`}
                     >
-                      <span
+                      <EuiLink
                         className='statWithLink'
-                        style={{ cursor: 'pointer' }}
+                        style={{ fontWeight: 'normal' }}
                         onClick={onClick}
                       >
                         {typeof this.props[status] !== 'undefined'
                           ? this.props[status]
                           : '-'}
-                      </span>
+                      </EuiLink>
                     </EuiToolTip>
                   }
                   description={`${label} agents`}


### PR DESCRIPTION
### Description
Fixes styling and redirection problem in home page KPIs 
 
### Issues Resolved
- #6406 

### Evidence

Safari

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/87890668-e5d8-4daa-92a6-3803e7b54bff)

Chrome

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/849f8fb1-8a8c-4ab9-bd50-7def101ab078)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/732d135f-73ae-4aeb-bdfe-294a2304404f)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/b56ecc55-f366-4db0-9544-9a9769716164)

### Test

1. Check of the Home view KPIs must have the same font size and font-weight
2. check that the KPIs Active Agents and Disconnected Agents redirect to the endpoint summary with the selected filter in the table

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
