### PR TITLE
Fix the prop onChange is marked as requires in EuiSwitch

### DIFF
--- a/plugins/main/public/components/common/permissions/button.tsx
+++ b/plugins/main/public/components/common/permissions/button.tsx
@@ -59,13 +59,12 @@ export const WzButtonPermissions = ({
           ...(!['link', 'switch'].includes(buttonType)
             ? { isDisabled: disabled }
             : { disabled }),
-          onClick:
-            disabled || !rest.onClick || buttonType == 'switch'
-              ? undefined
-              : rest.onClick,
-          onChange: disabled || !rest.onChange ? undefined : rest.onChange,
+          onClick: disabled || !rest.onClick ? undefined : rest.onClick,
+          onChange:
+            !disabled || rest.onChange || buttonType === 'switch'
+              ? rest.onChange
+              : undefined,
         };
-
         if (buttonType == 'switch') delete additionalProps.onClick;
 
         return additionalProps;


### PR DESCRIPTION
### Description

Fix the prop onChange is marked as requires in EuiSwitch
 
### Issues Resolved

#6693 

### Evidence

<img width="1792" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/99441266/535881c5-ed93-430f-9b88-5ad743d706d2">

### Test

- Go to Security and click edit on a user and see that the warning Failed prop type: The `onChange` property is marked as required in `EuiSwitch`, but its value is `undefined` does not appear in the console.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
