### PR TITLE
Select package type to upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.9.0
 - Added AngularJS dependencies [#6145](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6145)
 - Added a migration task to setup the configuration using a configuration file [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337)
-- Improve fleet management by adding 'Edit Agent Groups' and 'Upgrade Agents' actions, as well as a filter to show only outdated agents [#6250](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6250) [#6476](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6476) [#6274](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6274) [#6501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6501) [#6529](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6529)
+- Improve fleet management by adding 'Edit Agent Groups' and 'Upgrade Agents' actions, as well as a filter to show only outdated agents [#6250](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6250) [#6476](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6476) [#6274](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6274) [#6501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6501) [#6529](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6529) [#6648](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6648)
 - Added propagation of updates from the table to dashboard visualizations in Endpoints summary [#6460](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6460)
 - Handle index pattern selector on new discover [#6499](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6499)
 - Added macOS log collector tab [#6545](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6545)

--- a/plugins/main/public/components/endpoints-summary/services/upgrade-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/services/upgrade-agent.tsx
@@ -2,10 +2,14 @@ import IApiResponse from '../../../react-services/interfaces/api-response.interf
 import { WzRequest } from '../../../react-services/wz-request';
 import { ResponseUpgradeAgents } from '../types';
 
-export const upgradeAgentService = async (agentId: string) =>
+export const upgradeAgentService = async (
+  agentId: string,
+  packageType?: 'deb' | 'rpm',
+) =>
   (await WzRequest.apiReq('PUT', '/agents/upgrade', {
     params: {
       agents_list: agentId,
       wait_for_complete: true,
+      ...(packageType ? { package_type: packageType, force: true } : {}),
     },
   })) as IApiResponse<ResponseUpgradeAgents>;

--- a/plugins/main/public/components/endpoints-summary/table/actions/edit-groups-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/edit-groups-modal.tsx
@@ -10,7 +10,11 @@ import {
   EuiForm,
   EuiFormRow,
   EuiComboBox,
-  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
 } from '@elastic/eui';
 import { compose } from 'redux';
 import { withErrorBoundary, withReduxProvider } from '../../../common/hocs';
@@ -125,23 +129,44 @@ export const EditAgentGroupsModal = compose(
 
   const form = (
     <EuiForm component='form'>
-      <EuiFormRow label='Agent'>
-        <EuiBadge color='hollow'>{agent.name}</EuiBadge>
-      </EuiFormRow>
-      <EuiFormRow
-        label='Groups'
-        isInvalid={!selectedGroups?.length}
-        error={['You must add at least one group']}
-      >
-        <EuiComboBox
-          placeholder='Select groups'
-          options={groups?.map(group => ({ label: group })) || []}
-          selectedOptions={selectedGroups}
-          onChange={selectedGroups => setSelectedGroups(selectedGroups)}
-          isLoading={isGroupsLoading}
-          clearOnBlur
-        />
-      </EuiFormRow>
+      <EuiFlexGroup direction='column' gutterSize='m'>
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize='m'>
+            <EuiFlexItem>
+              <EuiDescriptionList compressed>
+                <EuiDescriptionListTitle>Agent ID</EuiDescriptionListTitle>
+                <EuiDescriptionListDescription>
+                  {agent.id}
+                </EuiDescriptionListDescription>
+              </EuiDescriptionList>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiDescriptionList compressed>
+                <EuiDescriptionListTitle>Agent name</EuiDescriptionListTitle>
+                <EuiDescriptionListDescription>
+                  {agent.name}
+                </EuiDescriptionListDescription>
+              </EuiDescriptionList>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label='Groups'
+            isInvalid={!selectedGroups?.length}
+            error={['You must add at least one group']}
+          >
+            <EuiComboBox
+              placeholder='Select groups'
+              options={groups?.map(group => ({ label: group })) || []}
+              selectedOptions={selectedGroups}
+              onChange={selectedGroups => setSelectedGroups(selectedGroups)}
+              isLoading={isGroupsLoading}
+              clearOnBlur
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiForm>
   );
 

--- a/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.test.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.test.tsx
@@ -9,7 +9,7 @@ jest.mock('../../services', () => ({
 
 jest.mock('../../../../react-services/common-services', () => ({
   getErrorOrchestrator: () => ({
-    handleError: () => {},
+    handleError: () => { },
   }),
 }));
 
@@ -20,18 +20,30 @@ describe('UpgradeAgentModal component', () => {
         agent={{
           id: '001',
           name: 'agent1',
+          version: 'v4.8.0',
           group: ['default'],
+          os: { name: 'Ubuntu', uname: 'Linux', platform: 'ubuntu' }
         }}
-        onClose={() => {}}
-        reloadAgents={() => {}}
-        setIsUpgradePanelClosed={() => {}}
+        onClose={() => { }}
+        reloadAgents={() => { }}
+        setIsUpgradePanelClosed={() => { }}
       />,
     );
 
     expect(container).toMatchSnapshot();
 
-    const agentName = getByText('Upgrade agent agent1?');
+    const agentId = getByText('001');
+    expect(agentId).toBeInTheDocument();
+
+    const agentName = getByText('agent1');
     expect(agentName).toBeInTheDocument();
+
+    const agentVersion = getByText('v4.8.0');
+    expect(agentVersion).toBeInTheDocument();
+
+    const os = getByText('Ubuntu');
+    expect(os).toBeInTheDocument();
+
 
     const saveButton = getByRole('button', { name: 'Upgrade' });
     expect(saveButton).toBeInTheDocument();
@@ -46,11 +58,13 @@ describe('UpgradeAgentModal component', () => {
         agent={{
           id: '001',
           name: 'agent1',
+          version: 'v4.8.0',
           group: ['default'],
+          os: { name: 'Ubuntu', uname: 'Linux', platform: 'ubuntu' }
         }}
-        onClose={() => {}}
-        reloadAgents={() => {}}
-        setIsUpgradePanelClosed={() => {}}
+        onClose={() => { }}
+        reloadAgents={() => { }}
+        setIsUpgradePanelClosed={() => { }}
       />,
     );
 

--- a/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
@@ -1,5 +1,22 @@
 import React, { useState } from 'react';
-import { EuiConfirmModal } from '@elastic/eui';
+import {
+  EuiForm,
+  EuiFormRow,
+  EuiSelect,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiButton,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButtonEmpty,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiIconTip,
+} from '@elastic/eui';
 import { compose } from 'redux';
 import { withErrorBoundary, withReduxProvider } from '../../../common/hocs';
 import { UI_LOGGER_LEVELS } from '../../../../../common/constants';
@@ -8,6 +25,21 @@ import { getErrorOrchestrator } from '../../../../react-services/common-services
 import { upgradeAgentService } from '../../services';
 import { Agent } from '../../types';
 import { getToasts } from '../../../../kibana-services';
+
+const supportedPlatforms = [
+  'debian',
+  'ubuntu',
+  'amzn',
+  'centos',
+  'fedora',
+  'ol',
+  'opensuse',
+  'opensuse-leap',
+  'opensuse-tumbleweed',
+  'rhel',
+  'sles',
+  'suse',
+];
 
 interface UpgradeAgentModalProps {
   agent: Agent;
@@ -27,6 +59,8 @@ export const UpgradeAgentModal = compose(
     setIsUpgradePanelClosed,
   }: UpgradeAgentModalProps) => {
     const [isLoading, setIsLoading] = useState(false);
+    const [packageType, setPackageType] = useState<'deb' | 'rpm'>();
+
     const showToast = (
       color: string,
       title: string = '',
@@ -45,7 +79,7 @@ export const UpgradeAgentModal = compose(
       setIsLoading(true);
 
       try {
-        await upgradeAgentService(agent.id);
+        await upgradeAgentService(agent.id, packageType);
         showToast('success', 'Upgrade agent', 'Upgrade task in progress');
         reloadAgents();
         setIsUpgradePanelClosed(false);
@@ -67,21 +101,109 @@ export const UpgradeAgentModal = compose(
       }
     };
 
+    const regex = /linux/i;
+    const isLinux = regex.test(agent.os.uname);
+    const showPackageSelector =
+      isLinux && !supportedPlatforms.includes(agent.os.platform);
+
+    const form = (
+      <EuiForm component='form'>
+        <EuiFlexGroup direction='column' gutterSize='m'>
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize='m'>
+              <EuiFlexItem>
+                <EuiDescriptionList compressed>
+                  <EuiDescriptionListTitle>Agent ID</EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription>
+                    {agent.id}
+                  </EuiDescriptionListDescription>
+                </EuiDescriptionList>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiDescriptionList compressed>
+                  <EuiDescriptionListTitle>Agent name</EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription>
+                    {agent.name}
+                  </EuiDescriptionListDescription>
+                </EuiDescriptionList>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize='m'>
+              <EuiFlexItem>
+                <EuiDescriptionList compressed>
+                  <EuiDescriptionListTitle>
+                    Agent version
+                  </EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription>
+                    {agent.version}
+                  </EuiDescriptionListDescription>
+                </EuiDescriptionList>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiDescriptionList compressed>
+                  <EuiDescriptionListTitle>OS</EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription>
+                    {agent.os.name}
+                  </EuiDescriptionListDescription>
+                </EuiDescriptionList>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          {showPackageSelector && (
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <span>
+                    Package type{' '}
+                    <EuiIconTip content="Specify the package type, as the manager can't determine it automatically for the OS platform" />
+                  </span>
+                }
+                isInvalid={!packageType}
+              >
+                <EuiSelect
+                  placeholder='Packege type'
+                  value={packageType}
+                  options={[
+                    { value: 'deb', text: 'DEB' },
+                    { value: 'rpm', text: 'RPM' },
+                  ]}
+                  onChange={e => setPackageType(e.target.value)}
+                  hasNoInitialSelection
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiForm>
+    );
+
     return (
-      <EuiConfirmModal
-        title='Upgrade agent'
-        onCancel={onClose}
-        onConfirm={handleOnSave}
-        cancelButtonText='Cancel'
-        confirmButtonText='Upgrade'
+      <EuiModal
         onClose={onClose}
         onClick={ev => {
           ev.stopPropagation();
         }}
-        isLoading={isLoading}
       >
-        <p>{`Upgrade agent ${agent?.name}?`}</p>
-      </EuiConfirmModal>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>Upgrade agent</EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>{form}</EuiModalBody>
+
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+          <EuiButton
+            onClick={handleOnSave}
+            fill
+            isLoading={isLoading}
+            disabled={showPackageSelector && !packageType}
+          >
+            Upgrade agent
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
     );
   },
 );

--- a/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
@@ -200,7 +200,7 @@ export const UpgradeAgentModal = compose(
             isLoading={isLoading}
             disabled={showPackageSelector && !packageType}
           >
-            Upgrade agent
+            Upgrade
           </EuiButton>
         </EuiModalFooter>
       </EuiModal>

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -148,7 +148,7 @@ export const AgentsTable = compose(
     return {
       'data-test-subj': `row-${id}`,
       className: 'customRowClass',
-      onClick: () => {},
+      onClick: () => { },
     };
   };
 
@@ -220,9 +220,8 @@ export const AgentsTable = compose(
             <EuiFlexItem grow={false}>
               <EuiCallOut
                 size='s'
-                title={`${totalSelected} ${
-                  totalSelected === 1 ? 'agent' : 'agents'
-                } selected`}
+                title={`${totalSelected} ${totalSelected === 1 ? 'agent' : 'agents'
+                  } selected`}
               />
             </EuiFlexItem>
             {showSelectAllItems ? (
@@ -410,11 +409,11 @@ export const AgentsTable = compose(
                               sort: `+${field}`,
                               ...(currentValue
                                 ? {
-                                    q: `${searchBarWQLOptions.implicitQuery.query}${searchBarWQLOptions.implicitQuery.conjunction}${field}~${currentValue}`,
-                                  }
+                                  q: `${searchBarWQLOptions.implicitQuery.query}${searchBarWQLOptions.implicitQuery.conjunction}${field}~${currentValue}`,
+                                }
                                 : {
-                                    q: `${searchBarWQLOptions.implicitQuery.query}`,
-                                  }),
+                                  q: `${searchBarWQLOptions.implicitQuery.query}`,
+                                }),
                             },
                           },
                         );
@@ -505,7 +504,7 @@ export const AgentsTable = compose(
           agent={agent}
           reloadAgents={() => reloadAgents()}
           onClose={() => {
-            setIsEditGroupsVisible(false);
+            setIsUpgradeModalVisible(false)
             setAgent(undefined);
           }}
           setIsUpgradePanelClosed={setIsUpgradePanelClosed}


### PR DESCRIPTION
### Description
When upgrade an individual agent, in case that the OS is **`Linux`** and the platform is not one of these:

- `debian`
- `ubuntu`
- `amzn`
- `centos`
- `fedora`
- `ol`
- `opensuse`
- `opensuse-leap`
- `opensuse-tumbleweed`
- `rhel`
- `sles`
- `suse`
 
 The confirm modal asks for the package type (RPM or DEB).

> [!NOTE]  
> The multiple upgrade action was not modified

### Issues Resolved
https://github.com/wazuh/internal-devel-requests/issues/1102

### Evidence

#### Ubuntu platform

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/fc008cea-a063-4f76-9b0a-3ec83a8b3606)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/1b678c30-6ff6-44d2-a7de-0b119a13e206)

The request was made **without** `package_type` and `force` parameters
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/2702698c-938b-453a-b629-7d3311196bd9)

#### Alpine platform

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/1fc35587-82ee-4f4c-bae9-ec9694369f13)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/b9d6fc7d-ecba-4048-9340-9a4f8c4ce22e)

The request was made **with** `package_type` and `force` parameters
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/83546f21-1012-4df5-927d-1169ad0344f0)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

> [!IMPORTANT]  
> Test with a **real manager** from this branch: https://github.com/wazuh/wazuh/tree/migration/21755-wazuh-packages-redesign. Here are the API changes with the new `package_type` parameter.
> 
> **Create an out of date agent with Ubuntu (or other supported Linux platform)**
> ```
> docker run --name os-dev-2130-agent-$(date +%s) --network os-dev-2.13.0 --label com.docker.compose.project=os-dev-2130 --env WAZUH_AGENT_VERSION=4.6.0 -d ubuntu:20.04 bash -c '
>   apt update -y
>   apt install -y curl lsb-release
>   curl -so \wazuh-agent-${WAZUH_AGENT_VERSION}.deb \
>     https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${WAZUH_AGENT_VERSION}-1_amd64.deb \
>     && WAZUH_MANAGER='wazuh.manager' WAZUH_AGENT_GROUP='default' dpkg -i ./wazuh-agent-${WAZUH_AGENT_VERSION}.deb
> 
>   /etc/init.d/wazuh-agent start
>   tail -f /var/ossec/logs/ossec.log
> '
> ```
> 
> **Create an out of date agent with Alpine (or other unsupported Linux platform)**
> Vagrantfile
> ```
> Vagrant.configure("2") do |config|
>   config.vm.box = "generic/alpine312"
> end
> ```
> Guide to install the agent in Alpine: https://documentation.wazuh.com/current/installation-guide/wazuh-agent/wazuh-agent-package-linux.html (APK tab)
> Docker
>
```
docker run --platform linux/amd64 --name os-dev-2130-agent-$(date +%s) --network os-dev-2.13.0 --label com.docker.compose.project=os-dev-2130 --env WAZUH_AGENT_VERSION=4.6.0 -d alpine sh -c '
  wget -O /etc/apk/keys/alpine-devel@wazuh.com-633d7457.rsa.pub https://packages.wazuh.com/key/alpine-devel%40wazuh.com-633d7457.rsa.pub
  echo "https://packages.wazuh.com/4.x/alpine/v3.12/main" >> /etc/apk/repositories
  apk update -y
  apk add wazuh-agent
  export WAZUH_MANAGER="wazuh-manager-master" && sed -i "s|MANAGER_IP|$WAZUH_MANAGER|g" /var/ossec/etc/ossec.conf
  /var/ossec/bin/wazuh-control start
  tail -f /var/ossec/logs/ossec.log
'
```
> **The upgrade tasks fail because the manager 4.9.0 cannot find the 4.9.0 package to upgrade the agents.**

Go to Server management -> Endpoint Summary

### Ubuntu agent

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
|  Click the `All actions` (`...`) button in the agent row and click `Upgrade`. A modal should open should only display the Agent ID, Agent name, Agent version and OS fields. | :black_circle: | :black_circle: | :black_circle: |
|  Inside the modal, click `Upgrade`. The API request should only use the `agents_list` and `wait_for_complete` parameters. | :black_circle: | :black_circle: | :black_circle: |

**Details**

<details>

<summary>:black_circle: Click the `All actions` (`...`) button in the agent row and click `Upgrade`. A modal should open should only display the Agent ID, Agent name, Agent version and OS fields.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>

<summary>:black_circle: Inside the modal, click `Upgrade`. The API request should only use the `agents_list` and `wait_for_complete` parameters.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Alpine agent

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
|  Click the `All actions` (`...`) button in the agent row and click `Upgrade`. A modal should open should display the Agent ID, Agent name, Agent version and OS fields, and the package type input. | :black_circle: | :black_circle: | :black_circle: |
|  Inside the modal, select the package type and click `Upgrade`. The API request should use the `agents_list`, `wait_for_complete`, `force` and `package_type` parameters. | :black_circle: | :black_circle: | :black_circle: |

**Details**

<details>

<summary>:black_circle: Click the `All actions` (`...`) button in the agent row and click `Upgrade`. A modal should open should display the Agent ID, Agent name, Agent version and OS fields, and the package type input.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>

<summary>:black_circle: Inside the modal, select the package type and click `Upgrade`. The API request should use the `agents_list`, `wait_for_complete`, `force` and `package_type` parameters.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
