### PR TITLE
Minor style fixes in light and dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the help menu, to be consistent and avoid duplication [#6374](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6374)
 - Fixed the axis label visual bug from dashboards [#6378](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6378)
 - Fixed a error pop-up spawn in MITRE ATT&CK [#6431](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6431)
-- Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484)
+- Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484) [#6489](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6489)
 
 ### Removed
 

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -1869,9 +1869,9 @@ iframe.width-changed {
 
 .wz-app {
   .euiPage {
-    background-color: #fafbfd;
+    background-color: transparent;
   }
   [name='OverviewWelcome'] .euiIcon--app .euiIcon__fillSecondary {
-    fill: #000000;
+    fill: #000000bb;
   }
 }

--- a/plugins/main/public/styles/theme/dark/index.dark.scss
+++ b/plugins/main/public/styles/theme/dark/index.dark.scss
@@ -464,3 +464,9 @@ svg .legend text {
 .copy-codeblock-wrapper .euiToolTipAnchor {
   background-color: rgba(0, 0, 0, 0.7);
 }
+
+.wz-app {
+  [name='OverviewWelcome'] .euiIcon--app .euiIcon__fillSecondary {
+    fill: #dfe5ef;
+  }
+}


### PR DESCRIPTION
### Description
This pull request fixes the style of the euiPage component background color and overview icons for both light and dark theme.
 
### Issues Resolved
- #6483 

## Evidence

### Light theme
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/fb5699b7-87a7-473e-8a00-233918a8967d)

### Dark theme
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/c36d7159-9479-45f3-8b52-75313b4b563c)


### Test
- Check the Overview page looks like the images provided.
- The euiPage component shouldn't have the native grey color in the light theme.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
