### PR TITLE
Fix quick switch between tabs vulnerabilities gives a filter error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed cronjob max seconds interval validation [#6730](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6730)
 - Fixed styles in small height viewports [#6747](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6747)
 - Fixed behavior in Configuration Assessment when changing API [#6770](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6770)
+- Fixed the disappearance of fixed filters when changing tabs quickly in vulnerabilities [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Implement new data source feature on MITRE ATT&CK module [#6482](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6482)
 - Upgraded versions of `follow-redirects` and `es5-ext` [#6626](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6626)
 - Changed agent log collector socket API response controller component [#6660](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6660)
-- Improve margins and paddins in the Events, Inventory and Control tabs [#6708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6708)
+- Improve margins and paddings in the Events, Inventory and Control tabs [#6708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6708)
 - Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716) [#6755](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6755)
 - Generate URL with predefined filters [#6745](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6745)
 - Migrated AngularJS routing to ReactJS [#6689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6689)
+- Improvement of the filter management system by implementing new standard modules [#6534](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6534) [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772)
 
 ### Fixed
 
@@ -53,7 +54,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed cronjob max seconds interval validation [#6730](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6730)
 - Fixed styles in small height viewports [#6747](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6747)
 - Fixed behavior in Configuration Assessment when changing API [#6770](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6770)
-- Fixed the disappearance of fixed filters when changing tabs quickly in vulnerabilities [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772)
 
 ### Removed
 

--- a/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
+++ b/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
@@ -87,7 +87,9 @@ export function useDataSource<
   };
 
   useEffect(() => {
-    let subscription;
+    let subscription: any;
+    let isMounted = true;
+
     (async () => {
       setIsLoading(true);
       const factory = injectedFactory || new PatternDataSourceFactory();
@@ -101,6 +103,7 @@ export function useDataSource<
       if (!dataSource) {
         throw new Error('No valid data source found');
       }
+      if (!isMounted) return;
       setDataSource(dataSource);
       const dataSourceFilterManager = new PatternDataSourceFilterManager(
         dataSource,
@@ -108,9 +111,11 @@ export function useDataSource<
         injectedFilterManager,
         initialFetchFilters,
       );
+      if (!isMounted) return;
       // what the filters update
       subscription = dataSourceFilterManager.getUpdates$().subscribe({
         next: () => {
+          if (!isMounted) return;
           // this is necessary to remove the hidden filters from the filter manager and not show them in the search bar
           dataSourceFilterManager.setFilters(
             dataSourceFilterManager.getFilters(),
@@ -125,7 +130,12 @@ export function useDataSource<
       setIsLoading(false);
     })();
 
-    return () => subscription && subscription.unsubscribe();
+    return () => {
+      isMounted = false;
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+    };
   }, []);
 
   useEffect(() => {

--- a/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
+++ b/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
@@ -136,7 +136,7 @@ export function useDataSource<
         subscription.unsubscribe();
       }
     };
-  }, [isComponentMounted, getAbortController]);
+  }, []);
 
   useEffect(() => {
     if (dataSourceFilterManager && dataSource) {

--- a/plugins/main/public/components/common/hooks/use-is-mounted.test.tsx
+++ b/plugins/main/public/components/common/hooks/use-is-mounted.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useIsMounted } from './use-is-mounted';
+
+describe('useIsMounted()', () => {
+  it('should return true when component is mounted', () => {
+    const { result } = renderHook(() => useIsMounted());
+
+    expect(result.current.isComponentMounted()).toBe(true);
+  });
+
+  it('should return false when component is unmounted', () => {
+    const { result, unmount } = renderHook(() => useIsMounted());
+
+    unmount();
+
+    expect(result.current.isComponentMounted()).toBe(false);
+  });
+});

--- a/plugins/main/public/components/common/hooks/use-is-mounted.ts
+++ b/plugins/main/public/components/common/hooks/use-is-mounted.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export const useIsMounted = () => {
+  const isMounted = useRef(false);
+  const abortControllerRef = useRef(new AbortController());
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+      abortControllerRef.current.abort();
+    };
+  }, []);
+
+  const getAbortController = useCallback(() => {
+    if (!isMounted.current) {
+      abortControllerRef.current = new AbortController();
+    }
+    return abortControllerRef.current;
+  }, []);
+
+  const isComponentMounted = useCallback(() => isMounted.current, []);
+
+  return { isComponentMounted, getAbortController };
+};


### PR DESCRIPTION
## Description
This PR fixes the disappearance of fixed filters when changing tabs quickly in vulnerabilities, between the dashboard/inventory and events tabs.
 
## Issues Resolved
- #6764 

## Evidence

[evidence.webm](https://github.com/wazuh/wazuh-dashboard-plugins/assets/43619595/dd806cf3-82cc-41b5-ba15-467e30eef6ac)

## Test

> [!NOTE]  
> Data must be injected with dataInjectScript.py located in scripts/vulnerabilities-events-injector.

**Step to test:**

- Go to vulnerability detection module.
- Try change tabs quickly between the dashboard/inventory and events tabs.
- Check that the set filters do not disappear.

## Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
