### PR TITLE
Change text in endpoint summary most active agent tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added an agent selector to the IT Hygiene application [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840)
 - Added query results limit when the search exceed 10000 hits [#6106](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6106)
 - Added a redirection button to Endpoint Summary from IT Hygiene application [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176)
-- Added information icon with tooltip on the most active agent in the endpoint summary view [#6364](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6364)
+- Added information icon with tooltip on the most active agent in the endpoint summary view [#6364](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6364) [#6421](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6421)
 - Added a dash with a tooltip in the server APIs table when the run as is disabled [#6354](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6354)
 
 ### Changed

--- a/plugins/main/public/controllers/agent/components/agents-preview.js
+++ b/plugins/main/public/controllers/agent/components/agents-preview.js
@@ -391,7 +391,7 @@ export const AgentsPreview = compose(
                                   <EuiIconTip
                                     type='iInCircle'
                                     color='primary'
-                                    content='Agent with more alerts in the last 24 hours'
+                                    content='Highest alert count agent in the last 24 hours'
                                   />
                                 </>
                               }


### PR DESCRIPTION
### Description
This pull request changes the Most active agent tooltip located in Endpoints summary to "Highest alert count agent in the last 24 hours"
 
### Issues Resolved
 Closes #6418 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/8b2e8543-3bd6-4054-a165-9f7b1929d278)


### Test

- Go to Endpoints summary
- Hover over the Most active agent icon
- Validate the text

### Check List
- [x] All tests pass
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
