### PR TITLE
Remove legacy discover references and methods

### DIFF
--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -62,20 +62,10 @@ export function LastAlertsStat({ severity }: { severity: string }) {
         setCountLastAlerts(count);
         const core = getCore();
 
-        // Check if the new discover is enabled to build the URL
-        const v2Enabled = await core.uiSettings.get<boolean>('discover:v2');
-
         let discoverLocation = {
           app: 'data-explorer',
           basePath: 'discover',
         };
-
-        if (!v2Enabled) {
-          discoverLocation = {
-            app: 'discoverLegacy',
-            basePath: '',
-          };
-        }
 
         // TODO: find a better way to get the query discover URL
         const destURL = core.application.getUrlForApp(discoverLocation.app, {

--- a/plugins/main/public/plugin.ts
+++ b/plugins/main/public/plugin.ts
@@ -61,10 +61,6 @@ export class WazuhPlugin
     core: CoreSetup,
     plugins: WazuhSetupPlugins,
   ): Promise<WazuhSetup> {
-    // Hide the discover deprecation notice
-    // After opensearch version 2.11.0 this line may be deleted
-    localStorage.setItem('discover:deprecation-notice:show', 'false');
-
     // Get custom logos configuration to start up the app with the correct logos
     let logosInitialState = {};
     try {


### PR DESCRIPTION
### Description
Removes code that referenced discover legacy
 
### Issues Resolved
- #6584

### Evidence

<img width="1511" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/47962195-a374-4ce1-bfbc-b83fc0c724f4">

### Test

When navigating the dashboards, the error message with reference to discover:v2 should not be displayed.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
