### PR TITLE
Remove total outdated agents statistic from Endpoint Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added AngularJS dependencies [#6145](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6145)
 - Added a migration task to setup the configuration using a configuration file [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337)
 - Improve fleet management by adding 'Edit Agent Groups' and 'Upgrade Agents' actions, as well as a filter to show only outdated agents [#6250](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6250) [#6476](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6476) [#6274](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6274) [#6501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6501) [#6529](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6529) [#6648](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6648)
-- Added propagation of updates from the table to dashboard visualizations in Endpoints summary [#6460](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6460)
+- Added propagation of updates from the table to dashboard visualizations in Endpoints summary [#6460](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6460) [#6737](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6737)
 - Handle index pattern selector on new discover [#6499](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6499)
 - Added macOS log collector tab [#6545](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6545)
 - Add ability to disable the edition of configuration through API endpoints and UI [#6557](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6557)

--- a/plugins/main/public/components/common/data-source/pattern/vulnerabilities/vulnerabilities-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/vulnerabilities/vulnerabilities-data-source.ts
@@ -1,28 +1,24 @@
-import { DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER, VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER } from '../../../../../../common/constants';
+import {
+  DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
+  VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER,
+} from '../../../../../../common/constants';
 import { tFilter, PatternDataSourceFilterManager } from '../../index';
-import { AppState } from '../../../../../react-services/app-state';
 import { PatternDataSource } from '../pattern-data-source';
 
 export class VulnerabilitiesDataSource extends PatternDataSource {
+  constructor(id: string, title: string) {
+    super(id, title);
+  }
 
-    constructor(id: string, title: string) {
-        super(id, title);
-    }
+  getFixedFilters(): tFilter[] {
+    return [...this.getClusterManagerFilters(), ...super.getFixedFilters()];
+  }
 
-    getFixedFilters(): tFilter[] {
-        return [
-            ...this.getClusterManagerFilters(),
-            ...super.getFixedFilters(),
-        ]
-    }
-
-    getClusterManagerFilters() {
-        return PatternDataSourceFilterManager.getClusterManagerFilters(this.title, 
-            DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
-            VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER[
-                AppState.getClusterInfo().status
-            ],
-        );   
-    }
-
+  getClusterManagerFilters() {
+    return PatternDataSourceFilterManager.getClusterManagerFilters(
+      this.title,
+      DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
+      VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER,
+    );
+  }
 }

--- a/plugins/main/public/components/common/welcome/agents-welcome.js
+++ b/plugins/main/public/components/common/welcome/agents-welcome.js
@@ -18,7 +18,6 @@ import {
   EuiFlexGroup,
   EuiSpacer,
   EuiText,
-  EuiFlexGrid,
   EuiButtonEmpty,
   EuiPage,
   EuiPopover,
@@ -82,11 +81,11 @@ export const AgentsWelcome = compose(
       },
       ...(agent?.name
         ? [
-            {
-              text: `${agent.name}`,
-              truncate: true,
-            },
-          ]
+          {
+            text: `${agent.name}`,
+            truncate: true,
+          },
+        ]
         : []),
     ];
   }),
@@ -209,13 +208,13 @@ export const AgentsWelcome = compose(
         )
           ? JSON.parse(window.localStorage.getItem('wz-menu-agent-apps-pinned'))
           : [
-              // Default pinned applications
-              threatHunting.id,
-              fileIntegrityMonitoring.id,
-              configurationAssessment.id,
-              mitreAttack.id,
-              malwareDetection.id,
-            ];
+            // Default pinned applications
+            threatHunting.id,
+            fileIntegrityMonitoring.id,
+            configurationAssessment.id,
+            mitreAttack.id,
+            malwareDetection.id,
+          ];
       }
 
       // Ensure the pinned applications are supported
@@ -423,32 +422,30 @@ export const AgentsWelcome = compose(
     renderMitrePanel() {
       return (
         <Fragment>
-          <EuiPanel paddingSize='s' height={{ height: 300 }}>
-            <EuiFlexItem>
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <h2 className='embPanel__title wz-headline-title'>
-                    <EuiText size='xs'>
-                      <h2>MITRE ATT&CK</h2>
-                    </EuiText>
-                  </h2>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false} style={{ alignSelf: 'center' }}>
-                  <EuiToolTip position='top' content='Open MITRE ATT&CK'>
-                    <RedirectAppLinks application={getCore().application}>
-                      <EuiButtonIcon
-                        iconType='popout'
-                        color='primary'
-                        href={`${getCore().application.getUrlForApp(
-                          mitreAttack.id,
-                        )}`}
-                        aria-label='Open MITRE ATT&CK'
-                      />
-                    </RedirectAppLinks>
-                  </EuiToolTip>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
+          <EuiPanel paddingSize='m' height={{ height: 300 }}>
+            <EuiFlexGroup gutterSize='s'>
+              <EuiFlexItem>
+                <h2 className='embPanel__title wz-headline-title'>
+                  <EuiText size='xs'>
+                    <h2>MITRE ATT&CK</h2>
+                  </EuiText>
+                </h2>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false} style={{ alignSelf: 'center' }}>
+                <EuiToolTip position='top' content='Open MITRE ATT&CK'>
+                  <RedirectAppLinks application={getCore().application}>
+                    <EuiButtonIcon
+                      iconType='popout'
+                      color='primary'
+                      href={`${getCore().application.getUrlForApp(
+                        mitreAttack.id,
+                      )}`}
+                      aria-label='Open MITRE ATT&CK'
+                    />
+                  </RedirectAppLinks>
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
             <EuiSpacer size='m' />
             <EuiFlexGroup>
               <EuiFlexItem>
@@ -523,19 +520,19 @@ export const AgentsWelcome = compose(
                     >
                       {' '}
                       {/* TODO: Replace with SearchBar and replace implementation to get the time range in AgentView component*/}
-                      <WzDatePicker condensed={true} onTimeChange={() => {}} />
+                      <WzDatePicker condensed={true} onTimeChange={() => { }} />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                   {(this.state.widthWindow < 1150 && (
                     <Fragment>
-                      <EuiFlexGrid columns={2}>
+                      <EuiFlexGroup wrap>
                         <EuiFlexItem
                           key={'Wazuh-App-Agents-Welcome-MITRE-Top-Tactics'}
                         >
                           {this.renderMitrePanel()}
                         </EuiFlexItem>
                         {this.renderCompliancePanel()}
-                      </EuiFlexGrid>
+                      </EuiFlexGroup>
                       <EuiSpacer size='m' />
                       <EuiFlexGroup>
                         <FimEventsTable agent={this.props.agent} />
@@ -556,33 +553,33 @@ export const AgentsWelcome = compose(
                       </EuiFlexGroup>
                     </Fragment>
                   )) || (
-                    <Fragment>
-                      <EuiFlexGrid columns={2}>
-                        <EuiFlexItem>
-                          <EuiFlexGroup>
-                            <EuiFlexItem
-                              key={'Wazuh-App-Agents-Welcome-MITRE-Top-Tactics'}
-                            >
-                              {this.renderMitrePanel()}
-                            </EuiFlexItem>
-                            {this.renderCompliancePanel()}
-                          </EuiFlexGroup>
-                        </EuiFlexItem>
-                        <FimEventsTable agent={this.props.agent} />
-                      </EuiFlexGrid>
-                      <EuiSpacer size='l' />
-                      <EuiFlexGroup>
-                        <EuiFlexItem
-                          key={'Wazuh-App-Agents-Welcome-Events-Evolution'}
-                        >
-                          {' '}
-                          {/* Events count evolution */}
-                          {this.renderEventCountVisualization()}
-                        </EuiFlexItem>
-                        <EuiFlexItem>{this.renderSCALastScan()}</EuiFlexItem>
-                      </EuiFlexGroup>
-                    </Fragment>
-                  )}
+                      <Fragment>
+                        <EuiFlexGroup>
+                          <EuiFlexItem>
+                            <EuiFlexGroup>
+                              <EuiFlexItem
+                                key={'Wazuh-App-Agents-Welcome-MITRE-Top-Tactics'}
+                              >
+                                {this.renderMitrePanel()}
+                              </EuiFlexItem>
+                              {this.renderCompliancePanel()}
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                          <FimEventsTable agent={this.props.agent} />
+                        </EuiFlexGroup>
+                        <EuiSpacer size='l' />
+                        <EuiFlexGroup>
+                          <EuiFlexItem
+                            key={'Wazuh-App-Agents-Welcome-Events-Evolution'}
+                          >
+                            {' '}
+                            {/* Events count evolution */}
+                            {this.renderEventCountVisualization()}
+                          </EuiFlexItem>
+                          <EuiFlexItem>{this.renderSCALastScan()}</EuiFlexItem>
+                        </EuiFlexGroup>
+                      </Fragment>
+                    )}
                 </EuiPageBody>
               </EuiPage>
             </div>

--- a/plugins/main/public/components/endpoints-summary/dashboard/endpoints-summary-dashboard.tsx
+++ b/plugins/main/public/components/endpoints-summary/dashboard/endpoints-summary-dashboard.tsx
@@ -30,7 +30,7 @@ export const EndpointsSummaryDashboard: FC<EndpointsSummaryDashboardProps> = ({
       </EuiFlexItem>
       <EuiFlexItem>
         <DonutCard
-          betaBadgeLabel='Top 5 agents by OS'
+          betaBadgeLabel='Top 5 OS'
           onClickLabel={filterAgentByOS}
           getInfo={getAgentsByOs}
           reload={reloadDashboard}
@@ -38,7 +38,7 @@ export const EndpointsSummaryDashboard: FC<EndpointsSummaryDashboardProps> = ({
       </EuiFlexItem>
       <EuiFlexItem>
         <DonutCard
-          betaBadgeLabel='Top 5 agents by Group'
+          betaBadgeLabel='Top 5 groups'
           onClickLabel={filterAgentByGroup}
           getInfo={getAgentsByGroup}
           reload={reloadDashboard}

--- a/plugins/main/public/components/endpoints-summary/dashboard/endpoints-summary-dashboard.tsx
+++ b/plugins/main/public/components/endpoints-summary/dashboard/endpoints-summary-dashboard.tsx
@@ -3,15 +3,12 @@ import { getAgentsByGroup } from '../services/get-agents-by-group';
 import { getAgentsByOs } from '../services/get-agents-by-os';
 import { getSummaryAgentsStatus } from '../services/get-summary-agents-status';
 import DonutCard from './components/donut-card';
-import OutdatedAgentsCard from './components/outdated-agents-card';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 interface EndpointsSummaryDashboardProps {
   filterAgentByStatus: (data: any) => void;
   filterAgentByOS: (data: any) => void;
   filterAgentByGroup: (data: any) => void;
-  outdatedAgents: number;
-  isLoadingOutdatedAgents: boolean;
-  filterByOutdatedAgent: (data: any) => void;
   reloadDashboard?: number;
 }
 
@@ -19,36 +16,34 @@ export const EndpointsSummaryDashboard: FC<EndpointsSummaryDashboardProps> = ({
   filterAgentByStatus,
   filterAgentByOS,
   filterAgentByGroup,
-  outdatedAgents,
-  isLoadingOutdatedAgents,
-  filterByOutdatedAgent,
   reloadDashboard,
 }) => {
   return (
-    <div className='endpoints-summary-container-indicators'>
-      <DonutCard
-        betaBadgeLabel='Agents by Status'
-        onClickLabel={filterAgentByStatus}
-        getInfo={getSummaryAgentsStatus}
-        reload={reloadDashboard}
-      />
-      <DonutCard
-        betaBadgeLabel='Top 5 agents by OS'
-        onClickLabel={filterAgentByOS}
-        getInfo={getAgentsByOs}
-        reload={reloadDashboard}
-      />
-      <DonutCard
-        betaBadgeLabel='Top 5 agents by Group'
-        onClickLabel={filterAgentByGroup}
-        getInfo={getAgentsByGroup}
-        reload={reloadDashboard}
-      />
-      <OutdatedAgentsCard
-        outdatedAgents={outdatedAgents}
-        isLoading={isLoadingOutdatedAgents}
-        filterByOutdatedAgent={filterByOutdatedAgent}
-      />
-    </div>
+    <EuiFlexGroup gutterSize='m' responsive={false} wrap>
+      <EuiFlexItem>
+        <DonutCard
+          betaBadgeLabel='Agents by Status'
+          onClickLabel={filterAgentByStatus}
+          getInfo={getSummaryAgentsStatus}
+          reload={reloadDashboard}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <DonutCard
+          betaBadgeLabel='Top 5 agents by OS'
+          onClickLabel={filterAgentByOS}
+          getInfo={getAgentsByOs}
+          reload={reloadDashboard}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <DonutCard
+          betaBadgeLabel='Top 5 agents by Group'
+          onClickLabel={filterAgentByGroup}
+          getInfo={getAgentsByGroup}
+          reload={reloadDashboard}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/plugins/main/public/components/endpoints-summary/endpoints-summary.scss
+++ b/plugins/main/public/components/endpoints-summary/endpoints-summary.scss
@@ -101,21 +101,3 @@
     white-space: nowrap;
   }
 }
-
-.endpoints-summary-container-indicators {
-  width: 100%;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 16px;
-  min-height: 200px;
-
-  @media (min-width: 1024px) {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  @media (min-width: 1440px) {
-    grid-template-columns:
-      minmax(375px, 1fr) minmax(375px, 1fr) minmax(375px, 1fr)
-      minmax(150px, 300px);
-  }
-}

--- a/plugins/main/public/components/endpoints-summary/services/get-outdated-agents.ts
+++ b/plugins/main/public/components/endpoints-summary/services/get-outdated-agents.ts
@@ -1,6 +1,6 @@
 import { WzRequest } from '../../../react-services/wz-request';
 
-export const getOutdatedAgents = async ({
+export const getOutdatedAgentsService = async ({
   agentIds,
   limit,
 }: {

--- a/plugins/main/public/components/endpoints-summary/services/get-outdated-agents.ts
+++ b/plugins/main/public/components/endpoints-summary/services/get-outdated-agents.ts
@@ -3,16 +3,26 @@ import { WzRequest } from '../../../react-services/wz-request';
 export const getOutdatedAgentsService = async ({
   agentIds,
   limit,
+  q,
 }: {
   agentIds?: string[];
   limit?: number;
+  q?: string;
 }) => {
+  const qArray = q?.split(';') ?? [];
+  const qAgents = agentIds?.length
+    ? [agentIds.map(agentId => `id=${agentId}`).join(',')]
+    : [];
+  const finalQ = [...qArray, ...qAgents].join(';');
+
   const {
     data: { data },
   } = await WzRequest.apiReq('GET', '/agents/outdated', {
     params: {
-      ...(agentIds?.length
-        ? { q: `(${agentIds.map(agentId => `id=${agentId}`).join(',')})` }
+      ...(agentIds?.length || q
+        ? {
+            q: finalQ,
+          }
         : {}),
       limit,
     },

--- a/plugins/main/public/components/endpoints-summary/services/index.tsx
+++ b/plugins/main/public/components/endpoints-summary/services/index.tsx
@@ -6,5 +6,5 @@ export { addAgentsToGroupService } from './add-agents-to-group';
 export { getGroupsService } from './get-groups';
 export { upgradeAgentService } from './upgrade-agent';
 export { upgradeAgentsService } from './upgrade-agents';
-export { getOutdatedAgents } from './get-outdated-agents';
+export { getOutdatedAgentsService } from './get-outdated-agents';
 export { getTasks } from './get-tasks';

--- a/plugins/main/public/components/endpoints-summary/table/__snapshots__/agents-table.test.tsx.snap
+++ b/plugins/main/public/components/endpoints-summary/table/__snapshots__/agents-table.test.tsx.snap
@@ -43,75 +43,7 @@ exports[`AgentsTable component Renders correctly to match the snapshot 1`] = `
                   >
                     <div
                       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <div
-                        class="euiFlexItem euiFlexItem--flexGrowZero"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <div
-                            class="euiSwitch"
-                          >
-                            <button
-                              aria-checked="false"
-                              aria-labelledby="htmlId"
-                              class="euiSwitch__button"
-                              disabled=""
-                              id="htmlId"
-                              role="switch"
-                              type="button"
-                            >
-                              <span
-                                class="euiSwitch__body"
-                              >
-                                <span
-                                  class="euiSwitch__thumb"
-                                />
-                                <span
-                                  class="euiSwitch__track"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
-                            <span
-                              class="euiSwitch__label"
-                              id="htmlId"
-                            >
-                              Show only outdated
-                            </span>
-                          </div>
-                        </span>
-                      </div>
-                    </div>
+                    />
                   </div>
                 </div>
               </div>
@@ -777,76 +709,7 @@ exports[`AgentsTable component Renders correctly to match the snapshot with cust
                   >
                     <div
                       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <div
-                        class="euiFlexItem euiFlexItem--flexGrowZero"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <div
-                            class="euiSwitch"
-                          >
-                            <button
-                              aria-checked="false"
-                              aria-labelledby="htmlId"
-                              class="euiSwitch__button"
-                              disabled=""
-                              id="htmlId"
-                              role="switch"
-                              type="button"
-                            >
-                              <span
-                                class="euiSwitch__body"
-                              >
-                                <span
-                                  class="euiSwitch__thumb"
-                                />
-                                <span
-                                  class="euiSwitch__track"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiSwitch__icon"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
-                                    />
-                                  </svg>
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiSwitch__icon euiSwitch__icon--checked"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
-                                      fill-rule="evenodd"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
-                            <span
-                              class="euiSwitch__label"
-                              id="htmlId"
-                            >
-                              Show only outdated
-                            </span>
-                          </div>
-                        </span>
-                      </div>
-                    </div>
+                    />
                   </div>
                 </div>
               </div>
@@ -1471,76 +1334,7 @@ exports[`AgentsTable component Renders correctly to match the snapshot with no p
                   >
                     <div
                       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <div
-                        class="euiFlexItem euiFlexItem--flexGrowZero"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <div
-                            class="euiSwitch"
-                          >
-                            <button
-                              aria-checked="false"
-                              aria-labelledby="htmlId"
-                              class="euiSwitch__button"
-                              disabled=""
-                              id="htmlId"
-                              role="switch"
-                              type="button"
-                            >
-                              <span
-                                class="euiSwitch__body"
-                              >
-                                <span
-                                  class="euiSwitch__thumb"
-                                />
-                                <span
-                                  class="euiSwitch__track"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiSwitch__icon"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
-                                    />
-                                  </svg>
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiSwitch__icon euiSwitch__icon--checked"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
-                                      fill-rule="evenodd"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
-                            <span
-                              class="euiSwitch__label"
-                              id="htmlId"
-                            >
-                              Show only outdated
-                            </span>
-                          </div>
-                        </span>
-                      </div>
-                    </div>
+                    />
                   </div>
                 </div>
               </div>

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -103,11 +103,12 @@ export const AgentsTable = compose(withErrorBoundary)(
       useState(false);
     const [isUpgradePanelClosed, setIsUpgradePanelClosed] = useState(false);
 
-    const getOutdatedAgents = async () => {
+    const getOutdatedAgents = async q => {
       try {
         setIsLoadingTotalOutdated(true);
         const { total_affected_items } = await getOutdatedAgentsService({
           limit: 1,
+          q,
         });
         setTotalOutdated(total_affected_items);
       } catch (error) {
@@ -132,7 +133,6 @@ export const AgentsTable = compose(withErrorBoundary)(
       if (sessionStorage.getItem('wz-agents-overview-table-filter')) {
         sessionStorage.removeItem('wz-agents-overview-table-filter');
       }
-      getOutdatedAgents();
     }, []);
 
     useEffect(() => {
@@ -263,11 +263,12 @@ export const AgentsTable = compose(withErrorBoundary)(
             <WzButton
               buttonType='switch'
               label={`Show only outdated${
-                totalOutdated ? ` (${totalOutdated})` : ''
+                totalOutdated || showOnlyOutdated ? ` (${totalOutdated})` : ''
               }`}
               checked={showOnlyOutdated}
-              disabled={!totalOutdated}
+              disabled={!showOnlyOutdated && !totalOutdated}
               tooltip={
+                !showOnlyOutdated &&
                 !totalOutdated && {
                   content: 'There are no outdated agents',
                 }
@@ -367,6 +368,10 @@ export const AgentsTable = compose(withErrorBoundary)(
               }}
               rowProps={getRowProps}
               filters={filters}
+              onFiltersChange={filters => {
+                const q = filters.q ?? filters.default.q;
+                getOutdatedAgents(q);
+              }}
               onDataChange={handleOnDataChange}
               downloadCsv
               showReload

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -39,7 +39,7 @@ import { agentsTableColumns } from './columns';
 import { AgentsTableGlobalActions } from './global-actions/global-actions';
 import { Agent } from '../types';
 import { UpgradeAgentModal } from './actions/upgrade-agent-modal';
-import { getOutdatedAgents } from '../services';
+import { getOutdatedAgentsService } from '../services';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 import { AgentUpgradesInProgress } from './upgrades-in-progress/upgrades-in-progress';
@@ -61,8 +61,6 @@ type AgentList = {
 interface AgentsTableProps {
   filters: any;
   externalReload?: boolean;
-  showOnlyOutdated: boolean;
-  setShowOnlyOutdated: (newValue: boolean) => void;
   totalOutdated?: number;
   setExternalReload?: (newValue: number) => void;
 }
@@ -96,15 +94,45 @@ export const AgentsTable = compose(withErrorBoundary)(
       { action: 'task:status', resource: '*:*:*' },
     ]);
 
+    const [totalOutdated, setTotalOutdated] = useState<number>();
+    const [isLoadingTotalOutdated, setIsLoadingTotalOutdated] = useState(true);
+    const [showOnlyOutdated, setShowOnlyOutdated] = useState(false);
     const [outdatedAgents, setOutdatedAgents] = useState<Agent[]>([]);
+
     const [isUpgradeTasksModalVisible, setIsUpgradeTasksModalVisible] =
       useState(false);
     const [isUpgradePanelClosed, setIsUpgradePanelClosed] = useState(false);
+
+    const getOutdatedAgents = async () => {
+      try {
+        setIsLoadingTotalOutdated(true);
+        const { total_affected_items } = await getOutdatedAgentsService({
+          limit: 1,
+        });
+        setTotalOutdated(total_affected_items);
+      } catch (error) {
+        const options = {
+          context: `EndpointsSummary.getOutdatedAgents`,
+          level: UI_LOGGER_LEVELS.ERROR,
+          severity: UI_ERROR_SEVERITIES.BUSINESS,
+          store: true,
+          error: {
+            error,
+            message: error.message || error,
+            title: `Could not get total outdated agents`,
+          },
+        };
+        getErrorOrchestrator().handleError(options);
+      } finally {
+        setIsLoadingTotalOutdated(false);
+      }
+    };
 
     useEffect(() => {
       if (sessionStorage.getItem('wz-agents-overview-table-filter')) {
         sessionStorage.removeItem('wz-agents-overview-table-filter');
       }
+      getOutdatedAgents();
     }, []);
 
     useEffect(() => {
@@ -172,7 +200,7 @@ export const AgentsTable = compose(withErrorBoundary)(
 
       try {
         const outdatedAgents = agentIds?.length
-          ? (await getOutdatedAgents({ agentIds })).affected_items
+          ? (await getOutdatedAgentsService({ agentIds })).affected_items
           : [];
         setOutdatedAgents(outdatedAgents);
       } catch (error) {
@@ -230,20 +258,24 @@ export const AgentsTable = compose(withErrorBoundary)(
             </EuiFlexGroup>
           </EuiFlexItem>
         ) : null}
-        <EuiFlexItem grow={false}>
-          <WzButton
-            buttonType='switch'
-            label='Show only outdated'
-            checked={props.showOnlyOutdated}
-            disabled={!props.totalOutdated}
-            tooltip={
-              !props.totalOutdated && {
-                content: 'There are no outdated agents',
+        {!isLoadingTotalOutdated ? (
+          <EuiFlexItem grow={false}>
+            <WzButton
+              buttonType='switch'
+              label={`Show only outdated${
+                totalOutdated ? ` (${totalOutdated})` : ''
+              }`}
+              checked={showOnlyOutdated}
+              disabled={!totalOutdated}
+              tooltip={
+                !totalOutdated && {
+                  content: 'There are no outdated agents',
+                }
               }
-            }
-            onChange={() => props.setShowOnlyOutdated(!props.showOnlyOutdated)}
-          />
-        </EuiFlexItem>
+              onChange={() => setShowOnlyOutdated(!showOnlyOutdated)}
+            />
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
     );
 
@@ -303,7 +335,7 @@ export const AgentsTable = compose(withErrorBoundary)(
                   />
                 </EuiFlexItem>
               )}
-              endpoint={props.showOnlyOutdated ? '/agents/outdated' : '/agents'}
+              endpoint={showOnlyOutdated ? '/agents/outdated' : '/agents'}
               tableColumns={agentsTableColumns(
                 !denyEditGroups,
                 !denyUpgrade,

--- a/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/__snapshots__/upgrades-in-progress.test.tsx.snap
+++ b/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/__snapshots__/upgrades-in-progress.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AgentUpgradesInProgress component should return the component 1`] = `
 <div>
   <div
-    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--subdued euiPanel--noShadow euiPanel--noBorder"
+    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow"
@@ -151,5 +151,8 @@ exports[`AgentUpgradesInProgress component should return the component 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="euiSpacer euiSpacer--s"
+  />
 </div>
 `;

--- a/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.tsx
@@ -88,115 +88,118 @@ export const AgentUpgradesInProgress = ({
   if (isPanelClosed || !showTasks) return null;
 
   return (
-    <EuiPanel color='subdued'>
-      <EuiFlexGroup
-        gutterSize='s'
-        alignItems='flexStart'
-        wrap={false}
-        responsive={false}
-      >
+    <>
+      <EuiPanel color='plain'>
         <EuiFlexGroup
           gutterSize='s'
-          alignItems='center'
+          alignItems='flexStart'
           wrap={false}
           responsive={false}
         >
+          <EuiFlexGroup
+            gutterSize='s'
+            alignItems='center'
+            wrap={false}
+            responsive={false}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiText>Upgrade tasks</EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color='primary'
+                onClick={() => setIsModalVisible(true)}
+                iconType='eye'
+              >
+                Task details
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiText>Upgrade tasks</EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              color='primary'
-              onClick={() => setIsModalVisible(true)}
-              iconType='eye'
-            >
-              Task details
-            </EuiButtonEmpty>
+            <EuiButtonIcon
+              onClick={() => setIsPanelClosed(true)}
+              color='text'
+              iconType='cross'
+              aria-label='Close'
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            onClick={() => setIsPanelClosed(true)}
-            color='text'
-            iconType='cross'
-            aria-label='Close'
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+        <EuiSpacer size='s' />
+        <EuiFlexGroup gutterSize='s' alignItems='center'>
+          {totalInProgressTasks > 0 ? (
+            <EuiFlexItem grow={false}>
+              <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
+                <EuiProgress size='xs' color='warning' position='absolute' />
+                <EuiText size='s'>
+                  <b>{totalInProgressTasks}</b>
+                  {` ${API_NAME_TASK_STATUS.IN_PROGRESS}`}
+                </EuiText>
+              </EuiPanel>
+            </EuiFlexItem>
+          ) : null}
+          {totalSuccessTasks > 0 ? (
+            <EuiFlexItem grow={false}>
+              <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
+                <EuiProgress
+                  value={100}
+                  max={100}
+                  size='xs'
+                  color='success'
+                  position='absolute'
+                />
+                <span>
+                  <EuiText size='s'>
+                    <b>{totalSuccessTasks}</b>
+                    {` ${API_NAME_TASK_STATUS.DONE} `}
+                    <EuiIconTip content='Last 60 minutes' color='primary' />
+                  </EuiText>
+                </span>
+              </EuiPanel>
+            </EuiFlexItem>
+          ) : null}
+          {totalErrorUpgradeTasks > 0 ? (
+            <EuiFlexItem grow={false}>
+              <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
+                <EuiProgress
+                  value={100}
+                  max={100}
+                  size='xs'
+                  color='danger'
+                  position='absolute'
+                />
+                <span>
+                  <EuiText size='s'>
+                    <b>{totalErrorUpgradeTasks}</b>
+                    {` ${API_NAME_TASK_STATUS.FAILED} `}
+                    <EuiIconTip content='Last 60 minutes' color='primary' />
+                  </EuiText>
+                </span>
+              </EuiPanel>
+            </EuiFlexItem>
+          ) : null}
+          {totalTimeoutUpgradeTasks > 0 ? (
+            <EuiFlexItem grow={false}>
+              <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
+                <EuiProgress
+                  value={100}
+                  max={100}
+                  size='xs'
+                  color='subdued'
+                  position='absolute'
+                />
+                <span>
+                  <EuiText size='s'>
+                    <b>{totalTimeoutUpgradeTasks}</b>
+                    {` ${API_NAME_TASK_STATUS.TIMEOUT} `}
+                    <EuiIconTip content='Last 60 minutes' color='primary' />
+                  </EuiText>
+                </span>
+              </EuiPanel>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      </EuiPanel>
       <EuiSpacer size='s' />
-      <EuiFlexGroup gutterSize='s' alignItems='center'>
-        {totalInProgressTasks > 0 ? (
-          <EuiFlexItem grow={false}>
-            <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
-              <EuiProgress size='xs' color='warning' position='absolute' />
-              <EuiText size='s'>
-                <b>{totalInProgressTasks}</b>
-                {` ${API_NAME_TASK_STATUS.IN_PROGRESS}`}
-              </EuiText>
-            </EuiPanel>
-          </EuiFlexItem>
-        ) : null}
-        {totalSuccessTasks > 0 ? (
-          <EuiFlexItem grow={false}>
-            <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
-              <EuiProgress
-                value={100}
-                max={100}
-                size='xs'
-                color='success'
-                position='absolute'
-              />
-              <span>
-                <EuiText size='s'>
-                  <b>{totalSuccessTasks}</b>
-                  {` ${API_NAME_TASK_STATUS.DONE} `}
-                  <EuiIconTip content='Last 60 minutes' color='primary' />
-                </EuiText>
-              </span>
-            </EuiPanel>
-          </EuiFlexItem>
-        ) : null}
-        {totalErrorUpgradeTasks > 0 ? (
-          <EuiFlexItem grow={false}>
-            <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
-              <EuiProgress
-                value={100}
-                max={100}
-                size='xs'
-                color='danger'
-                position='absolute'
-              />
-              <span>
-                <EuiText size='s'>
-                  <b>{totalErrorUpgradeTasks}</b>
-                  {` ${API_NAME_TASK_STATUS.FAILED} `}
-                  <EuiIconTip content='Last 60 minutes' color='primary' />
-                </EuiText>
-              </span>
-            </EuiPanel>
-          </EuiFlexItem>
-        ) : null}
-        {totalTimeoutUpgradeTasks > 0 ? (
-          <EuiFlexItem grow={false}>
-            <EuiPanel paddingSize='s' style={{ position: 'relative' }}>
-              <EuiProgress
-                value={100}
-                max={100}
-                size='xs'
-                color='subdued'
-                position='absolute'
-              />
-              <span>
-                <EuiText size='s'>
-                  <b>{totalTimeoutUpgradeTasks}</b>
-                  {` ${API_NAME_TASK_STATUS.TIMEOUT} `}
-                  <EuiIconTip content='Last 60 minutes' color='primary' />
-                </EuiText>
-              </span>
-            </EuiPanel>
-          </EuiFlexItem>
-        ) : null}
-      </EuiFlexGroup>
-    </EuiPanel>
+    </>
   );
 };


### PR DESCRIPTION
### Description

This PR addresses the following changes:

1. Removed outdated agents' statistic from the Endpoints Summary page:

    - The outdated agents' statistic has been removed to streamline the information displayed on the Endpoints Summary page.

2. Moved state management to table component:
    - The state management for the total number of outdated agents has been shifted from the Endpoints Summary page to the table component. This ensures that the table component independently manages and reflects the accurate count of outdated agents.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6736

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/7aa778c0-1253-4627-a4c7-718a89ab2160)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/483c2145-9cf4-47a7-b496-8e7c9d734205)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/4b450c80-600d-4fbe-9838-2f7b9899a04e)
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/103193307/6449094b-4604-44ef-a09d-0e4baf44f640)

### Test

> [!IMPORTANT]  
> Test with a real 4.9.0 manager and at least one outdated agent.

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Verified that the Endpoints Summary page no longer displays the outdated agents' statistic. | :black_circle: | :black_circle: | :black_circle: |
| If there are outdated agents, then the agents table must display the total. | :black_circle: | :black_circle: | :black_circle: |
| If there are outdated agents, turning on the switch should make the table display only those agents. | :black_circle: | :black_circle: | :black_circle: |
| If there are no outdated agents, then the agents table should disable the switch. | :black_circle: | :black_circle: | :black_circle: |
| Verified that the Agent Welcome page (with data) adapts the components correctly por 850px screen width. | :black_circle: | :black_circle: | :black_circle: |
| Check Endpoint Summary statistic titles: Must be "Top 5 OS" and "Top 5 groups". | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Verified that the Endpoints Summary page no longer displays the outdated agents' statistic.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: If there are outdated agents, then the agents table must display the total.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: If there are outdated agents, turning on the switch should make the table display only those agents.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: If there are no outdated agents, then the agents table should disable the switch.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Verified that the Agent Welcome page (with data) adapts the components correctly por 850px screen width.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Check Endpoint Summary statistic titles: Must be "Top 5 OS" and "Top 5 groups".</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
