### PR TITLE
[Remove discover] Implement embeddable dashboard on Virustotal module

### DIFF
--- a/plugins/main/public/components/common/hocs/withPinnedAgent.tsx
+++ b/plugins/main/public/components/common/hocs/withPinnedAgent.tsx
@@ -1,0 +1,19 @@
+/*
+ * Wazuh app - React HOCs to manage allowed agents
+ * Copyright (C) 2015-2022 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import { ModulesHelper } from '../modules/modules-helper';
+
+export const withPinnedAgent = WrappedComponent => props => {
+  const pinnedAgent = ModulesHelper.getImplicitPinnedAgent('wazuh-alerts-*');
+  return <WrappedComponent {...props} pinnedAgent={pinnedAgent} />;
+};

--- a/plugins/main/public/components/common/modules/modules-defaults.js
+++ b/plugins/main/public/components/common/modules/modules-defaults.js
@@ -25,6 +25,7 @@ import { threatHuntingColumns } from '../wazuh-discover/config/data-grid-columns
 import { vulnerabilitiesColumns } from '../../overview/vulnerabilities/events/vulnerabilities-columns';
 import { DashboardFim } from '../../overview/fim/dashboard/dashboard';
 import { InventoryFim } from '../../overview/fim/inventory/inventory';
+import { DashboardVirustotal } from '../../overview/virustotal/dashboard/dashboard';
 import React from 'react';
 import { dockerColumns } from '../../overview/docker/events/docker-columns';
 import { googleCloudColumns } from '../../overview/google-cloud/events/google-cloud-columns';
@@ -43,6 +44,7 @@ import { virustotalColumns } from '../../overview/virustotal/events/virustotal-c
 import { malwareDetectionColumns } from '../../overview/malware-detection/events/malware-detection-columns';
 import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../common/constants';
 import { withVulnerabilitiesStateDataSource } from '../../overview/vulnerabilities/common/hocs/validate-vulnerabilities-states-index-pattern';
+import { withPinnedAgent } from '../hocs/withPinnedAgent';
 
 const DashboardTab = {
   id: 'dashboard',
@@ -253,9 +255,13 @@ export const ModulesDefaults = {
     availableFor: ['manager', 'agent'],
   },
   virustotal: {
-    init: 'dashboard',
     tabs: [
-      DashboardTab,
+      {
+        id: 'dashboard',
+        name: 'Dashboard',
+        buttons: [ButtonModuleExploreAgent, ButtonModuleGenerateReport],
+        component: withPinnedAgent(DashboardVirustotal),
+      },
       renderDiscoverTab(DEFAULT_INDEX_PATTERN, virustotalColumns),
     ],
     availableFor: ['manager', 'agent'],

--- a/plugins/main/public/components/overview/virustotal/components/no_results.tsx
+++ b/plugins/main/public/components/overview/virustotal/components/no_results.tsx
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
+
+import { EuiCallOut, EuiPanel } from '@elastic/eui';
+
+interface Props {
+  message?: string;
+}
+
+export const DiscoverNoResults = ({ message }: Props) => {
+  return (
+    <I18nProvider>
+      <EuiPanel hasBorder={false} hasShadow={false} color='transparent'>
+        <EuiCallOut
+          title={
+            message ?? (
+              <FormattedMessage
+                id='discover.noResults.searchExamples.noResultsMatchSearchCriteriaTitle'
+                defaultMessage='No results match your search criteria'
+              />
+            )
+          }
+          color='warning'
+          iconType='help'
+          data-test-subj='discoverNoResults'
+        />
+      </EuiPanel>
+    </I18nProvider>
+  );
+};

--- a/plugins/main/public/components/overview/virustotal/dashboard/dashboard.tsx
+++ b/plugins/main/public/components/overview/virustotal/dashboard/dashboard.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import { getPlugins } from '../../../../kibana-services';
+import { ViewMode } from '../../../../../../../src/plugins/embeddable/public';
+import { SearchResponse } from '../../../../../../../src/core/server';
+import { IndexPattern } from '../../../../../../../src/plugins/data/common';
+import { getDashboardPanels } from './dashboard_panels';
+import { I18nProvider } from '@osd/i18n/react';
+import useSearchBar from '../../../common/search-bar/use-search-bar';
+import { WAZUH_ALERTS_PATTERN } from '../../../../../common/constants';
+import { getKPIsPanel } from './dashboard_panels_kpis';
+import { Filter } from '../../../../../../../src/plugins/data/common';
+import { search } from '../../../common/search-bar/search-bar-service';
+import {
+  ErrorFactory,
+  ErrorHandler,
+  HttpError,
+} from '../../../../react-services/error-management';
+import { LoadingSpinner } from '../../vulnerabilities/common/components/loading_spinner';
+import { DiscoverNoResults } from '../components/no_results';
+import { withErrorBoundary } from '../../../common/hocs/error-boundary/with-error-boundary';
+import './virustotal_dashboard.scss';
+import { SampleDataWarning } from '../../../visualize/components/sample-data-warning';
+
+const plugins = getPlugins();
+
+const SearchBar = getPlugins().data.ui.SearchBar;
+
+const DashboardByRenderer = plugins.dashboard.DashboardContainerByValueRenderer;
+
+interface DashboardVTProps {
+  pinnedAgent: Filter;
+}
+
+const DashboardVT: React.FC<DashboardVTProps> = ({ pinnedAgent }) => {
+  /* TODO: Analyze whether to use the new index pattern handler https://github.com/wazuh/wazuh-dashboard-plugins/issues/6434
+  Replace WAZUH_ALERTS_PATTERN with appState.getCurrentPattern... */
+  const VT_INDEX_PATTERN_ID = WAZUH_ALERTS_PATTERN;
+
+  const { searchBarProps } = useSearchBar({
+    defaultIndexPatternID: VT_INDEX_PATTERN_ID,
+  });
+
+  const { isLoading, query, indexPatterns } = searchBarProps;
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+
+  const [results, setResults] = useState<SearchResponse>({} as SearchResponse);
+
+  useEffect(() => {
+    if (!isLoading) {
+      search({
+        indexPattern: indexPatterns?.[0] as IndexPattern,
+        filters: searchBarProps.filters ?? [],
+        query,
+      })
+        .then(results => {
+          setResults(results);
+          setIsSearching(false);
+        })
+        .catch(error => {
+          const searchError = ErrorFactory.create(HttpError, {
+            error,
+            message: 'Error fetching results',
+          });
+          ErrorHandler.handleError(searchError);
+          setIsSearching(false);
+        });
+    }
+  }, [JSON.stringify(searchBarProps)]);
+
+  return (
+    <>
+      <I18nProvider>
+        {isLoading ? <LoadingSpinner /> : null}
+        {!isLoading ? (
+          <SearchBar
+            appName='vt-searchbar'
+            {...searchBarProps}
+            showDatePicker={true}
+            showQueryInput={true}
+            showQueryBar={true}
+          />
+        ) : null}
+        {isSearching ? <LoadingSpinner /> : null}
+        {!isLoading && !isSearching && results?.hits?.total > 0 ? (
+          <SampleDataWarning />
+        ) : null}
+        {!isLoading && !isSearching && results?.hits?.total === 0 ? (
+          <DiscoverNoResults />
+        ) : null}
+        {!isLoading && !isSearching && results?.hits?.total > 0 ? (
+          <div className='th-dashboard-responsive'>
+            <DashboardByRenderer
+              input={{
+                viewMode: ViewMode.VIEW,
+                panels: getKPIsPanel(VT_INDEX_PATTERN_ID),
+                isFullScreenMode: false,
+                filters: searchBarProps.filters ?? [],
+                useMargins: true,
+                id: 'kpis-vt-dashboard-tab',
+                timeRange: {
+                  from: searchBarProps.dateRangeFrom,
+                  to: searchBarProps.dateRangeTo,
+                },
+                title: 'KPIs Virustotal dashboard',
+                description: 'KPIs Dashboard of the Virustotal',
+                query: searchBarProps.query,
+                refreshConfig: {
+                  pause: false,
+                  value: 15,
+                },
+                hidePanelTitles: true,
+              }}
+            />
+            <DashboardByRenderer
+              input={{
+                viewMode: ViewMode.VIEW,
+                panels: getDashboardPanels(VT_INDEX_PATTERN_ID, !!pinnedAgent),
+                isFullScreenMode: false,
+                filters: searchBarProps.filters ?? [],
+                useMargins: true,
+                id: 'vt-dashboard-tab',
+                timeRange: {
+                  from: searchBarProps.dateRangeFrom,
+                  to: searchBarProps.dateRangeTo,
+                },
+                title: 'Virustotal dashboard',
+                description: 'Dashboard of the Virustotal',
+                query: searchBarProps.query,
+                refreshConfig: {
+                  pause: false,
+                  value: 15,
+                },
+                hidePanelTitles: false,
+              }}
+            />
+          </div>
+        ) : null}
+      </I18nProvider>
+    </>
+  );
+};
+
+export const DashboardVirustotal = withErrorBoundary(DashboardVT);

