### PR TITLE
Replaced SearchBar with WzSearchBar in flyout component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Upgraded versions of `follow-redirects` and `es5-ext` [#6626](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6626)
 - Changed agent log collector socket API response controller component [#6660](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6660)
 - Improve margins and paddins in the Events, Inventory and Control tabs [#6708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6708)
-- Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716)
+- Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716) [#6755](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6755)
 - Generate URL with predefined filters [#6745](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6745)
 
 ### Fixed

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -12,12 +12,14 @@ export interface WzSearchBarProps extends SearchBarProps {
   userFilters?: Filter[];
   preQueryBar?: React.ReactElement;
   postFilters?: React.ReactElement;
+  hideFixedFilters?: boolean;
 }
 
 export const WzSearchBar = ({
   fixedFilters = [],
   userFilters = [],
   preQueryBar,
+  hideFixedFilters,
   postFilters,
   ...restProps
 }: WzSearchBarProps) => {
@@ -53,25 +55,28 @@ export const WzSearchBar = ({
       ) : null}
       {showFilters ? (
         <EuiFlexGroup gutterSize='s'>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              gutterSize='xs'
-              className='globalFilterBar globalFilterGroup__filterBar'
-              responsive={false}
-              wrap={true}
-            >
-              {fixedFilters?.map((filter, idx) => (
-                <EuiFlexItem grow={false} key={idx}>
-                  <EuiBadge className='globalFilterItem' color='hollow'>
-                    {`${filter.meta.key}: ${typeof filter.meta.value === 'function'
-                      ? filter.meta.value()
-                      : filter.meta.value
+          {hideFixedFilters ? null : (
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup
+                gutterSize='xs'
+                className='globalFilterBar globalFilterGroup__filterBar'
+                responsive={false}
+                wrap={true}
+              >
+                {fixedFilters?.map((filter, idx) => (
+                  <EuiFlexItem grow={false} key={idx}>
+                    <EuiBadge className='globalFilterItem' color='hollow'>
+                      {`${filter.meta.key}: ${
+                        typeof filter.meta.value === 'function'
+                          ? filter.meta.value()
+                          : filter.meta.value
                       }`}
-                  </EuiBadge>
-                </EuiFlexItem>
-              ))}
-            </EuiFlexGroup>
-          </EuiFlexItem>
+                    </EuiBadge>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          )}
           <EuiFlexItem>
             <EuiFlexGroup
               gutterSize='s'

--- a/plugins/main/public/components/common/wazuh-discover/wz-flyout-discover.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/wz-flyout-discover.tsx
@@ -21,7 +21,6 @@ import {
   HttpError,
 } from '../../../react-services/error-management';
 import useSearchBar, { tUseSearchBarProps } from '../search-bar/use-search-bar';
-import { getPlugins } from '../../../kibana-services';
 import { withErrorBoundary } from '../hocs';
 import { useTimeFilter } from '../hooks';
 import {
@@ -34,6 +33,7 @@ import {
   tFilter,
 } from '../data-source';
 import DocDetails from './components/doc-details';
+import { WzSearchBar } from '../search-bar/search-bar';
 
 export const MAX_ENTRIES_PER_QUERY = 10000;
 export const DEFAULT_PAGE_SIZE_OPTIONS = [20, 50, 100];
@@ -69,7 +69,6 @@ const WazuhFlyoutDiscoverComponent = (props: WazuhDiscoverProps) => {
     throw new Error('DataSource is required');
   }
 
-  const SearchBar = getPlugins().data.ui.SearchBar;
   const [results, setResults] = useState<SearchResponse>({} as SearchResponse);
   const [indexPattern, setIndexPattern] = useState<IndexPattern | undefined>(
     undefined,
@@ -251,8 +250,8 @@ const WazuhFlyoutDiscoverComponent = (props: WazuhDiscoverProps) => {
         indexPattern,
       })
     ) : (
-        <DocDetails doc={doc} item={item} indexPattern={indexPattern} />
-      );
+      <DocDetails doc={doc} item={item} indexPattern={indexPattern} />
+    );
   };
 
   const parsedItems = useMemo(() => {
@@ -275,14 +274,13 @@ const WazuhFlyoutDiscoverComponent = (props: WazuhDiscoverProps) => {
           {isDataSourceLoading ? (
             <LoadingSpinner />
           ) : (
-              <div className='wz-search-bar'>
-                <SearchBar
-                  appName='wazuh-discover-search-bar'
-                  {...searchBarProps}
-                  useDefaultBehaviors={false}
-                />
-              </div>
-            )}
+            <WzSearchBar
+              appName='wazuh-discover-search-bar'
+              {...searchBarProps}
+              useDefaultBehaviors={false}
+              hideFixedFilters
+            />
+          )}
           {!isDataSourceLoading && results?.hits?.total === 0 ? (
             <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
           ) : null}
@@ -299,15 +297,15 @@ const WazuhFlyoutDiscoverComponent = (props: WazuhDiscoverProps) => {
                   showResetButton={false}
                   tooltip={
                     results?.hits?.total &&
-                      results?.hits?.total > MAX_ENTRIES_PER_QUERY
+                    results?.hits?.total > MAX_ENTRIES_PER_QUERY
                       ? {
-                        ariaLabel: 'Warning',
-                        content: `The query results has exceeded the limit of 10,000 hits. To provide a better experience the table only shows the first ${formatNumWithCommas(
-                          MAX_ENTRIES_PER_QUERY,
-                        )} hits.`,
-                        iconType: 'alert',
-                        position: 'top',
-                      }
+                          ariaLabel: 'Warning',
+                          content: `The query results has exceeded the limit of 10,000 hits. To provide a better experience the table only shows the first ${formatNumWithCommas(
+                            MAX_ENTRIES_PER_QUERY,
+                          )} hits.`,
+                          iconType: 'alert',
+                          position: 'top',
+                        }
                       : undefined
                   }
                 />


### PR DESCRIPTION
## Description
This PR replaces `SearchBar` with `WzSearchBar` in flyout component. Also, add an attribute (`hideFixedFilters`) to `WzSearchBar` so that it hides the fixed filters if necessary.
 
## Issues Resolved
- #6711 

## Evidence
### Inventory FIM  Flyout

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/afecbc38-c62a-466d-bfb3-38b0e4dbcd6e)

### Dashboard FIM

![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/b1eb8c43-a839-4503-94b9-9dd510c65800)

## Test

- **Check Flyout**
  - Go to some screen that uses SearchBar in the flyout, for example, Inventory FIM.
  - Make the necessary interaction to open the Flyout.
  - Check that the SearchBar does not show the filters set as shown in the evidence.
- **Check SearchBar on non-Flyout screens**
  - Go to a screen that uses the SearchBar other than Flyout
  - Check, if applicable, that it shows the set filters.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
