### PR TITLE
Reduce overview welcome font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed the api configuration title in the Server APIs section. [#6373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6373)
 - Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379) [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408) [#6569](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6569)
 - Updated the PDF report year number. [#6492](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6492)
+- Changed overview home font size [#6627](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6627)
 
 ### Fixed
 

--- a/plugins/main/public/components/common/welcome/overview-welcome.js
+++ b/plugins/main/public/components/common/welcome/overview-welcome.js
@@ -109,7 +109,7 @@ export const OverviewWelcome = compose(
     render() {
       return (
         <Fragment>
-          <EuiPage>
+          <EuiPage className='wz-welcome-page'>
             <EuiFlexGroup gutterSize='l'>
               <EuiFlexItem>
                 {this.props.agentsCountTotal === 0 && this.addAgent()}

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -139,11 +139,11 @@ export function LastAlertsStat({ severity }: { severity: string }) {
             </EuiToolTip>
           }
           description={`${severityLabel[severity].label} severity`}
-          descriptionElement='h2'
+          descriptionElement='h3'
           titleColor={severityLabel[severity].color}
           textAlign='center'
         />
-        <EuiText size='s' css='margin-top: 0.7vh'>
+        <EuiText size='xs' css='margin-top: 0.7vh'>
           {'Rule level ' +
             severityLabel[severity].ruleLevelRange.minRuleLevel +
             (severityLabel[severity].ruleLevelRange.maxRuleLevel


### PR DESCRIPTION
### Description
This PR reduces the size of the overview home page.
 
### Issues Resolved
Closes #6624 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/2e3b6aa5-e1f3-4cc6-9736-a3ba44051e52)


### Test
- Go to overview home
- Verify:
  - KPI's title font size is 17.5px
  - KPI's description font size is 12px
  - Modules Card title is 16px
  - Modules Card content is 12px

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