--- a/plugins/main/public/components/overview/virustotal/dashboard/dashboard_panels.ts
+++ b/plugins/main/public/components/overview/virustotal/dashboard/dashboard_panels.ts
@@ -1,0 +1,989 @@
+import { DashboardPanelState } from '../../../../../../../../src/plugins/dashboard/public/application';
+import { EmbeddableInput } from '../../../../../../../../src/plugins/embeddable/public';
+
+/* WARNING: The panel id must be unique including general and agents visualizations. Otherwise, the visualizations will not refresh when we pin an agent, because they are cached by id */
+
+/* Overview visualizations */
+
+const getVisStateTop5UniqueMaliciousFilesPerAgent = (
+  indexPatternId: string,
+) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Malicious-Per-Agent',
+    title: 'Top 5 agents with unique malicious files',
+    type: 'pie',
+    params: {
+      type: 'pie',
+      addTooltip: true,
+      addLegend: true,
+      legendPosition: 'right',
+      isDonut: true,
+      labels: {
+        show: false,
+        values: true,
+        last_level: true,
+        truncate: 100,
+      },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: true,
+              disabled: false,
+              alias: null,
+              type: 'phrase',
+              key: 'data.virustotal.malicious',
+              value: '0',
+              params: {
+                query: '0',
+                type: 'phrase',
+              },
+            },
+            query: {
+              match: {
+                'data.virustotal.malicious': {
+                  query: '0',
+                  type: 'phrase',
+                },
+              },
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+        ],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'cardinality',
+          schema: 'metric',
+          params: { field: 'data.virustotal.source.md5' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'terms',
+          schema: 'segment',
+          params: {
+            field: 'agent.name',
+            size: 5,
+            order: 'desc',
+            orderBy: '1',
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateLastScannedFiles = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Last-Files-Pie',
+    title: 'Last scanned files',
+    type: 'pie',
+    params: {
+      type: 'pie',
+      addTooltip: true,
+      addLegend: true,
+      legendPosition: 'right',
+      isDonut: true,
+      labels: {
+        show: false,
+        values: true,
+        last_level: true,
+        truncate: 100,
+      },
+    },
+    uiState: {
+      vis: { legendOpen: true },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Files' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'terms',
+          schema: 'segment',
+          params: {
+            field: 'data.virustotal.source.file',
+            size: 5,
+            order: 'desc',
+            orderBy: '1',
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateAlertsEvolutionByAgents = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Alerts-Evolution',
+    title: 'Alerts evolution by agents',
+    type: 'histogram',
+    params: {
+      type: 'histogram',
+      grid: { categoryLines: false },
+      categoryAxes: [
+        {
+          id: 'CategoryAxis-1',
+          type: 'category',
+          position: 'bottom',
+          show: true,
+          style: {},
+          scale: { type: 'linear' },
+          labels: { show: true, filter: true, truncate: 100 },
+          title: {},
+        },
+      ],
+      valueAxes: [
+        {
+          id: 'ValueAxis-1',
+          name: 'LeftAxis-1',
+          type: 'value',
+          position: 'left',
+          show: true,
+          style: {},
+          scale: { type: 'linear', mode: 'normal' },
+          labels: { show: true, rotate: 0, filter: false, truncate: 100 },
+          title: { text: 'Count' },
+        },
+      ],
+      seriesParams: [
+        {
+          show: true,
+          type: 'histogram',
+          mode: 'stacked',
+          data: { label: 'Count', id: '1' },
+          valueAxis: 'ValueAxis-1',
+          drawLinesBetweenPoints: true,
+          lineWidth: 2,
+          showCircles: true,
+        },
+      ],
+      addTooltip: true,
+      addLegend: true,
+      legendPosition: 'right',
+      times: [],
+      addTimeMarker: false,
+      labels: { show: false },
+      thresholdLine: {
+        show: false,
+        value: 10,
+        width: 1,
+        style: 'full',
+        color: '#E7664C',
+      },
+      dimensions: {
+        x: {
+          accessor: 0,
+          format: { id: 'date', params: { pattern: 'YYYY-MM-DD HH:mm' } },
+          params: {
+            date: true,
+            interval: 'PT3H',
+            intervalOpenSearchValue: 3,
+            intervalOpenSearchUnit: 'h',
+            format: 'YYYY-MM-DD HH:mm',
+            bounds: {
+              min: '2020-04-17T12:11:35.943Z',
+              max: '2020-04-24T12:11:35.944Z',
+            },
+          },
+          label: 'timestamp per 3 hours',
+          aggType: 'date_histogram',
+        },
+        y: [
+          {
+            accessor: 2,
+            format: { id: 'number' },
+            params: {},
+            label: 'Count',
+            aggType: 'count',
+          },
+        ],
+        series: [
+          {
+            accessor: 1,
+            format: {
+              id: 'string',
+              params: {
+                parsedUrl: {
+                  origin: 'http://localhost:5601',
+                  pathname: '/app/kibana',
+                  basePath: '',
+                },
+              },
+            },
+            params: {},
+            label: 'Top 5 unusual terms in agent.name',
+            aggType: 'significant_terms',
+          },
+        ],
+      },
+      radiusRatio: 50,
+    },
+    uiState: {
+      vis: {
+        defaultColors: {
+          '0 - 7': 'rgb(247,251,255)',
+          '7 - 13': 'rgb(219,233,246)',
+          '13 - 20': 'rgb(187,214,235)',
+          '20 - 26': 'rgb(137,190,220)',
+          '26 - 33': 'rgb(83,158,205)',
+          '33 - 39': 'rgb(42,123,186)',
+          '39 - 45': 'rgb(11,85,159)',
+        },
+        legendOpen: true,
+      },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: false,
+              disabled: false,
+              alias: null,
+              type: 'exists',
+              key: 'data.virustotal.positives',
+              value: 'exists',
+            },
+            exists: {
+              field: 'data.virustotal.positives',
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: true,
+              disabled: false,
+              alias: null,
+              type: 'phrase',
+              key: 'data.virustotal.positives',
+              value: '0',
+              params: {
+                query: 0,
+                type: 'phrase',
+              },
+            },
+            query: {
+              match: {
+                'data.virustotal.positives': {
+                  query: 0,
+                  type: 'phrase',
+                },
+              },
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+        ],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: {},
+        },
+        {
+          id: '3',
+          enabled: true,
+          type: 'terms',
+          schema: 'group',
+          params: {
+            field: 'agent.name',
+            orderBy: '1',
+            order: 'desc',
+            size: 5,
+            otherBucket: false,
+            otherBucketLabel: 'Other',
+            missingBucket: false,
+            missingBucketLabel: 'Missing',
+          },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'date_histogram',
+          schema: 'segment',
+          params: {
+            field: 'timestamp',
+            timeRange: { from: 'now-7d', to: 'now' },
+            useNormalizedEsInterval: true,
+            scaleMetricValues: false,
+            interval: 'auto',
+            drop_partials: false,
+            min_doc_count: 1,
+            extended_bounds: {},
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateMaliciousFilesAlertsEvolution = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Malicious-Evolution',
+    title: 'Malicious files alerts evolution',
+    type: 'histogram',
+    params: {
+      type: 'histogram',
+      grid: { categoryLines: false, style: { color: '#eee' } },
+      categoryAxes: [
+        {
+          id: 'CategoryAxis-1',
+          type: 'category',
+          position: 'bottom',
+          show: true,
+          style: {},
+          scale: { type: 'linear' },
+          labels: { show: true, filter: true, truncate: 100 },
+          title: {},
+        },
+      ],
+      valueAxes: [
+        {
+          id: 'ValueAxis-1',
+          name: 'LeftAxis-1',
+          type: 'value',
+          position: 'left',
+          show: true,
+          style: {},
+          scale: { type: 'linear', mode: 'normal' },
+          labels: { show: true, rotate: 0, filter: false, truncate: 100 },
+          title: { text: 'Malicious' },
+        },
+      ],
+      seriesParams: [
+        {
+          show: 'true',
+          type: 'histogram',
+          mode: 'stacked',
+          data: { label: 'Malicious', id: '1' },
+          valueAxis: 'ValueAxis-1',
+          drawLinesBetweenPoints: true,
+          showCircles: true,
+        },
+      ],
+      addTooltip: true,
+      addLegend: false,
+      legendPosition: 'right',
+      times: [],
+      addTimeMarker: false,
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: false,
+              disabled: false,
+              alias: null,
+              type: 'exists',
+              key: 'data.virustotal.malicious',
+              value: 'exists',
+            },
+            exists: {
+              field: 'data.virustotal.malicious',
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: true,
+              disabled: false,
+              alias: null,
+              type: 'phrase',
+              key: 'data.virustotal.malicious',
+              value: '0',
+              params: {
+                query: 0,
+                type: 'phrase',
+              },
+            },
+            query: {
+              match: {
+                'data.virustotal.malicious': {
+                  query: 0,
+                  type: 'phrase',
+                },
+              },
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+        ],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Malicious' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'date_histogram',
+          schema: 'segment',
+          params: {
+            field: 'timestamp',
+            interval: 'auto',
+            customInterval: '2h',
+            min_doc_count: 1,
+            extended_bounds: {},
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateLastFiles = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Files-Table',
+    title: 'Last files',
+    type: 'table',
+    params: {
+      perPage: 10,
+      showPartialRows: false,
+      showMeticsAtAllLevels: false,
+      sort: { columnIndex: 2, direction: 'desc' },
+      showTotal: false,
+      showToolbar: true,
+      totalFunc: 'sum',
+    },
+    uiState: {
+      vis: { params: { sort: { columnIndex: 2, direction: 'desc' } } },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Count' },
+        },
+        {
+          id: '4',
+          enabled: true,
+          type: 'terms',
+          schema: 'bucket',
+          params: {
+            field: 'data.virustotal.source.file',
+            size: 10,
+            order: 'desc',
+            orderBy: '1',
+            customLabel: 'File',
+          },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'terms',
+          schema: 'bucket',
+          params: {
+            field: 'data.virustotal.permalink',
+            size: 1,
+            order: 'desc',
+            orderBy: '1',
+            customLabel: 'Link',
+          },
+        },
+      ],
+    },
+  };
+};
+
+/* Agent visualizations */
+
+const getVisStateAgentLastScannedFiles = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Agents-Virustotal-Last-Files-Pie',
+    title: 'Last scanned files',
+    type: 'pie',
+    params: {
+      type: 'pie',
+      addTooltip: true,
+      addLegend: true,
+      legendPosition: 'right',
+      isDonut: true,
+      labels: { show: false, values: true, last_level: true, truncate: 100 },
+    },
+    uiState: { vis: { legendOpen: true } },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Files' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'terms',
+          schema: 'segment',
+          params: {
+            field: 'data.virustotal.source.file',
+            size: 5,
+            order: 'desc',
+            orderBy: '1',
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateAgentMaliciousFilesAlertsEvolution = (
+  indexPatternId: string,
+) => {
+  return {
+    id: 'Wazuh-App-Agents-Virustotal-Malicious-Evolution',
+    title: 'Malicious files alerts Evolution',
+    type: 'histogram',
+    params: {
+      type: 'histogram',
+      grid: { categoryLines: false, style: { color: '#eee' } },
+      categoryAxes: [
+        {
+          id: 'CategoryAxis-1',
+          type: 'category',
+          position: 'bottom',
+          show: true,
+          style: {},
+          scale: { type: 'linear' },
+          labels: { show: true, filter: true, truncate: 100 },
+          title: {},
+        },
+      ],
+      valueAxes: [
+        {
+          id: 'ValueAxis-1',
+          name: 'LeftAxis-1',
+          type: 'value',
+          position: 'left',
+          show: true,
+          style: {},
+          scale: { type: 'linear', mode: 'normal' },
+          labels: { show: true, rotate: 0, filter: false, truncate: 100 },
+          title: { text: 'Malicious' },
+        },
+      ],
+      seriesParams: [
+        {
+          show: 'true',
+          type: 'histogram',
+          mode: 'stacked',
+          data: { label: 'Malicious', id: '1' },
+          valueAxis: 'ValueAxis-1',
+          drawLinesBetweenPoints: true,
+          showCircles: true,
+        },
+      ],
+      addTooltip: true,
+      addLegend: false,
+      legendPosition: 'right',
+      times: [],
+      addTimeMarker: false,
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: false,
+              disabled: false,
+              alias: null,
+              type: 'exists',
+              key: 'data.virustotal.positives',
+              value: 'exists',
+            },
+            exists: {
+              field: 'data.virustotal.positives',
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+          {
+            meta: {
+              index: 'wazuh-alerts',
+              negate: true,
+              disabled: false,
+              alias: null,
+              type: 'phrase',
+              key: 'data.virustotal.positives',
+              value: '0',
+              params: {
+                query: 0,
+                type: 'phrase',
+              },
+            },
+            query: {
+              match: {
+                'data.virustotal.positives': {
+                  query: 0,
+                  type: 'phrase',
+                },
+              },
+            },
+            $state: {
+              store: 'appState',
+            },
+          },
+        ],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Malicious' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'date_histogram',
+          schema: 'segment',
+          params: {
+            field: 'timestamp',
+            interval: 'auto',
+            customInterval: '2h',
+            min_doc_count: 1,
+            extended_bounds: {},
+          },
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateAgentLastFiles = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Agents-Virustotal-Files-Table',
+    title: 'Last files',
+    type: 'table',
+    params: {
+      perPage: 10,
+      showPartialRows: false,
+      showMeticsAtAllLevels: false,
+      sort: { columnIndex: 2, direction: 'desc' },
+      showTotal: false,
+      showToolbar: true,
+      totalFunc: 'sum',
+    },
+    uiState: {
+      vis: { params: { sort: { columnIndex: 2, direction: 'desc' } } },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: 'Count' },
+        },
+        {
+          id: '4',
+          enabled: true,
+          type: 'terms',
+          schema: 'bucket',
+          params: {
+            field: 'data.virustotal.source.file',
+            size: 10,
+            order: 'desc',
+            orderBy: '1',
+            customLabel: 'File',
+          },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'terms',
+          schema: 'bucket',
+          params: {
+            field: 'data.virustotal.permalink',
+            size: 1,
+            order: 'desc',
+            orderBy: '1',
+            missingBucket: true,
+            missingBucketLabel: '-',
+            customLabel: 'Link',
+          },
+        },
+      ],
+    },
+  };
+};
+
+/* Definitiion of panels */
+
+export const getDashboardPanels = (
+  indexPatternId: string,
+  pinnedAgent?: boolean,
+): {
+  [panelId: string]: DashboardPanelState<
+    EmbeddableInput & { [k: string]: unknown }
+  >;
+} => {
+  const pinnedAgentPanels = {
+    '6': {
+      gridData: {
+        w: 12,
+        h: 9,
+        x: 0,
+        y: 0,
+        i: '6',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '6',
+        savedVis: getVisStateAgentLastScannedFiles(indexPatternId),
+      },
+    },
+    '7': {
+      gridData: {
+        w: 36,
+        h: 9,
+        x: 12,
+        y: 0,
+        i: '7',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '7',
+        savedVis: getVisStateAgentMaliciousFilesAlertsEvolution(indexPatternId),
+      },
+    },
+    '8': {
+      gridData: {
+        w: 48,
+        h: 20,
+        x: 0,
+        y: 9,
+        i: '8',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '8',
+        savedVis: getVisStateAgentLastFiles(indexPatternId),
+      },
+    },
+  };
+
+  const panels = {
+    '1': {
+      gridData: {
+        w: 24,
+        h: 13,
+        x: 0,
+        y: 0,
+        i: '1',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '1',
+        savedVis: getVisStateTop5UniqueMaliciousFilesPerAgent(indexPatternId),
+      },
+    },
+    '2': {
+      gridData: {
+        w: 24,
+        h: 13,
+        x: 28,
+        y: 0,
+        i: '2',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '2',
+        savedVis: getVisStateLastScannedFiles(indexPatternId),
+      },
+    },
+    '3': {
+      gridData: {
+        w: 48,
+        h: 20,
+        x: 0,
+        y: 13,
+        i: '3',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '3',
+        savedVis: getVisStateAlertsEvolutionByAgents(indexPatternId),
+      },
+    },
+    '4': {
+      gridData: {
+        w: 48,
+        h: 9,
+        x: 0,
+        y: 23,
+        i: '4',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '4',
+        savedVis: getVisStateMaliciousFilesAlertsEvolution(indexPatternId),
+      },
+    },
+    '5': {
+      gridData: {
+        w: 48,
+        h: 20,
+        x: 0,
+        y: 32,
+        i: '5',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '5',
+        savedVis: getVisStateLastFiles(indexPatternId),
+      },
+    },
+  };
+
+  return pinnedAgent ? pinnedAgentPanels : panels;
+};

