### PR TITLE
Fixed filebeat in development environments

### DIFF
--- a/docker/osd-dev/dev.yml
+++ b/docker/osd-dev/dev.yml
@@ -204,8 +204,8 @@ services:
         mkdir -p /etc/filebeat
         echo admin | filebeat keystore add username --stdin --force
         echo ${PASSWORD}| filebeat keystore add password --stdin --force
-        curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json
-        curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.4.tar.gz | tar -xvz -C /usr/share/filebeat/module
+        curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v4.7.2/extensions/elasticsearch/7.x/wazuh-template.json
+        curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.3.tar.gz | tar -xvz -C /usr/share/filebeat/module
         # copy filebeat to preserve correct permissions without
         # affecting host filesystem
         cp /tmp/filebeat.yml /usr/share/filebeat/filebeat.yml


### PR DESCRIPTION
### Description
Filebeat correction in development environments
 
### Issues Resolved
- #6432 

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/78f33ab0-dcbd-4d2a-95dd-2bbfcd58f965)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/529cc868-cd93-4c54-b57f-a1e6e9dde099)


### Test

- Run the environment without any real manager, only the imposter, filebeat should continue to run and the healtcheck should pass.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
