### PR TITLE
Fix height of Home overview cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Moved the plugin menu to platform applications into the side menu [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840) [#6226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6226) [#6244](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6244) [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176) [#6423](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6423)
+- Moved the plugin menu to platform applications into the side menu [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840) [#6226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6226) [#6244](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6244) [#6176](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6176) [#6423](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6423) [#6510](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6510)
 - Changed dashboards. [#6035](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6035)
 - Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 - Upgraded the `axios` dependency to `1.6.1` [#6114](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6114)

--- a/plugins/main/public/components/common/welcome/overview-welcome.js
+++ b/plugins/main/public/components/common/welcome/overview-welcome.js
@@ -129,7 +129,7 @@ export const OverviewWelcome = compose(
                           <EuiFlexGrid columns={2}>
                             {apps.map(app => (
                               <EuiFlexItem key={app.id}>
-                                <RedirectAppLinks
+                                <RedirectAppLinks className='flex-redirect-app-links'
                                   application={getCore().application}
                                 >
                                   <EuiCard

--- a/plugins/main/public/components/common/welcome/welcome.scss
+++ b/plugins/main/public/components/common/welcome/welcome.scss
@@ -44,3 +44,8 @@
 span.statWithLink:hover {
   text-decoration: underline;
 }
+
+[name="OverviewWelcome"] .flex-redirect-app-links {
+  display: flex;
+  flex-grow: 1;
+}


### PR DESCRIPTION
### Description
This PR adds a class to the RedirectAppLinks component in the Home cards link to make the height even in each row.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6509

### Evidence
![screencapture-localhost-5601-app-wz-home-2024-03-13-18_13_30](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/da4a9763-f51a-49ea-bbf7-e9861de41e37)


### Test

- Go to the Home page
- Check each card's height is even in the category rows

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
