### PR TITLE
Remove empty panel when there is no data

### DIFF
--- a/plugins/main/public/components/common/wazuh-discover/wz-discover.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/wz-discover.tsx
@@ -208,77 +208,80 @@ const WazuhDiscoverComponent = (props: WazuhDiscoverProps) => {
         {!isDataSourceLoading && results?.hits?.total === 0 ? (
           <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
         ) : null}
-        <EuiPanel
-          paddingSize='s'
-          hasShadow={false}
-          hasBorder={false}
-          color='transparent'
+        <div
           className={
             !isDataSourceLoading && dataSource && results?.hits?.total > 0
               ? ''
               : 'wz-no-display'
           }
         >
-          <EuiFlexGroup gutterSize='s' direction='column'>
-            <EuiFlexItem grow={false} className='discoverChartContainer'>
-              <EuiPanel
-                hasBorder={false}
-                hasShadow={false}
-                color='transparent'
-                paddingSize='none'
-              >
-                <EuiPanel>
-                  <DashboardByRenderer
-                    input={histogramChartInput(
-                      AlertsRepository.getStoreIndexPatternId(),
-                      fetchFilters,
-                      query,
-                      dateRangeFrom,
-                      dateRangeTo,
-                    )}
-                  />
+          <EuiPanel
+            paddingSize='s'
+            hasShadow={false}
+            hasBorder={false}
+            color='transparent'
+          >
+            <EuiFlexGroup gutterSize='s' direction='column'>
+              <EuiFlexItem grow={false} className='discoverChartContainer'>
+                <EuiPanel
+                  hasBorder={false}
+                  hasShadow={false}
+                  color='transparent'
+                  paddingSize='none'
+                >
+                  <EuiPanel>
+                    <DashboardByRenderer
+                      input={histogramChartInput(
+                        AlertsRepository.getStoreIndexPatternId(),
+                        fetchFilters,
+                        query,
+                        dateRangeFrom,
+                        dateRangeTo,
+                      )}
+                    />
+                  </EuiPanel>
                 </EuiPanel>
-              </EuiPanel>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiDataGrid
-                {...dataGridProps}
-                className={sideNavDocked ? 'dataGridDockedNav' : ''}
-                toolbarVisibility={{
-                  additionalControls: (
-                    <>
-                      <DiscoverDataGridAdditionalControls
-                        totalHits={results?.hits?.total || 0}
-                        isExporting={isExporting}
-                        onClickExportResults={onClickExportResults}
-                        maxEntriesPerQuery={MAX_ENTRIES_PER_QUERY}
-                      />
-                    </>
-                  ),
-                }}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiPanel>
-        {inspectedHit && (
-          <EuiFlyout onClose={() => setInspectedHit(undefined)} size='m'>
-            <EuiFlyoutHeader>
-              <EuiTitle>
-                <h2>Document Details</h2>
-              </EuiTitle>
-            </EuiFlyoutHeader>
-            <EuiFlyoutBody>
-              <EuiFlexGroup direction='column'>
-                <EuiFlexItem>
-                  <DocumentViewTableAndJson
-                    document={inspectedHit}
-                    indexPattern={indexPattern}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlyoutBody>
-          </EuiFlyout>
-        )}
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiDataGrid
+                  {...dataGridProps}
+                  className={sideNavDocked ? 'dataGridDockedNav' : ''}
+                  toolbarVisibility={{
+                    additionalControls: (
+                      <>
+                        <DiscoverDataGridAdditionalControls
+                          totalHits={results?.hits?.total || 0}
+                          isExporting={isExporting}
+                          onClickExportResults={onClickExportResults}
+                          maxEntriesPerQuery={MAX_ENTRIES_PER_QUERY}
+                        />
+                      </>
+                    ),
+                  }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+          {inspectedHit && (
+            <EuiFlyout onClose={() => setInspectedHit(undefined)} size='m'>
+              <EuiFlyoutHeader>
+                <EuiTitle>
+                  <h2>Document Details</h2>
+                </EuiTitle>
+              </EuiFlyoutHeader>
+              <EuiFlyoutBody>
+                <EuiFlexGroup direction='column'>
+                  <EuiFlexItem>
+                    <DocumentViewTableAndJson
+                      document={inspectedHit}
+                      indexPattern={indexPattern}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlyoutBody>
+            </EuiFlyout>
+          )}
+        </div>
       </EuiPageTemplate>
     </IntlProvider>
   );


### PR DESCRIPTION
### Description
Remove empty panel when there is no data
 
### Issues Resolved
- #6744

### Evidence

<img width="1510" alt="image" src="https://github.com/wazuh/wazuh-dashboard-plugins/assets/63758389/29337306-8631-4e30-90ee-ff47cf7fc0f5">

### Test

1. Navigate to some module / events
2. only the no data warning should be rendered. 


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