--- a/plugins/main/public/components/overview/virustotal/dashboard/dashboard_panels_kpis.ts
+++ b/plugins/main/public/components/overview/virustotal/dashboard/dashboard_panels_kpis.ts
@@ -1,0 +1,304 @@
+import { DashboardPanelState } from '../../../../../../../../src/plugins/dashboard/public/application';
+import { EmbeddableInput } from '../../../../../../../../src/plugins/embeddable/public';
+
+const getVisStateTotalMalicious = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Total-Malicious',
+    title: 'Total Malicious',
+    type: 'metric',
+    params: {
+      addTooltip: true,
+      addLegend: false,
+      type: 'metric',
+      metric: {
+        percentageMode: false,
+        useRanges: false,
+        colorSchema: 'Reds',
+        metricColorMode: 'Labels',
+        colorsRange: [
+          {
+            from: 0,
+            to: 0,
+          },
+          {
+            from: 0,
+            to: 0,
+          },
+        ],
+        labels: {
+          show: true,
+        },
+        invertColors: false,
+        style: {
+          bgFill: '#000',
+          bgColor: false,
+          labelColor: false,
+          subText: '',
+          fontSize: 40,
+        },
+      },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: ' ' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'filters',
+          params: {
+            filters: [
+              {
+                input: {
+                  query: 'data.virustotal.malicious: 1',
+                  language: 'kuery',
+                },
+                label: '- Total malicious',
+              },
+            ],
+          },
+          schema: 'group',
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateTotalPositives = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Total-Positives',
+    title: 'Total Positives',
+    type: 'metric',
+    params: {
+      addTooltip: true,
+      addLegend: false,
+      type: 'metric',
+      metric: {
+        percentageMode: false,
+        useRanges: false,
+        colorSchema: 'Greens',
+        metricColorMode: 'Labels',
+        colorsRange: [
+          {
+            from: 0,
+            to: 0,
+          },
+          {
+            from: 0,
+            to: 0,
+          },
+        ],
+        labels: {
+          show: true,
+        },
+        invertColors: false,
+        style: {
+          bgFill: '#000',
+          bgColor: false,
+          labelColor: false,
+          subText: '',
+          fontSize: 40,
+        },
+      },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: ' ' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'filters',
+          params: {
+            filters: [
+              {
+                input: {
+                  query: 'data.virustotal.positives: *',
+                  language: 'kuery',
+                },
+                label: '- Total Positives',
+              },
+            ],
+          },
+          schema: 'group',
+        },
+      ],
+    },
+  };
+};
+
+const getVisStateTotal = (indexPatternId: string) => {
+  return {
+    id: 'Wazuh-App-Overview-Virustotal-Total',
+    title: 'Total',
+    type: 'metric',
+    params: {
+      addTooltip: true,
+      addLegend: false,
+      type: 'metric',
+      metric: {
+        percentageMode: false,
+        useRanges: false,
+        colorSchema: 'Greens',
+        metricColorMode: 'Labels',
+        colorsRange: [
+          {
+            from: 0,
+            to: 0,
+          },
+          {
+            from: 0,
+            to: 0,
+          },
+        ],
+        labels: {
+          show: true,
+        },
+        invertColors: false,
+        style: {
+          bgFill: '#000',
+          bgColor: false,
+          labelColor: false,
+          subText: '',
+          fontSize: 40,
+        },
+      },
+    },
+    data: {
+      searchSource: {
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        filter: [],
+        index: indexPatternId,
+      },
+      references: [
+        {
+          name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+          type: 'index-pattern',
+          id: indexPatternId,
+        },
+      ],
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          schema: 'metric',
+          params: { customLabel: ' ' },
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'filters',
+          params: {
+            filters: [
+              {
+                input: {
+                  query: 'data.virustotal:*',
+                  language: 'kuery',
+                },
+                label: '- Total',
+              },
+            ],
+          },
+          schema: 'group',
+        },
+      ],
+    },
+  };
+};
+
+export const getKPIsPanel = (
+  indexPatternId: string,
+): {
+  [panelId: string]: DashboardPanelState<
+    EmbeddableInput & { [k: string]: unknown }
+  >;
+} => {
+  return {
+    '1': {
+      gridData: {
+        w: 12,
+        h: 6,
+        x: 6,
+        y: 0,
+        i: '1',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '1',
+        savedVis: getVisStateTotalMalicious(indexPatternId),
+      },
+    },
+    '2': {
+      gridData: {
+        w: 12,
+        h: 6,
+        x: 18,
+        y: 0,
+        i: '2',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '2',
+        savedVis: getVisStateTotalPositives(indexPatternId),
+      },
+    },
+    '3': {
+      gridData: {
+        w: 12,
+        h: 6,
+        x: 30,
+        y: 0,
+        i: '3',
+      },
+      type: 'visualization',
+      explicitInput: {
+        id: '3',
+        savedVis: getVisStateTotal(indexPatternId),
+      },
+    },
+  };
+};

