### PR TITLE
Refine malware detection dashboard

### DIFF
--- a/plugins/main/public/components/visualize/visualizations.js
+++ b/plugins/main/public/components/visualize/visualizations.js
@@ -781,8 +781,8 @@ export const visualizations = {
         height: 300,
         vis: [
           {
-            title: 'Emotet malware activity',
-            id: 'Wazuh-App-Overview-PM-Emotet-Malware-Activity',
+            title: 'Malware activity',
+            id: 'Wazuh-App-Overview-PM-Malware-Activity',
             width: 30,
           },
           {
@@ -792,9 +792,8 @@ export const visualizations = {
           },
         ],
       },
-
       {
-        height: 400,
+        height: 560,
         vis: [
           {
             title: 'Security alerts',

--- a/plugins/main/server/integration-files/visualizations/overview/overview-pm.ts
+++ b/plugins/main/server/integration-files/visualizations/overview/overview-pm.ts
@@ -11,12 +11,12 @@
  */
 export default [
   {
-    _id: 'Wazuh-App-Overview-PM-Emotet-Malware-Activity',
+    _id: 'Wazuh-App-Overview-PM-Malware-Activity',
     _type: 'visualization',
     _source: {
-      title: 'Emotet malware activity',
+      title: 'Malware activity',
       visState: JSON.stringify({
-        title: 'Emotet malware activity',
+        title: 'Malware activity',
         type: 'area',
         aggs: [
           {
@@ -418,40 +418,6 @@ export default [
             enabled: true,
             type: 'terms',
             params: {
-              field: 'rule.mitre.id',
-              orderBy: '_key',
-              order: 'desc',
-              size: 5,
-              otherBucket: false,
-              otherBucketLabel: 'Other',
-              missingBucket: false,
-              missingBucketLabel: 'Missing',
-              customLabel: 'rule.mitre.id',
-            },
-            schema: 'bucket',
-          },
-          {
-            id: '5',
-            enabled: true,
-            type: 'terms',
-            params: {
-              field: 'rule.mitre.tactic',
-              orderBy: '_key',
-              order: 'desc',
-              size: 5,
-              otherBucket: false,
-              otherBucketLabel: 'Other',
-              missingBucket: false,
-              missingBucketLabel: 'Missing',
-              customLabel: 'rule.mitre.tactic',
-            },
-            schema: 'bucket',
-          },
-          {
-            id: '6',
-            enabled: true,
-            type: 'terms',
-            params: {
               field: 'rule.description',
               orderBy: '_key',
               order: 'desc',
@@ -465,7 +431,7 @@ export default [
             schema: 'bucket',
           },
           {
-            id: '7',
+            id: '5',
             enabled: true,
             type: 'terms',
             params: {
@@ -482,7 +448,7 @@ export default [
             schema: 'bucket',
           },
           {
-            id: '8',
+            id: '6',
             enabled: true,
             type: 'terms',
             params: {
@@ -509,7 +475,28 @@ export default [
           row: false,
         },
       }),
-      uiStateJSON: '{}',
+      uiStateJSON: JSON.stringify({
+        vis: {
+          columnsWidth: [
+            {
+              colIndex: 0,
+              width: 200,
+            },
+            {
+              colIndex: 3,
+              width: 100,
+            },
+            {
+              colIndex: 4,
+              width: 100,
+            },
+            {
+              colIndex: 5,
+              width: 100,
+            },
+          ],
+        },
+      }),
       description: '',
       version: 1,
       kibanaSavedObjectMeta: {


### PR DESCRIPTION
### Description
This pull request changes the top left visualization label from **Emotet malware activity** to **Malware activity** and removes the fields `rule.mitre.tactic` and `rule.mitre.id` in the lower table.
It also adds an enhancement with custom widths for columns with a known short data length: Time; Rule level; Rule ID; Count
 
### Issues Resolved
Closes #6552 

### Evidence
![screencapture-localhost-5601-app-malware-detection-2024-03-26-14_45_59](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/f46e3bfc-c4bf-4dbb-8c42-644531167aaa)


### Test
- Go to Malware detection
- Check the top left visualization label says "Malware activity"
- Check the bottom table doesn't have any `rule.mitre` field

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] ~~Update [CHANGELOG.md](./../CHANGELOG.md)~~
- [x] Commits are signed per the DCO using --signoff 
