### PR TITLE
Fix view rule alert link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the axis label visual bug from dashboards [#6378](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6378)
 - Fixed a error pop-up spawn in MITRE ATT&CK [#6431](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6431)
 - Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484) [#6489](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6489)
+- Fixed "View alerts of this Rule" link [#6553](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6553)
 
 ### Removed
 

--- a/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
+++ b/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
@@ -752,7 +752,7 @@ export default class WzRuleInfo extends Component {
                 iconType='popout'
                 aria-label='popout'
                 href={getCore().application.getUrlForApp(threatHunting.id, {
-                  path: `#/overview?tab=general&tabView=panels&addRuleFilter=${id}`,
+                  path: `#/overview/?tab=general&tabView=panels&addRuleFilter=${id}`,
                 })}
                 target='blank'
               >


### PR DESCRIPTION
### Description
This pull request fixes the path of the **_"View alerts of this rule"_** so it pre-filters the rule ID in the Threat hunting view.
 
### Issues Resolved
Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/6551

### Evidence

Link:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/4f967388-d70a-4703-9444-610e85eb3cd0)

Applied filter:
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/8a2bf4ad-c65d-421b-ae81-6d1a426162f2)


### Test
- Go to Server management -> Rules
- Click on a rule row to display de details flyout
- Click on the top right link **_"View alerts of this rule"_**
- Check it opens a new tab in Threat hunting with the rule ID pre-applied filter

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