--- a/plugins/main/public/components/overview/virustotal/dashboard/virustotal_dashboard.scss
+++ b/plugins/main/public/components/overview/virustotal/dashboard/virustotal_dashboard.scss
@@ -1,0 +1,10 @@
+.vt-dashboard-responsive {
+  @media (max-width: 767px) {
+    .react-grid-layout {
+      height: auto !important;
+    }
+    .dshLayout-isMaximizedPanel {
+      height: 100% !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description
This pull request implement the embeddable dashboard on Virustotal -> dashboard tab and deprecate any use of kibana-integrations components.
 
## Issues Resolved
- #6511 

## Evidence

[Evidence_updates.webm](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/143de00b-65d4-40c3-a710-dcd1a7928dff)

## Test
Go to Virustotal and check the following:
- [ ] Each visualization, if applicable, must have interaction so that it adds the corresponding filter(s) upon clicking.
- [ ] The visualizations have to be updated according to the filters applied in the searchbar.
- [ ] The visualizations have to be updated when a search is performed in the searchbar.
- [ ] If there are no results, the corresponding message must appear that there are no results and the visualizations should not be rendered.
- [ ] If there is SampleData, the corresponding SampleData message must appear.
- [ ] If an agent is pinned, the views must be updated and changed to the agent view, if applicable.  

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
