### PR TITLE
Bug 6621/generate valid ip addrs and sha256

### DIFF
--- a/scripts/wazuh-alerts-generator/lib/common.js
+++ b/scripts/wazuh-alerts-generator/lib/common.js
@@ -53,7 +53,7 @@ module.exports.Agents = [
   {
     id: '007',
     name: 'Debian',
-    ip: '24.273.97.14'
+    ip: '24.243.97.14'
   }
 ];
 

--- a/scripts/wazuh-alerts-generator/lib/index.js
+++ b/scripts/wazuh-alerts-generator/lib/index.js
@@ -507,7 +507,7 @@ function generateAlert(params) {
                 alert.syscheck.sha1_after = randomElements(40, 'abcdef0123456789');
                 alert.syscheck.changed_attributes = [randomArrayItem(IntegrityMonitoring.attributes)];
                 alert.syscheck.md5_after = randomElements(32, 'abcdef0123456789');
-                alert.syscheck.sha256_after = randomElements(60, 'abcdef0123456789');
+                alert.syscheck.sha256_after = randomElements(64, 'abcdef0123456789');
                 break;
             case 'deleted':
                 alert.rule = IntegrityMonitoring.regulatory[2];
@@ -533,7 +533,7 @@ function generateAlert(params) {
                     },
                 };
                 alert.syscheck.md5_after = randomElements(32, 'abcdef0123456789');
-                alert.syscheck.sha256_after = randomElements(60, 'abcdef0123456789');
+                alert.syscheck.sha256_after = randomElements(64, 'abcdef0123456789');
                 break;
             default: {
             }


### PR DESCRIPTION
### Description
Replace invalid IP address and fix SHA-256 hash generation so that the generated alerts contain valid data.
 
### Issues Resolved
#6621

### Test
- The new IP address does not throw when passed to python3's ipaddress.ip_address.
- The SHA-256 hash is now valid (64 hexadecimal characters instead of 60).

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
