### PR TITLE
Change endpoints summary KPIs and index pattern and APIs selects font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed overview home top KPIs. [#6379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6379) [#6408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6408) [#6569](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6569)
 - Updated the PDF report year number. [#6492](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6492)
 - Changed overview home font size [#6627](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6627)
+- Changed endpoints summary KPIs, index pattern and APIs selects font sizes [#6702](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6702)
 
 ### Fixed
 

--- a/plugins/main/public/components/wz-menu/wz-menu.js
+++ b/plugins/main/public/components/wz-menu/wz-menu.js
@@ -621,7 +621,7 @@ export const WzMenu = withWindowSize(
             <EuiFlexGroup
               alignItems='center'
               responsive={false}
-              className='wz-margin-left-10 wz-margin-right-10'
+              className='wz-margin-left-10 wz-margin-right-10 font-size-14'
             >
               {!this.showSelectorsInPopover &&
                 this.state.patternList.length > 1 &&

--- a/plugins/main/public/controllers/dev-tools/dev-tools.ts
+++ b/plugins/main/public/controllers/dev-tools/dev-tools.ts
@@ -785,11 +785,11 @@ export class DevToolsController {
     this.$window.onresize = () => {
       $('#wz-dev-left-column').attr(
         'style',
-        'width: calc(30% - 7px); !important',
+        'width: calc(45% - 7px); !important',
       );
       $('#wz-dev-right-column').attr(
         'style',
-        'width: calc(70% - 7px); !important',
+        'width: calc(55% - 7px); !important',
       );
       dynamicHeight();
     };

--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -502,14 +502,14 @@ md-sidenav {
 }
 
 #wz-dev-left-column {
-  width: calc(30% - 7px);
+  width: calc(45% - 7px);
   min-width: calc(20% - 7px);
   max-width: calc(80% - 7px);
   float: left;
 }
 
 #wz-dev-right-column {
-  width: calc(70% - 7px);
+  width: calc(55% - 7px);
   min-width: calc(20% - 7px);
   max-width: calc(80% - 7px);
   float: left;
@@ -1550,6 +1550,10 @@ kbn-dis.hide-filter-control .globalFilterGroup__branch {
   .agents-link-item {
     max-width: 45%;
     max-height: 100%;
+
+    .euiLink {
+      font-weight: normal;
+    }
 
     .last-agents-link {
       .euiToolTipAnchor {

--- a/plugins/main/public/styles/typography.scss
+++ b/plugins/main/public/styles/typography.scss
@@ -104,6 +104,10 @@ select {
   font-size: 12px !important;
 }
 
+.font-size-14 {
+  font-size: 14.5px;
+}
+
 .font-size-16 {
   font-size: 16px;
 }


### PR DESCRIPTION
### Description
This pull request changes: 

- Removes bold font-weight from Endpoints summary KPIs `Last enrolled agent` and `Most active agent`
- Changes index pattern and APIs selectors font sizes to 14.5 px
- Changes the default console columns width of the Dev tools view
  - Left column 45%
  - Right column 55%
 
### Issues Resolved
Closes #6699 

### Evidence

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/825c5cd8-bdfb-4f2a-80df-684d59311354)

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/9343732/847b3fab-8dff-4aaa-819c-1f778efdba5c)


### Test
- Check the font-weight from Endpoints summary KPIs `Last enrolled agent` and `Most active agent` is `normal`
- Check the index pattern and APIs selectors font sizes are 14.5 px
- Check the default console columns width of the Dev tools view are:
  - Left column 45%
  - Right column 55%

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
