### PR TITLE
Change the order of filters

### DIFF
--- a/plugins/main/public/components/common/data-source/pattern/alerts/alerts-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/alerts-data-source.ts
@@ -3,53 +3,54 @@ import { tFilter, PatternDataSourceFilterManager } from '../../index';
 import { DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER } from '../../../../../../common/constants';
 
 export class AlertsDataSource extends PatternDataSource {
-    constructor(id: string, title: string) {
-        super(id, title);
-    }
+  constructor(id: string, title: string) {
+    super(id, title);
+  }
 
-    getFixedFilters(): tFilter[] {
-        return [
-            ...this.getClusterManagerFilters(),
-            ...super.getFixedFilters(),
-        ]
-    }
+  getFixedFiltersClusterManager(): tFilter[] {
+    return [...this.getClusterManagerFilters()];
+  }
 
-    getRuleGroupsFilter(key: string, value: string, controlledByValue: string) {
-        if (!key || !value){
-            console.warn('key or value is missing to create the getRuleGroupsFilter')
-            return [];
-        } 
-        return [{
-            meta: {
-                index: this.id,
-                negate: false,
-                disabled: false,
-                alias: null,
-                type: 'phrase',
-                key: key,
-                value: value,
-                params: {
-                    query: value,
-                    type: 'phrase',
-                },
-                controlledBy: controlledByValue
+  getRuleGroupsFilter(key: string, value: string, controlledByValue: string) {
+    if (!key || !value) {
+      console.warn('key or value is missing to create the getRuleGroupsFilter');
+      return [];
+    }
+    return [
+      {
+        meta: {
+          index: this.id,
+          negate: false,
+          disabled: false,
+          alias: null,
+          type: 'phrase',
+          key: key,
+          value: value,
+          params: {
+            query: value,
+            type: 'phrase',
+          },
+          controlledBy: controlledByValue,
+        },
+        query: {
+          match: {
+            [key]: {
+              query: value,
+              type: 'phrase',
             },
-            query: {
-                match: {
-                    [key]: {
-                        query: value,
-                        type: 'phrase',
-                    }
-                },
-            },
-            $state: {
-                store: 'appState',
-            },
-        } as tFilter];
-    }
+          },
+        },
+        $state: {
+          store: 'appState',
+        },
+      } as tFilter,
+    ];
+  }
 
-    getClusterManagerFilters() {
-        return PatternDataSourceFilterManager.getClusterManagerFilters(this.title, DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER);   
-    }
-
+  getClusterManagerFilters() {
+    return PatternDataSourceFilterManager.getClusterManagerFilters(
+      this.title,
+      DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
+    );
+  }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/aws/aws-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/aws/aws-data-source.ts
@@ -19,6 +19,10 @@ export class AWSDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/cluster/cluster-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/cluster/cluster-data-source.ts
@@ -1,3 +1,4 @@
+import { tFilter } from '../../../types';
 import { AlertsDataSource } from '../alerts-data-source';
 
 export class ClusterDataSource extends AlertsDataSource {
@@ -6,8 +7,6 @@ export class ClusterDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [
-        ...super.getClusterManagerFilters(),    
-    ];
+    return [...super.getClusterManagerFilters()];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/configuration-assessment/configuration-assessment-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/configuration-assessment/configuration-assessment-data-source.ts
@@ -19,6 +19,10 @@ export class ConfigurationAssessmentDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/docker/docker-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/docker/docker-data-source.ts
@@ -19,6 +19,10 @@ export class DockerDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/fim/fim-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/fim/fim-data-source.ts
@@ -19,6 +19,10 @@ export class FIMDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/gdpr/gdpr-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/gdpr/gdpr-data-source.ts
@@ -37,6 +37,10 @@ export class GDPRDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getFilterExist(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getFilterExist(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/github/github-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/github/github-data-source.ts
@@ -19,6 +19,10 @@ export class GitHubDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...super.getFixedFilters(), ...this.getRuleGroupsFilter()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/google-cloud/google-cloud-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/google-cloud/google-cloud-data-source.ts
@@ -19,6 +19,10 @@ export class GoogleCloudDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/hipaa/hipaa-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/hipaa/hipaa-data-source.ts
@@ -37,6 +37,10 @@ export class HIPAADataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getFilterExist(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getFilterExist(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/index.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/index.ts
@@ -17,4 +17,5 @@ export * from './configuration-assessment';
 export * from './google-cloud';
 export * from './tsc';
 export * from './office-365';
-export * from './cluster'
+export * from './cluster';
+export * from './threat-hunting';

--- a/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
@@ -19,6 +19,10 @@ export class MalwareDetectionDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/mitre-attack/mitre-attack-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/mitre-attack/mitre-attack-data-source.ts
@@ -40,6 +40,10 @@ export class MitreAttackDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...super.getFixedFilters(), ...this.getMitreRuleFilter()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getMitreRuleFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/nist-800-53/nist-800-53-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/nist-800-53/nist-800-53-data-source.ts
@@ -37,6 +37,10 @@ export class NIST80053DataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getFilterExist(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getFilterExist(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/office-365/office-365-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/office-365/office-365-data-source.ts
@@ -19,6 +19,10 @@ export class Office365DataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getRuleGroupsFilter(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/pci-dss/pci-dss-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/pci-dss/pci-dss-data-source.ts
@@ -37,6 +37,10 @@ export class PCIDSSDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getFilterExist(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getFilterExist(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/threat-hunting/index.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/threat-hunting/index.ts
@@ -1,0 +1,1 @@
+export * from './threat-hunting-data-source';

--- a/plugins/main/public/components/common/data-source/pattern/alerts/threat-hunting/threat-hunting-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/threat-hunting/threat-hunting-data-source.ts
@@ -1,0 +1,15 @@
+import { tFilter } from '../../../index';
+import { AlertsDataSource } from '../alerts-data-source';
+
+export class ThreatHuntingDataSource extends AlertsDataSource {
+  constructor(id: string, title: string) {
+    super(id, title);
+  }
+
+  getFixedFilters(): tFilter[] {
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...super.getFixedFilters(),
+    ];
+  }
+}

--- a/plugins/main/public/components/common/data-source/pattern/alerts/tsc/tsc-data-souce.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/tsc/tsc-data-souce.ts
@@ -37,6 +37,10 @@ export class TSCDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...this.getFilterExist(), ...super.getFixedFilters()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getFilterExist(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/virustotal/virustotal-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/virustotal/virustotal-data-source.ts
@@ -19,6 +19,10 @@ export class VirusTotalDataSource extends AlertsDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [...super.getFixedFilters(), ...this.getRuleGroupsFilter()];
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/vulnerabilities/vulnerabilities-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/vulnerabilities/vulnerabilities-data-source.ts
@@ -1,24 +1,28 @@
-import { tFilter } from "../../../index";
+import { tFilter } from '../../../index';
 import { DATA_SOURCE_FILTER_CONTROLLED_VULNERABILITIES_RULE_GROUP } from '../../../../../../../common/constants';
-import { AlertsDataSource } from "../alerts-data-source";
+import { AlertsDataSource } from '../alerts-data-source';
 
 const VULNERABILITIES_GROUP_KEY = 'rule.groups';
 const VULNERABILITIES_GROUP_VALUE = 'vulnerability-detector';
 
 export class AlertsVulnerabilitiesDataSource extends AlertsDataSource {
-    constructor(id: string, title: string) {
-        super(id, title);
-    }
+  constructor(id: string, title: string) {
+    super(id, title);
+  }
 
+  getRuleGroupsFilter() {
+    return super.getRuleGroupsFilter(
+      VULNERABILITIES_GROUP_KEY,
+      VULNERABILITIES_GROUP_VALUE,
+      DATA_SOURCE_FILTER_CONTROLLED_VULNERABILITIES_RULE_GROUP,
+    );
+  }
 
-    getRuleGroupsFilter() {
-        return super.getRuleGroupsFilter(VULNERABILITIES_GROUP_KEY, VULNERABILITIES_GROUP_VALUE, DATA_SOURCE_FILTER_CONTROLLED_VULNERABILITIES_RULE_GROUP);
-    }
-
-    getFixedFilters(): tFilter[] {
-        return [
-            ...this.getRuleGroupsFilter(),
-            ...super.getFixedFilters(),
-        ]
-    }
+  getFixedFilters(): tFilter[] {
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...this.getRuleGroupsFilter(),
+      ...super.getFixedFilters(),
+    ];
+  }
 }

--- a/plugins/main/public/components/common/modules/modules-defaults.tsx
+++ b/plugins/main/public/components/common/modules/modules-defaults.tsx
@@ -59,7 +59,6 @@ import { DashboardHIPAA } from '../../overview/hipaa/dashboards/dashboard';
 import { DashboardTSC } from '../../overview/tsc/dashboards/dashboard';
 import {
   DockerDataSource,
-  AlertsDataSource,
   AlertsVulnerabilitiesDataSource,
   AWSDataSource,
   VirusTotalDataSource,
@@ -75,6 +74,7 @@ import {
   HIPAADataSource,
   PCIDSSDataSource,
   Office365DataSource,
+  ThreatHuntingDataSource,
 } from '../data-source';
 import { ButtonExploreAgent } from '../../wz-agent-selector/button-explore-agent';
 
@@ -99,7 +99,7 @@ export const ModulesDefaults = {
       },
       renderDiscoverTab({
         tableColumns: threatHuntingColumns,
-        DataSource: AlertsDataSource,
+        DataSource: ThreatHuntingDataSource,
       }),
     ],
     availableFor: ['manager', 'agent'],

--- a/plugins/main/public/components/overview/threat-hunting/dashboard/dashboard.tsx
+++ b/plugins/main/public/components/overview/threat-hunting/dashboard/dashboard.tsx
@@ -42,8 +42,8 @@ import {
   threatHuntingTableDefaultColumns,
 } from '../events/threat-hunting-columns';
 import {
-  AlertsDataSource,
   AlertsDataSourceRepository,
+  ThreatHuntingDataSource,
   PatternDataSource,
   PatternDataSourceFilterManager,
   tParsedIndexPattern,
@@ -68,7 +68,7 @@ const DashboardTH: React.FC = () => {
     fetchData,
     setFilters,
   } = useDataSource<tParsedIndexPattern, PatternDataSource>({
-    DataSource: AlertsDataSource,
+    DataSource: ThreatHuntingDataSource,
     repository: new AlertsDataSourceRepository(),
   });
 


### PR DESCRIPTION
### Description
Change the order of the filters to: `(cluster||manager).name`, `rule.groups` and `agent.id
` 
### Issues Resolved
- #6672 

### Evidence

<img width="879" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/c85def0f-7ce3-4e30-869a-6f97ef12ea33">


### Test

- navigate to different dashboards and events, the order of the filters must be `(cluster||manager).name`, `rule.groups` and `agent.id`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
