### PR TITLE
Fix wrong initial value editing an API connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.9.0
 - Added AngularJS dependencies [#6145](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6145)
 - Added a migration task to setup the configuration using a configuration file [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337)
-- Added the ability to manage the API hosts from the Server APIs [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337)
+- Added the ability to manage the API hosts from the Server APIs [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337) [#6519](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6519)
 - Added edit groups action to Endpoints Summary [#6250](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6250)
 - Added upgrade agent action to Endpoints Summary [#6476](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6476)
 - Added global actions add agents to groups and remove agents from groups to Endpoints Summary [#6274](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6274)

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -657,6 +657,7 @@ export const ApiTable = compose(
                       id: item.id,
                       url: item.url,
                       port: item.port,
+                      run_as: item.run_as,
                       username: item.username,
                       password: '',
                       password_confirm: '',


### PR DESCRIPTION
### Description
This pull request fixes a problem with the initial value when editing the API connection.
 
### Issues Resolved
#6201

### Evidence
Run as disabled as initial value:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/722de216-5b08-49f8-88db-3c87b683765c)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/f6265fcd-4f96-495d-928d-04e3d107a73d)

Run as enabled as initial value:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/d5503210-72fe-4fe7-b53c-70112cea9a38)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/08503448-41da-4240-9c5e-f87f284874fe)

### Test
# 6519-fix-run_as-edit-api-connection

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With a API connection with run_as disabled, click on the edit button, the Run as should display as false. | :black_circle: | :black_circle: | :black_circle: |
| With a API connection with run_as enabled, click on the edit button, the Run as should display as true. | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With a API connection with run_as disabled, click on the edit button, the Run as should display as false.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With a API connection with run_as enabled, click on the edit button, the Run as should display as true.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
