### PR TITLE
Fixed behavior in Configuration Assessment when changing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the sample alerts scripts to generate valid IP ranges and file hashes [#6667](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6667)
 - Fixed cronjob max seconds interval validation [#6730](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6730)
 - Fixed styles in small height viewports [#6747](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6747)
+- Fixed behavior in Configuration Assessment when changing API [#6770](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6770)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/overview.tsx
+++ b/plugins/main/public/components/overview/overview.tsx
@@ -33,7 +33,7 @@ export const Overview: React.FC = withRouteResolvers({
   savedSearch,
 })(() => {
   const [agentsCounts, setAgentsCounts] = useState<object>({});
-  const { tab = 'welcome', tabView = 'dashboard' } = useRouterSearch();
+  const { tab = 'welcome', tabView = 'dashboard', agentId } = useRouterSearch();
   const navigationService = NavigationService.getInstance();
   const pinnedAgentManager = new PinnedAgentManager();
 
@@ -100,7 +100,7 @@ export const Overview: React.FC = withRouteResolvers({
       stopSyncingGlobalStateWithUrl();
       stopSyncingQueryAppStateWithStateContainer();
     };
-  }, []);
+  }, [agentId]);
 
   /**
    * This fetch de agents summary

--- a/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
+++ b/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
@@ -13,13 +13,11 @@ export class PinnedAgentManager {
     DATA_SOURCE_FILTER_CONTROLLED_PINNED_AGENT;
   private AGENT_VIEW_URL = '/agents';
   private store: any;
-  private params: URLSearchParams;
   private navigationService: NavigationService;
 
   constructor(inputStore?: any) {
     this.store = inputStore ?? store;
     this.navigationService = NavigationService.getInstance();
-    this.params = this.navigationService.getParams();
   }
 
   private equalToPinnedAgent(agentData: any): boolean {
@@ -44,25 +42,28 @@ export class PinnedAgentManager {
     const includesAgentViewURL = this.navigationService
       .getPathname()
       .includes(this.AGENT_VIEW_URL);
-    this.params.set(
-      includesAgentViewURL
-        ? PinnedAgentManager.AGENT_ID_VIEW_KEY
-        : PinnedAgentManager.AGENT_ID_URL_VIEW_KEY,
-      String(agentData?.id),
-    );
-    this.navigationService.renewURL(this.params);
+    this.navigationService
+      .getParams()
+      .set(
+        includesAgentViewURL
+          ? PinnedAgentManager.AGENT_ID_VIEW_KEY
+          : PinnedAgentManager.AGENT_ID_URL_VIEW_KEY,
+        String(agentData?.id),
+      );
+    this.navigationService.renewURL(this.navigationService.getParams());
   }
 
   unPinAgent(): void {
     this.store.dispatch(
       updateCurrentAgentData(PinnedAgentManager.NO_AGENT_DATA),
     );
+    const params = this.navigationService.getParams();
     ['agent', 'agentId'].forEach(param => {
-      if (this.params.has(param)) {
-        this.params.delete(param);
+      if (params.has(param)) {
+        params.delete(param);
       }
     });
-    this.navigationService.renewURL(this.params);
+    this.navigationService.renewURL(params);
   }
 
   isPinnedAgent(): boolean {

--- a/plugins/main/public/react-services/navigation-service.tsx
+++ b/plugins/main/public/react-services/navigation-service.tsx
@@ -56,29 +56,29 @@ class NavigationService {
       ? params.toString()
       : this.getParams().toString();
     const locationHash = this.getHash();
-    this.replace(
+    this.navigate(
       `${newPath}${queryParams ? `?${queryParams}` : ''}${locationHash}`,
     );
   }
 
   public navigate(path: string, state?: any): void {
-    if(!state){
+    if (!state) {
       this.history.push(path);
     } else {
       this.history.push({
         pathname: path,
-        state
+        state,
       });
     }
   }
 
   public replace(path: string, state?: any): void {
-    if(!state){
+    if (!state) {
       this.history.replace(path);
     } else {
       this.history.replace({
         pathname: path,
-        state
+        state,
       });
     }
   }


### PR DESCRIPTION
## Description
This PR fixes rendering when changing the API in Configuration Assessment when you have an agent pinned.
 
## Issues Resolved
- #6763 

## Evidence

[evidence.webm](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/aa08f375-d8ad-4572-a39f-6fd13362cbab)

## Test

- Navigate to Configuration Assessment.
- Pin an agent.
- Go to Home -> Overview
- Go to Configuration Assessment.
- Change the API.
- Check that the agent selection screen appears in Configuration Assessment.

## Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
