### PR TITLE
Remove attributes in unused in select input 

### DIFF
--- a/plugins/main/public/components/common/form/input_select.tsx
+++ b/plugins/main/public/components/common/form/input_select.tsx
@@ -7,9 +7,6 @@ export const InputFormSelect = ({
   value,
   onChange,
   placeholder,
-  selectedOptions,
-  isDisabled,
-  isClearable,
   dataTestSubj,
 }: IInputFormType) => {
   return (
@@ -18,9 +15,6 @@ export const InputFormSelect = ({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      selectedOptions={selectedOptions}
-      isDisabled={isDisabled}
-      isClearable={isClearable}
       data-test-subj={dataTestSubj}
     />
   );

--- a/plugins/main/public/components/common/form/types.ts
+++ b/plugins/main/public/components/common/form/types.ts
@@ -7,6 +7,8 @@ export interface IInputFormType {
   isInvalid?: boolean;
   options: any;
   setInputRef: (reference: any) => void;
+  placeholder: string;
+  dataTestSubj: string;
 }
 
 export interface IInputForm {


### PR DESCRIPTION
### Description
Remove attributes in unused in select input to remove console errors
 
### Issues Resolved

- #6693

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/89698e30-eeec-4b7c-85e5-13134a5f28a1

### Test
1. Navigate to Dashboard management > App settings
2. Check that these errors do not appear in the console

`React does not recognize the isClearable prop on a DOM element.`
`React does not recognize the isDisabled prop on a DOM element.`
`React does not recognize the selectedOptions prop on a DOM element.`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
