### PR TITLE
Change location of I18nProvider

### DIFF
--- a/plugins/main/public/components/overview/server-management-statistics/dashboards/dashboardTabsPanels.tsx
+++ b/plugins/main/public/components/overview/server-management-statistics/dashboards/dashboardTabsPanels.tsx
@@ -133,7 +133,7 @@ export const DashboardTabsPanels = ({
     },
   };
   return (
-    <I18nProvider>
+    <>
       {isDataSourceLoading && !dataSource ? (
         <LoadingSpinner />
       ) : (
@@ -194,6 +194,6 @@ export const DashboardTabsPanels = ({
           )}
         </>
       ) : null}
-    </I18nProvider>
+    </>
   );
 };

--- a/plugins/main/public/components/overview/server-management-statistics/dashboards/dashboardTabsPanels.tsx
+++ b/plugins/main/public/components/overview/server-management-statistics/dashboards/dashboardTabsPanels.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { getPlugins } from '../../../../kibana-services';
-import { I18nProvider } from '@osd/i18n/react';
 import useSearchBar from '../../../common/search-bar/use-search-bar';
 import {
   EuiFlexItem,

--- a/plugins/main/public/controllers/management/components/management/statistics/statistics-overview.js
+++ b/plugins/main/public/controllers/management/components/management/statistics/statistics-overview.js
@@ -24,6 +24,7 @@ import {
   EuiSpacer,
   EuiProgress,
 } from '@elastic/eui';
+import { I18nProvider } from '@osd/i18n/react';
 
 import { clusterReq, clusterNodes } from '../configuration/utils/wz-fetch';
 import { compose } from 'redux';
@@ -160,57 +161,59 @@ export class WzStatisticsOverview extends Component {
 
   render() {
     return (
-      <EuiPage style={{ background: 'transparent' }}>
-        <EuiPanel>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiTitle>
-                    <h2>Statistics</h2>
-                  </EuiTitle>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            {this.props.configurationUIEditable && (
-              <EuiFlexItem grow={false}>
-                <RedirectAppLinks application={getCore().application}>
-                  <EuiButtonEmpty
-                    href={getCore().application.getUrlForApp(appSettings.id, {
-                      path: '#/settings?tab=configuration&category=Task:Statistics',
-                    })}
-                    iconType='gear'
-                    iconSide='left'
-                  >
-                    Settings
-                  </EuiButtonEmpty>
-                </RedirectAppLinks>
+      <I18nProvider>
+        <EuiPage style={{ background: 'transparent' }}>
+          <EuiPanel>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <EuiTitle>
+                      <h2>Statistics</h2>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiText color='subdued'>
-                From here you can see daemon statistics.
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiTabs>{this.renderTabs()}</EuiTabs>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
-          <DashboardTabsPanels
-            selectedTab={this.state.selectedTabId}
-            loadingNode={this.state.loadingNode}
-            isClusterMode={this.state.isClusterMode}
-            clusterNodes={this.state.clusterNodes}
-            clusterNodeSelected={this.state.clusterNodeSelected}
-            onSelectNode={this.onSelectNode}
-          />
-        </EuiPanel>
-      </EuiPage>
+              {this.props.configurationUIEditable && (
+                <EuiFlexItem grow={false}>
+                  <RedirectAppLinks application={getCore().application}>
+                    <EuiButtonEmpty
+                      href={getCore().application.getUrlForApp(appSettings.id, {
+                        path: '#/settings?tab=configuration&category=Task:Statistics',
+                      })}
+                      iconType='gear'
+                      iconSide='left'
+                    >
+                      Settings
+                    </EuiButtonEmpty>
+                  </RedirectAppLinks>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiText color='subdued'>
+                  From here you can see daemon statistics.
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiTabs>{this.renderTabs()}</EuiTabs>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+            <DashboardTabsPanels
+              selectedTab={this.state.selectedTabId}
+              loadingNode={this.state.loadingNode}
+              isClusterMode={this.state.isClusterMode}
+              clusterNodes={this.state.clusterNodes}
+              clusterNodeSelected={this.state.clusterNodeSelected}
+              onSelectNode={this.onSelectNode}
+            />
+          </EuiPanel>
+        </EuiPage>
+      </I18nProvider>
     );
   }
 }


### PR DESCRIPTION
### Description
Move the I18nProvider so that it is wrapping the whole view and is only 1 element (EuiPage).
 
### Issues Resolved
- #6693

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/ae7d32a1-2b77-45c1-88bb-3b55c116c764

### Test

1. Navigate to Server Management > Statistics
2. Check that the error does not appear in the console
`Failed prop type: Invalid prop children of type array supplied to PseudoLocaleWrapper, expected a single ReactElement.`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
