### PR TITLE
Change PDF report year number to 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Upgraded the `axios` dependency to `1.6.1` [#6114](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6114)
 - Changed the api configuration title in the Server APIs section. [#6373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6373)
 - Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379) [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408)
+- Updated the PDF report year number. [#6492](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6492)
 
 ### Fixed
 

--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -311,7 +311,7 @@ export const ASSETS_PUBLIC_URL = '/plugins/wazuh/public/assets/';
 export const REPORTS_LOGO_IMAGE_ASSETS_RELATIVE_PATH =
   'images/logo_reports.png';
 export const REPORTS_PRIMARY_COLOR = '#256BD1';
-export const REPORTS_PAGE_FOOTER_TEXT = 'Copyright © 2023 Wazuh, Inc.';
+export const REPORTS_PAGE_FOOTER_TEXT = 'Copyright © 2024 Wazuh, Inc.';
 export const REPORTS_PAGE_HEADER_TEXT = 'info@wazuh.com\nhttps://wazuh.com';
 
 // Plugin platform

--- a/plugins/main/common/services/settings.test.ts
+++ b/plugins/main/common/services/settings.test.ts
@@ -43,10 +43,10 @@ describe('[settings] Methods', () => {
       ${false}             | ${'customization.logo.app'}       | ${'custom-image-app.png'} | ${''}
       ${false}             | ${'customization.logo.app'}       | ${''}                     | ${''}
       ${true}              | ${'customization.reports.footer'} | ${'Custom footer'}        | ${'Custom footer'}
-      ${true}              | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2023 Wazuh, Inc.'}
-      ${false}             | ${'customization.reports.footer'} | ${'Custom footer'}        | ${'Copyright © 2023 Wazuh, Inc.'}
-      ${false}             | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2023 Wazuh, Inc.'}
-      ${false}             | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2023 Wazuh, Inc.'}
+      ${true}              | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2024 Wazuh, Inc.'}
+      ${false}             | ${'customization.reports.footer'} | ${'Custom footer'}        | ${'Copyright © 2024 Wazuh, Inc.'}
+      ${false}             | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2024 Wazuh, Inc.'}
+      ${false}             | ${'customization.reports.footer'} | ${''}                     | ${'Copyright © 2024 Wazuh, Inc.'}
       ${true}              | ${'customization.reports.header'} | ${'Custom header'}        | ${'Custom header'}
       ${true}              | ${'customization.reports.header'} | ${''}                     | ${'info@wazuh.com\nhttps://wazuh.com'}
       ${false}             | ${'customization.reports.header'} | ${'Custom header'}        | ${'info@wazuh.com\nhttps://wazuh.com'}

--- a/plugins/main/server/routes/wazuh-reporting.test.ts
+++ b/plugins/main/server/routes/wazuh-reporting.test.ts
@@ -204,11 +204,11 @@ describe('[endpoint] PUT /utils/configuration', () => {
   // If any of the parameters is changed this variable should be updated with the new md5
   it.each`
     footer              | header                                 | responseStatusCode | expectedMD5                           | tab
-    ${null}             | ${null}                                | ${200}             | ${'301281824427c6ea8546fd14ee1aa5d8'} | ${'pm'}
+    ${null}             | ${null}                                | ${200}             | ${'5b5211a0514e36cc43d18d7d54cc4c35'} | ${'pm'}
     ${'Custom\nFooter'} | ${'info@company.com\nFake Avenue 123'} | ${200}             | ${'c2adfd7ab05ae3ed1548abd3c8be8f7e'} | ${'general'}
-    ${''}               | ${''}                                  | ${200}             | ${'06726f42a4129dd47262ea7228939006'} | ${'fim'}
+    ${''}               | ${''}                                  | ${200}             | ${'1b121407ad7748bbcc2f9973bafb2a85'} | ${'fim'}
     ${'Custom Footer'}  | ${null}                                | ${200}             | ${'1ea187181c307a4be5e90a38f614c42d'} | ${'aws'}
-    ${null}             | ${'Custom Header'}                     | ${200}             | ${'f2fc0804eb52ebca21291eb5a40dec35'} | ${'gcp'}
+    ${null}             | ${'Custom Header'}                     | ${200}             | ${'01fa7a09aba3aa99d4d56c915d733646'} | ${'gcp'}
   `(
     `Set custom report header and footer - Verify PDF output`,
     async ({ footer, header, responseStatusCode, expectedMD5, tab }) => {


### PR DESCRIPTION
### Description
This PR changes PDF report year number to 2024.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6491

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/c8349cf1-1f25-4a54-9a48-d1f6fffacbf9)


### Test
- Verify the PDF reports have 2024 as the year number

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
