### PR TITLE
GHA: add prettier and eslint checks on the changed files for the pull request

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,19 +1,10 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# ESLint is a tool for identifying and reporting on patterns
-# found in ECMAScript/JavaScript code.
-# More details at https://github.com/eslint/eslint
-# and https://eslint.org
-
-name: ESLint
+name: Prettier
 
 on:
   pull_request:
 
 jobs:
-  linter:
+  prettier:
     name: Ensure the code format on the changed files
     runs-on: ubuntu-latest
     steps:
@@ -46,5 +37,5 @@ jobs:
           plugin_package_json=$(ls -d plugins/* | head -n1)
           echo "Installing dependencies from plugin: ${plugin_package_json}"
           yarn --cwd "${plugin_package_json}" --modules-folder ../../node_modules
-          echo "Running eslint on the changed files"
-          npx eslint ${CHANGED_FILES}
+          echo "Running prettier on the changed files"
+          npx prettier ${CHANGED_FILES} --check --ignore-unknown


### PR DESCRIPTION
### Description
This pull request adds the Prettier and ESLint checks on the changed files for the pull requests workflow.
 
### Issues Resolved
#6761

### Test

We could test it creating a pull request with changes on the files that do not pass the code format of prettier and eslint. To test, you could use a fork to create the pull request and review the check result for the code formatting (prettier and linter).

Currently, the ESLint check is disabled for this repository, so we could ignore the test of this check.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
