### PR TITLE
Fix invalid prop children of type array supplied to I18nProvider

### DIFF
--- a/plugins/main/public/components/overview/mitre/framework/mitre.tsx
+++ b/plugins/main/public/components/overview/mitre/framework/mitre.tsx
@@ -155,8 +155,8 @@ const MitreComponent = props => {
   };
 
   return (
-    <div>
-      <I18nProvider>
+    <I18nProvider>
+      <>
         <EuiFlexGroup style={flexGroupStyle}>
           <EuiFlexItem>
             {isDataSourceLoading && !dataSource ? (
@@ -211,8 +211,8 @@ const MitreComponent = props => {
             </EuiPanel>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </I18nProvider>
-    </div>
+      </>
+    </I18nProvider>
   );
 };
 


### PR DESCRIPTION
### Description

This PR fixes the console warning : "**Failed prop type: Invalid prop children of type array supplied to I18nProvider, expected a single ReactElement**"
 
### Issues Resolved

#6693 

### Evidence

<img width="1792" alt="Captura de pantalla 2024-05-22 a la(s) 2 36 30 p  m" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/99441266/ae2ed0d3-f426-4bca-8447-4e9c04186d60">

### Test

Go to the Framework tab of the MITRE ATT&CK module and check that the following warning message does not appear in the console: 
<img width="1792" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/99441266/45400dd3-77fc-43d6-be76-87063b1e0554">

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
