### PR TITLE
Hide discover callout warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484) [#6489](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6489) [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6587)
 - Fixed "View alerts of this Rule" link [#6553](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6553)
 - Fixed disconnected agent configuration error [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6617)
+- Fixed discover callout warning message render [#6690](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6690)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Moved the plugin menu to platform applications into the side menu [#5840](https://github.com/wazuh/wazuh-dashboard-plugins/pull/5840) [#6226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6226) [#6244](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6244) [#6423](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6423) [#6510](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6510) [#6591](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6591)
-- Changed dashboards visualizations definitions. [#6035](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6035) [#6632](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6632)
+- Changed dashboards visualizations definitions. [#6035](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6035) [#6632](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6632) [#6690](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6690)
 - Change the display order of tabs in all modules. [#6067](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6067)
 - Upgraded the `axios` dependency to `1.6.1` [#6114](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6114)
 - Changed the API configuration title in the Server APIs section. [#6373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6373)
@@ -45,7 +45,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed minor style issues [#6484](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6484) [#6489](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6489) [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6587)
 - Fixed "View alerts of this Rule" link [#6553](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6553)
 - Fixed disconnected agent configuration error [#6587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6617)
-- Fixed discover callout warning message render [#6690](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6690)
 
 ### Removed
 

--- a/plugins/main/public/components/agents/sca/dashboard/dashboard.tsx
+++ b/plugins/main/public/components/agents/sca/dashboard/dashboard.tsx
@@ -79,8 +79,9 @@ const Dashboard = ({ currentAgentData }) => {
   };
 
   useEffect(() => {
-    let storedPolicies = JSON.parse(localStorage.getItem('scaPolicies')) || [];
-    let lastStoredPolicy = storedPolicies[storedPolicies.length - 1];
+    const storedPolicies =
+      JSON.parse(localStorage.getItem('scaPolicies')) || [];
+    const lastStoredPolicy = storedPolicies[storedPolicies.length - 1];
     setLookingPolicy(lastStoredPolicy);
 
     if (lastStoredPolicy === undefined) {
@@ -88,7 +89,7 @@ const Dashboard = ({ currentAgentData }) => {
     }
 
     return () => {
-      localStorage.clear();
+      localStorage.removeItem('scaPolicies');
     };
   }, [currentAgentData]);
 


### PR DESCRIPTION
### Description

A `localStorage.clear` is modified so that it does not delete the state responsible for hiding the discover message.
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6683


### Evidence

Before:

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/56431c30-c64a-4ad7-a6f4-ebcc692ee651)


After:

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/124377319/c9ae3c6d-4ff1-4fb0-8493-489a46bdeaee)


### Test


- [ ] Go to Endpoint security > Configuration Assessment, pin and unpin an agent, 
- [ ] Go to OpenSearch Dashboards > Discover, and check that the discover callout warning message doesn't render.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
