### PR TITLE
Change flyout title to Vulnerability details

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
@@ -82,7 +82,7 @@ const InventoryVulsComponent = () => {
   const DocViewInspectButton = ({
     rowIndex,
   }: EuiDataGridCellValueElementProps) => {
-    const inspectHintMsg = 'Inspect document details';
+    const inspectHintMsg = 'Inspect vulnerability details';
     return (
       <EuiToolTip content={inspectHintMsg}>
         <EuiButtonIcon
@@ -237,7 +237,7 @@ const InventoryVulsComponent = () => {
               <EuiFlyout onClose={() => setInspectedHit(undefined)} size='m'>
                 <EuiFlyoutHeader>
                   <EuiTitle>
-                    <h2>Document details</h2>
+                    <h2>Vulnerability details</h2>
                   </EuiTitle>
                 </EuiFlyoutHeader>
                 <EuiFlyoutBody>


### PR DESCRIPTION
### Description
Hi team, this pull request changes the vulnerabilities inventory flyout title to `Vulnerability details`.

### Issues Resolved
Closes #6661 

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/bd6ade60-c61f-493b-ac8b-230515fa89d2)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/d08c842a-c624-414a-a3a9-32dbd7d53bf5)


### Test
- Check the _**Vulnerabilities / Inventory**_ Open details buttons tooltip say `Inspect vulnerability details`
- Check the _**Vulnerabilities / Inventory**_ flyout title says `Vulnerability details`

### Check List
- [x] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
