### PR TITLE
Add only active agents guard for configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484) [#6489](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6489)
 - Fixed "View alerts of this Rule" link [#6553](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6553)
 - Fixed minor color styles [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6587)
+- Fixed disconnected agent configuration error [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6617)
 
 ### Removed
 

--- a/plugins/main/public/controllers/management/components/management/configuration/configuration-switch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/configuration-switch.js
@@ -82,7 +82,7 @@ import { UI_ERROR_SEVERITIES } from '../../../../../react-services/error-orchest
 import { getErrorOrchestrator } from '../../../../../react-services/common-services';
 import { WzConfigurationOffice365 } from './office365/office365';
 import { getCore } from '../../../../../kibana-services';
-import { PromptAgentNeverConnected } from '../../../../../components/agents/prompts';
+import { PromptNoActiveAgentWithoutSelect } from '../../../../../components/agents/prompts';
 import { RedirectAppLinks } from '../../../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { endpointGroups } from '../../../../../utils/applications';
 
@@ -501,8 +501,8 @@ export default compose(
         ],
   ]), //TODO: this need cluster:read permission but manager/cluster is managed in WzConfigurationSwitch component
   withRenderIfOrWrapped(
-    props => props.agent.status === API_NAME_AGENT_STATUS.NEVER_CONNECTED,
-    PromptAgentNeverConnected,
+    props => props.agent.status !== API_NAME_AGENT_STATUS.ACTIVE,
+    PromptNoActiveAgentWithoutSelect,
   ),
   connect(mapStateToProps, mapDispatchToProps),
 )(WzConfigurationSwitch);

