### PR TITLE
Remove relative_dirname from CDB List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.7.3
 
+### Fixed
+
+- Fixed CDB List import file feature [#6458](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6458)
+
 ## Wazuh v4.7.2 - OpenSearch Dashboards 2.8.0 - Revision 02
 
 ### Added

--- a/plugins/main/public/controllers/management/components/management/common/resources-handler.ts
+++ b/plugins/main/public/controllers/management/components/management/common/resources-handler.ts
@@ -93,7 +93,7 @@ export class ResourcesHandler {
     fileName: string,
     content: string,
     overwrite: boolean,
-    relativeDirname: string,
+    relativeDirname?: string,
   ) {
     try {
       const result = await WzRequest.apiReq(
@@ -102,7 +102,9 @@ export class ResourcesHandler {
         {
           params: {
             overwrite: overwrite,
-            relative_dirname: relativeDirname,
+            ...(this.resource !== 'lists'
+              ? { relative_dirname: relativeDirname }
+              : {}),
           },
           body: content.toString(),
           origin: 'raw',
@@ -119,7 +121,7 @@ export class ResourcesHandler {
    * @param {Resource} resource
    * @param {String} fileName
    */
-  async deleteFile(fileName: string, relativeDirname: string = '') {
+  async deleteFile(fileName: string, relativeDirname?: string) {
     try {
       const result = await WzRequest.apiReq(
         'DELETE',


### PR DESCRIPTION
### Description
This PR removes the `relative_dirname` when using CDB lists endpoints.
 
### Issues Resolved
Closes #6455

### Evidence
![Peek 2024-02-29 12-34](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/f2e4787f-3f2b-4051-b47d-11fbb643b792)


### Test
- Go to Management -> CDB List 
- Click Import file button
- Select a file to import
- Refresh the table and check it was imported
- Edit the imported file
- Delete the imported file



### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
