### PR TITLE
Fixed keeping filters between dashboard and inventory using visualizations call to actions

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/common/vulnerability_detector_adapters.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/common/vulnerability_detector_adapters.tsx
@@ -256,3 +256,24 @@ const cleanFilters = (
   );
   return mappedFilters;
 };
+
+export const updateFiltersStorage = (filters: Filter[]) => {
+  const storagePreviousFilters = sessionStorage.getItem(
+    SESSION_STORAGE_FILTERS_NAME,
+  );
+  if (storagePreviousFilters) {
+    const previousFilters = JSON.parse(storagePreviousFilters);
+    const previousImplicitFilters = previousFilters.filter(
+      (filter: Filter) => filter?.$state?.isImplicit,
+    );
+    /* Normal filters added to storagePreviousFilters are added to keep them between dashboard and inventory tab */
+    const newFilters = filters.filter(
+      (filter: Filter) => !filter?.$state?.isImplicit,
+    );
+
+    sessionStorage.setItem(
+      SESSION_STORAGE_FILTERS_NAME,
+      JSON.stringify([...previousImplicitFilters, ...newFilters]),
+    );
+  }
+};

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -16,6 +16,7 @@ import {
   vulnerabilityIndexFiltersAdapter,
   restorePrevIndexFiltersAdapter,
   onUpdateAdapter,
+  updateFiltersStorage,
 } from '../../common/vulnerability_detector_adapters';
 import { search } from '../inventory/inventory_service';
 import { IndexPattern } from '../../../../../../../../src/plugins/data/common';
@@ -28,6 +29,7 @@ import { compose } from 'redux';
 import { withVulnerabilitiesStateDataSource } from '../../common/hocs/validate-vulnerabilities-states-index-pattern';
 import { ModuleEnabledCheck } from '../../common/components/check-module-enabled';
 import { DataSourceFilterManagerVulnerabilitiesStates } from '../../../../../react-services/data-sources';
+import { DashboardContainerInput } from '../../../../../../../../src/plugins/dashboard/public';
 
 const plugins = getPlugins();
 
@@ -50,12 +52,20 @@ const DashboardVulsComponent: React.FC = () => {
     onUnMount: restorePrevIndexFiltersAdapter,
   });
 
+  /* This function is responsible for updating the storage filters so that the
+  filters between dashboard and inventory added using visualizations call to actions.
+  Without this feature, filters added using visualizations call to actions are
+  not maintained between dashboard and inventory tabs */
+  const handleFilterByVisualization = (newInput: DashboardContainerInput) => {
+    updateFiltersStorage(newInput.filters);
+  };
+
   const fetchFilters = DataSourceFilterManagerVulnerabilitiesStates.getFilters(
     searchBarProps.filters,
     VULNERABILITIES_INDEX_PATTERN_ID,
   );
 
-  const { isLoading, filters, query, indexPatterns } = searchBarProps;
+  const { isLoading, query, indexPatterns } = searchBarProps;
 
   const [isSearching, setIsSearching] = useState<boolean>(false);
   const [results, setResults] = useState<SearchResponse>({} as SearchResponse);
@@ -128,6 +138,7 @@ const DashboardVulsComponent: React.FC = () => {
                     },
                     hidePanelTitles: true,
                   }}
+                  onInputUpdated={handleFilterByVisualization}
                 />
               </div>
               <DashboardByRenderer
@@ -151,6 +162,7 @@ const DashboardVulsComponent: React.FC = () => {
                   },
                   hidePanelTitles: true,
                 }}
+                onInputUpdated={handleFilterByVisualization}
               />
               <DashboardByRenderer
                 input={{
@@ -173,6 +185,7 @@ const DashboardVulsComponent: React.FC = () => {
                   },
                   hidePanelTitles: false,
                 }}
+                onInputUpdated={handleFilterByVisualization}
               />
             </div>
           ) : null}

--- a/scripts/vulnerabilities-events-injector/DIS_Template.json
+++ b/scripts/vulnerabilities-events-injector/DIS_Template.json
@@ -239,6 +239,14 @@
               }
             }
           },
+          "manager": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "node": {
             "properties": {
               "name": {


### PR DESCRIPTION
## Description
This pull request fix keeping filters between dashboard and inventory using visualizations call to actions when a user adds a filter using a visualization call to action, like a label or a row value from a table.
Also in this pull request, the vulnerability index pattern template (`scripts/vulnerabilities-events-injector/DIS_Template.json`) that is used to inject the test data is updated.
 
## Issues Resolved
- #6447 

## Evidence
[Provide screenshots or videos to prove this PR solves the issues]

## Test

> [!NOTE]  
> This test needs to have inserted data into the vulnerabilities index using the script `dataInjectScript.py` which is in `scripts/vulnerabilities-events-injector`

### Steps to test:
- Go to Vulnerabilities module
- Add filter using a visualization call to action
- Change to Inventory tab and check that the added filter is maintained
- Back to Dashboard tab and check that the added filter is maintained
- Remove added filter.
- Change to Inventory tab and check that the removed filter does not appear
- Repeat previous steps interacting with other visualizations

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
