### PR TITLE
Create published vulnerabilities severity visualization

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
@@ -269,11 +269,11 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
   indexPatternId: string,
 ) => {
   return {
-    id: 'accumulation_most_vulnerable_vulnerabilities',
-    title: 'Accumulation of the most detected vulnerabilities',
-    type: 'line',
+    id: 'published_vulnerabilities_severity',
+    title: 'Published vulnerabilities severity',
+    type: 'histogram',
     params: {
-      type: 'line',
+      type: 'histogram',
       grid: {
         categoryLines: false,
       },
@@ -304,8 +304,9 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
           show: true,
           style: {},
           scale: {
-            type: 'linear',
+            type: 'log',
             mode: 'normal',
+            defaultYExtents: true,
           },
           labels: {
             show: true,
@@ -321,16 +322,15 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
       seriesParams: [
         {
           show: true,
-          type: 'line',
-          mode: 'normal',
+          type: 'histogram',
+          mode: 'stacked',
           data: {
             label: 'Count',
             id: '1',
           },
           valueAxis: 'ValueAxis-1',
-          drawLinesBetweenPoints: false,
+          drawLinesBetweenPoints: true,
           lineWidth: 2,
-          interpolate: 'linear',
           showCircles: true,
         },
       ],
@@ -339,7 +339,9 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
       legendPosition: 'right',
       times: [],
       addTimeMarker: false,
-      labels: {},
+      labels: {
+        show: false,
+      },
       thresholdLine: {
         show: false,
         value: 10,
@@ -347,7 +349,6 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
         style: 'full',
         color: '#E7664C',
       },
-      radiusRatio: 20,
     },
     data: {
       searchSource: {
@@ -376,48 +377,37 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
         {
           id: '2',
           enabled: true,
-          type: 'count',
-          params: {},
-          schema: 'radius',
-        },
-        {
-          id: '4',
-          enabled: true,
-          type: 'terms',
-          params: {
-            field: 'vulnerability.id',
-            orderBy: '1',
-            order: 'desc',
-            size: 5,
-            otherBucket: false,
-            otherBucketLabel: 'Others',
-            missingBucket: false,
-            missingBucketLabel: 'Missing',
-          },
-          schema: 'group',
-        },
-        {
-          id: '3',
-          enabled: true,
           type: 'date_histogram',
           params: {
             field: 'vulnerability.published_at',
-            customLabel: 'Published at',
             timeRange: {
               from: 'now-24h',
               to: 'now',
             },
             useNormalizedOpenSearchInterval: true,
             scaleMetricValues: false,
-            interval: 'w',
-            // eslint-disable-next-line camelcase
+            interval: 'y',
             drop_partials: false,
-            // eslint-disable-next-line camelcase
             min_doc_count: 1,
-            // eslint-disable-next-line camelcase
             extended_bounds: {},
           },
           schema: 'segment',
+        },
+        {
+          id: '3',
+          enabled: true,
+          type: 'terms',
+          params: {
+            field: 'vulnerability.severity',
+            orderBy: '1',
+            order: 'desc',
+            size: 5,
+            otherBucket: false,
+            otherBucketLabel: 'Other',
+            missingBucket: false,
+            missingBucketLabel: 'Missing',
+          },
+          schema: 'group',
         },
       ],
     },


### PR DESCRIPTION
### Description
This pull request redesigns "Accumulation of the most detected vulnerabilities" visualization located in the Vulnerabilities dashboard to make it easier for the user to evaluate the oldest and most sever vulnerabilities. This helps come to conclusions about the overall health of a cluster.
 
### Issues Resolved
Closes #6581

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
- Go to Vulnerability Detection -> Dashboard
- Check the visualization shows `vulnerability.published_at` per year segregated by severity

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
