### PR TITLE
Change vulnerabilities dashboard

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -113,6 +113,29 @@ const DashboardVulsComponent: React.FC = () => {
           ) : null}
           {!isLoading && !isSearching && results?.hits?.total > 0 ? (
             <div className='vulnerability-dashboard-responsive'>
+              <DashboardByRenderer
+                input={{
+                  viewMode: ViewMode.VIEW,
+                  panels: getKPIsPanel(VULNERABILITIES_INDEX_PATTERN_ID),
+                  isFullScreenMode: false,
+                  filters: fetchFilters ?? [],
+                  useMargins: true,
+                  id: 'kpis-vulnerability-detector-dashboard-tab',
+                  timeRange: {
+                    from: searchBarProps.dateRangeFrom,
+                    to: searchBarProps.dateRangeTo,
+                  },
+                  title: 'KPIs Vulnerability detector dashboard',
+                  description: 'KPIs Dashboard of the Vulnerability detector',
+                  query: searchBarProps.query,
+                  refreshConfig: {
+                    pause: false,
+                    value: 15,
+                  },
+                  hidePanelTitles: true,
+                }}
+                onInputUpdated={handleFilterByVisualization}
+              />
               <div className='vulnerability-dashboard-filters-wrapper'>
                 <DashboardByRenderer
                   input={{
@@ -141,29 +164,6 @@ const DashboardVulsComponent: React.FC = () => {
                   onInputUpdated={handleFilterByVisualization}
                 />
               </div>
-              <DashboardByRenderer
-                input={{
-                  viewMode: ViewMode.VIEW,
-                  panels: getKPIsPanel(VULNERABILITIES_INDEX_PATTERN_ID),
-                  isFullScreenMode: false,
-                  filters: fetchFilters ?? [],
-                  useMargins: true,
-                  id: 'kpis-vulnerability-detector-dashboard-tab',
-                  timeRange: {
-                    from: searchBarProps.dateRangeFrom,
-                    to: searchBarProps.dateRangeTo,
-                  },
-                  title: 'KPIs Vulnerability detector dashboard',
-                  description: 'KPIs Dashboard of the Vulnerability detector',
-                  query: searchBarProps.query,
-                  refreshConfig: {
-                    pause: false,
-                    value: 15,
-                  },
-                  hidePanelTitles: true,
-                }}
-                onInputUpdated={handleFilterByVisualization}
-              />
               <DashboardByRenderer
                 input={{
                   viewMode: ViewMode.VIEW,

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
@@ -401,7 +401,8 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
           enabled: true,
           type: 'date_histogram',
           params: {
-            field: '@timestamp',
+            field: 'wazuh.published_at',
+            customLabel: 'Published at',
             timeRange: {
               from: 'now-24h',
               to: 'now',

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
@@ -401,7 +401,7 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
           enabled: true,
           type: 'date_histogram',
           params: {
-            field: 'wazuh.published_at',
+            field: 'vulnerability.published_at',
             customLabel: 'Published at',
             timeRange: {
               from: 'now-24h',

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels_filters.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels_filters.ts
@@ -86,31 +86,31 @@ export const getDashboardFilters = (
   >;
 } => {
   return {
-    topPackageSelector: {
+    topVulnerabilities: {
       gridData: {
-        w: 12,
+        w: 9,
         h: 12,
         x: 0,
         y: 0,
-        i: 'topPackageSelector',
+        i: 'topVulnerabilities',
       },
       type: 'visualization',
       explicitInput: {
-        id: 'topPackageSelector',
+        id: 'topVulnerabilities',
         savedVis: getVisStateFilter(
-          'topPackageSelector',
+          'topVulnerabilities',
           indexPatternId,
-          'Top packages vulnerabilities',
-          'Top 5 packages',
-          'package.name',
+          'Top vulnerabilities',
+          'Top 5 vulnerabilities',
+          'vulnerability.id',
         ),
       },
     },
     topOSVulnerabilities: {
       gridData: {
-        w: 12,
+        w: 15,
         h: 12,
-        x: 12,
+        x: 9,
         y: 0,
         i: 'topOSVulnerabilities',
       },
@@ -128,7 +128,7 @@ export const getDashboardFilters = (
     },
     topAgentVulnerabilities: {
       gridData: {
-        w: 12,
+        w: 15,
         h: 12,
         x: 24,
         y: 0,
@@ -146,23 +146,23 @@ export const getDashboardFilters = (
         ),
       },
     },
-    topVulnerabilities: {
+    topPackageSelector: {
       gridData: {
-        w: 12,
+        w: 9,
         h: 12,
-        x: 36,
+        x: 39,
         y: 0,
-        i: 'topVulnerabilities',
+        i: 'topPackageSelector',
       },
       type: 'visualization',
       explicitInput: {
-        id: 'topVulnerabilities',
+        id: 'topPackageSelector',
         savedVis: getVisStateFilter(
-          'topVulnerabilities',
+          'topPackageSelector',
           indexPatternId,
-          'Top vulnerabilities',
-          'Top 5 vulnerabilities',
-          'vulnerability.id',
+          'Top packages vulnerabilities',
+          'Top 5 packages',
+          'package.name',
         ),
       },
     },

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels_kpis.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels_kpis.ts
@@ -60,7 +60,7 @@ const getVisStateSeverityCritical = (indexPatternId: string) => {
           enabled: true,
           type: 'count',
           params: {
-            customLabel: ' ',
+            customLabel: 'Critical',
           },
           schema: 'metric',
         },
@@ -75,7 +75,7 @@ const getVisStateSeverityCritical = (indexPatternId: string) => {
                   query: 'vulnerability.severity:"Critical"',
                   language: 'kuery',
                 },
-                label: '- Critical severity alerts',
+                label: 'Severity',
               },
             ],
           },
@@ -126,7 +126,7 @@ const getVisStateSeverityHigh = (indexPatternId: string) => {
     uiState: {
       vis: {
         colors: {
-          'High Severity Alerts - Count': '#38D1BA',
+          'High Severity - Count': '#38D1BA',
         },
       },
     },
@@ -152,7 +152,7 @@ const getVisStateSeverityHigh = (indexPatternId: string) => {
           enabled: true,
           type: 'count',
           params: {
-            customLabel: ' ',
+            customLabel: 'High',
           },
           schema: 'metric',
         },
@@ -167,7 +167,7 @@ const getVisStateSeverityHigh = (indexPatternId: string) => {
                   query: 'vulnerability.severity:"High"',
                   language: 'kuery',
                 },
-                label: '- High severity alerts',
+                label: 'Severity',
               },
             ],
           },
@@ -237,7 +237,7 @@ const getVisStateSeverityMedium = (indexPatternId: string) => {
           enabled: true,
           type: 'count',
           params: {
-            customLabel: ' ',
+            customLabel: 'Medium',
           },
           schema: 'metric',
         },
@@ -252,7 +252,7 @@ const getVisStateSeverityMedium = (indexPatternId: string) => {
                   query: 'vulnerability.severity:"Medium"',
                   language: 'kuery',
                 },
-                label: '- Medium severity alerts',
+                label: 'Severity',
               },
             ],
           },
@@ -322,7 +322,7 @@ const getVisStateSeverityLow = (indexPatternId: string) => {
           enabled: true,
           type: 'count',
           params: {
-            customLabel: ' ',
+            customLabel: 'Low',
           },
           schema: 'metric',
         },
@@ -337,7 +337,7 @@ const getVisStateSeverityLow = (indexPatternId: string) => {
                   query: 'vulnerability.severity:"Low"',
                   language: 'kuery',
                 },
-                label: '- Low severity alerts',
+                label: 'Severity',
               },
             ],
           },

--- a/scripts/vulnerabilities-events-injector/DIS_Template.json
+++ b/scripts/vulnerabilities-events-injector/DIS_Template.json
@@ -13,9 +13,6 @@
       }
     ],
     "properties": {
-      "@timestamp": {
-        "type": "date"
-      },
       "agent": {
         "properties": {
           "build": {
@@ -239,6 +236,9 @@
               }
             }
           },
+          "detected_at": {
+            "type": "date"
+          },
           "manager": {
             "properties": {
               "name": {
@@ -246,6 +246,9 @@
                 "type": "keyword"
               }
             }
+          },
+          "published_at": {
+            "type": "date"
           },
           "node": {
             "properties": {

--- a/scripts/vulnerabilities-events-injector/DIS_Template.json
+++ b/scripts/vulnerabilities-events-injector/DIS_Template.json
@@ -179,6 +179,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "detected_at": {
+            "type": "date"
+          },
           "enumeration": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -186,6 +189,9 @@
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "published_at": {
+            "type": "date"
           },
           "reference": {
             "ignore_above": 1024,
@@ -236,9 +242,6 @@
               }
             }
           },
-          "detected_at": {
-            "type": "date"
-          },
           "manager": {
             "properties": {
               "name": {
@@ -246,9 +249,6 @@
                 "type": "keyword"
               }
             }
-          },
-          "published_at": {
-            "type": "date"
           },
           "node": {
             "properties": {

--- a/scripts/vulnerabilities-events-injector/dataInjectScript.py
+++ b/scripts/vulnerabilities-events-injector/dataInjectScript.py
@@ -115,13 +115,13 @@ def generateRandomVulnerability():
     vulnerability['scanner'] = {'vendor':'vendor-{}'.format(random.randint(0, 9))}
     vulnerability['score'] = {'base':round(random.uniform(0, 10),1), 'environmental':round(random.uniform(0, 10),1), 'temporal':round(random.uniform(0, 10),1),'version':'{}'.format(round(random.uniform(0, 10),1))}
     vulnerability['severity'] = random.choice(['Low','Medium','High','Critical'])
+    vulnerability['published_at'] = generateRandomDate()
+    vulnerability['detected_at'] = generateRandomDate()
     return(vulnerability)
 
 def generateRandomWazuh():
     wazuh = {}
     wazuh['cluster'] = {'name':random.choice(['wazuh.manager', 'wazuh']), 'node':random.choice(['master','worker-01','worker-02','worker-03'])}
-    wazuh['published_at'] = generateRandomDate()
-    wazuh['detected_at'] = generateRandomDate()
     return(wazuh)
 
 def generateRandomData(number):

--- a/scripts/vulnerabilities-events-injector/dataInjectScript.py
+++ b/scripts/vulnerabilities-events-injector/dataInjectScript.py
@@ -120,12 +120,13 @@ def generateRandomVulnerability():
 def generateRandomWazuh():
     wazuh = {}
     wazuh['cluster'] = {'name':random.choice(['wazuh.manager', 'wazuh']), 'node':random.choice(['master','worker-01','worker-02','worker-03'])}
+    wazuh['published_at'] = generateRandomDate()
+    wazuh['detected_at'] = generateRandomDate()
     return(wazuh)
 
 def generateRandomData(number):
     for i in range(0, int(number)):
         yield{
-            '@timestamp':generateRandomDate(),
             'agent':generateRandomAgent(),
             'ecs':{'version':'1.7.0'},
             'host':generateRandomHost(),


### PR DESCRIPTION
### Description
This pull request makes additional changes to the Vulnerabilities dashboard as part of another refinement iteration.
 
### Issues Resolved
Closes #6533 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/209dff79-e83a-4509-8a75-ee03a4b92491)



### Test
- The severity KPIs must be placed in the first row of the dashboard
- The filter tables must be placed in the second row of the dashboard
- The filter tables order must be: Top 5 vulnerabilities, Top 5 OS, Top 5 agents, Top 5 packages
- The Top 5 OS, Top 5 agents tables must be wider than the Top 5 vulnerabilities, Top 5 packages tables
- We have to remove the word alerts and hyphens from the KPIs
- We must change the @timestamp field used in the Accumulation of the most detected vulnerabilities visualization for the new field published_at

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
