### PR TITLE
Add to the url of overview the parameter agentId

### DIFF
--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -46,7 +46,12 @@ export const overview = {
   order: 1,
   showInOverviewApp: false,
   showInAgentMenu: false,
-  redirectTo: () => '/overview/',
+  redirectTo: () =>
+    `/overview/${
+      store.getState()?.appStateReducers?.currentAgentData?.id
+        ? `?agentId=${store.getState()?.appStateReducers?.currentAgentData?.id}`
+        : ''
+    }`,
 };
 
 export const fileIntegrityMonitoring = {


### PR DESCRIPTION
### Description
Add to the url of the overview the parameter agentId to keep the agent pinned
 
### Issues Resolved
- #6672 

### Evidence

<img width="1486" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/755c496f-c9b1-48e2-afcc-8a9cb2739c79">
<img width="1499" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/443063ae-2dcc-44f6-ad55-2f7adbb869e4">


### Test

1. Navigate to some dashboard
2. Pin some agent
3. Navigate to overview
4. Navigate to another dashboard
5. The previously pinned agent must remain pinned.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