--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
@@ -34,8 +34,6 @@ class WzConfigurationIntegrityMonitoring extends Component {
     super(props);
   }
   componentDidMount() {
-    if (!isString(this.props.currentConfig['syscheck-syscheck']))
-      this.props.currentConfig['syscheck-syscheck'].syscheck.disabled = 'no';
     this.props.updateBadge(this.badgeEnabled());
   }
   badgeEnabled() {

--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
@@ -16,7 +16,7 @@ import withWzConfig from '../util-hocs/wz-config';
 import WzNoConfig from '../util-components/no-config';
 import { isString } from '../utils/utils';
 import WzTabSelector, {
-  WzTabSelectorTab
+  WzTabSelectorTab,
 } from '../util-components/tab-selector';
 import helpLinks from './help-links';
 
@@ -34,15 +34,14 @@ class WzConfigurationIntegrityMonitoring extends Component {
     super(props);
   }
   componentDidMount() {
-    this.props.currentConfig['syscheck-syscheck'].syscheck.disabled = 'no';
+    if (!isString(this.props.currentConfig['syscheck-syscheck']))
+      this.props.currentConfig['syscheck-syscheck'].syscheck.disabled = 'no';
     this.props.updateBadge(this.badgeEnabled());
   }
   badgeEnabled() {
     return (
-      this.props.currentConfig['syscheck-syscheck'] &&
-      this.props.currentConfig['syscheck-syscheck'].syscheck &&
-      this.props.currentConfig['syscheck-syscheck'].syscheck.disabled &&
-      this.props.currentConfig['syscheck-syscheck'].syscheck.disabled === 'no'
+      this.props.currentConfig?.['syscheck-syscheck']?.syscheck?.disabled ===
+      'no'
     );
   }
 
@@ -61,43 +60,44 @@ class WzConfigurationIntegrityMonitoring extends Component {
         {currentConfig['syscheck-syscheck'] &&
           !isString(currentConfig['syscheck-syscheck']) &&
           !currentConfig['syscheck-syscheck'].syscheck && (
-            <WzNoConfig error="not-present" help={helpLinks} />
+            <WzNoConfig error='not-present' help={helpLinks} />
           )}
         {currentConfig['syscheck-syscheck'] &&
           !isString(currentConfig['syscheck-syscheck']) &&
           currentConfig['syscheck-syscheck'].syscheck && (
             <WzTabSelector>
-              <WzTabSelectorTab label="General">
+              <WzTabSelectorTab label='General'>
                 <WzConfigurationIntegrityMonitoringGeneral {...this.props} />
               </WzTabSelectorTab>
-              <WzTabSelectorTab label="Monitored">
+              <WzTabSelectorTab label='Monitored'>
                 <WzConfigurationIntegrityMonitoringMonitored {...this.props} />
               </WzTabSelectorTab>
-              <WzTabSelectorTab label="Ignored">
+              <WzTabSelectorTab label='Ignored'>
                 <WzConfigurationIntegrityMonitoringIgnored {...this.props} />
               </WzTabSelectorTab>
-              <WzTabSelectorTab label="No diff">
+              <WzTabSelectorTab label='No diff'>
                 <WzConfigurationIntegrityMonitoringNoDiff {...this.props} />
               </WzTabSelectorTab>
               {agentPlatform !== 'windows' && (
-                <WzTabSelectorTab label="Who-data">
+                <WzTabSelectorTab label='Who-data'>
                   <WzConfigurationIntegrityMonitoringWhoData {...this.props} />
                 </WzTabSelectorTab>
               )}
-              <WzTabSelectorTab label="Synchronization">
+              <WzTabSelectorTab label='Synchronization'>
                 <WzConfigurationIntegrityMonitoringSynchronization
                   {...this.props}
                 />
               </WzTabSelectorTab>
-              <WzTabSelectorTab label="Files limit">
+              <WzTabSelectorTab label='Files limit'>
                 <WzConfigurationIntegrityMonitoringFileLimit {...this.props} />
               </WzTabSelectorTab>
-              { agentPlatform === 'windows' && (
-                <WzTabSelectorTab label="Registries limit">
-                  <WzConfigurationIntegrityMonitoringRegistryLimit {...this.props} />
+              {agentPlatform === 'windows' && (
+                <WzTabSelectorTab label='Registries limit'>
+                  <WzConfigurationIntegrityMonitoringRegistryLimit
+                    {...this.props}
+                  />
                 </WzTabSelectorTab>
               )}
-              
             </WzTabSelector>
           )}
       </Fragment>

--- a/plugins/main/public/controllers/management/components/management/configuration/log-collection/log-collection.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/log-collection/log-collection.js
@@ -67,7 +67,7 @@ class WzConfigurationLogCollection extends Component {
         condition:
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_LOGS_PROP]
-            .length > 0,
+            ?.length > 0,
         component: (
           <WzTabSelectorTab label='Logs'>
             <WzConfigurationLogCollectionLogs
@@ -82,7 +82,7 @@ class WzConfigurationLogCollection extends Component {
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][
             LOCALFILE_WINDOWSEVENT_PROP
-          ].length > 0,
+          ]?.length > 0,
         component: (
           <WzTabSelectorTab label='Windows Events'>
             <WzConfigurationLogCollectionWindowsEvents
@@ -96,7 +96,7 @@ class WzConfigurationLogCollection extends Component {
         condition:
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP] &&
           currentConfig[LOGCOLLECTOR_LOCALFILE_PROP][LOCALFILE_COMMANDS_PROP]
-            .length > 0,
+            ?.length > 0,
         component: (
           <WzTabSelectorTab label='Commands'>
             <WzConfigurationLogCollectionCommands


### PR DESCRIPTION
### Description
This pull request fixes a disconnected agent exception when accessing the agent `log collection` or `integrity monitoring` configuration.

Changes made:
- Handle log collector and integrity monitoring falsy values
- Add HOC guard validating the agent is active for the configuration view

### Issues Resolved
Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/6615

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/608ec223-e36f-4fb8-a0f2-ac9b5ba40bc0)



### Test
- Register a real agent and wait until it is active
- Disconnect the agent
- Go to Endpoints Summary
- Select the disconnected agent
- Go to Configuration
- Verify the view can only be used with active agents

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
