### PR TITLE
Index pattern on the filters of home KPI links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.8.1
 
+### Fixed
+
+- Fixed home KPI links with custom or index pattern whose title is different to the id [#6777](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6777)
+
 ## Wazuh v4.8.0 - OpenSearch Dashboards 2.10.0 - Revision 12
 
 ### Added

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-service.ts
@@ -10,7 +10,7 @@ interface Last24HoursAlerts {
     field: string;
     name: string;
   };
-  indexPatternName: string;
+  indexPatternId: string;
 }
 
 /**
@@ -44,7 +44,7 @@ export const getLast24HoursAlerts = async (
         field: isCluster ? 'cluster.name' : 'manager.name',
         name: clusterValue,
       },
-      indexPatternName: currentIndexPattern.title,
+      indexPatternId: currentIndexPattern.id,
     };
   } catch (error) {
     return Promise.reject(error);

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -56,7 +56,7 @@ export function LastAlertsStat({ severity }: { severity: string }) {
   useEffect(() => {
     const getCountLastAlerts = async () => {
       try {
-        const { indexPatternName, cluster, count } = await getLast24HoursAlerts(
+        const { indexPatternId, cluster, count } = await getLast24HoursAlerts(
           severityLabel[severity].ruleLevelRange,
         );
         setCountLastAlerts(count);
@@ -81,13 +81,13 @@ export function LastAlertsStat({ severity }: { severity: string }) {
         const destURL = core.application.getUrlForApp(discoverLocation.app, {
           path: `${
             discoverLocation.basePath
-          }#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'${indexPatternName}',view:discover))&_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:'${indexPatternName}',key:${
+          }#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'${indexPatternId}',view:discover))&_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:'${indexPatternId}',key:${
             cluster.field
           },negate:!f,params:(query:${
             cluster.name
           }),type:phrase),query:(match_phrase:(${cluster.field}:${
             cluster.name
-          }))),('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:'wazuh-alerts-*',key:rule.level,negate:!f,params:(gte:${
+          }))),('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:'${indexPatternId}',key:rule.level,negate:!f,params:(gte:${
             severityLabel[severity].ruleLevelRange.minRuleLevel
           },lte:${
             severityLabel[severity].ruleLevelRange.maxRuleLevel || '!n'

--- a/plugins/main/public/controllers/overview/components/stats.test.tsx
+++ b/plugins/main/public/controllers/overview/components/stats.test.tsx
@@ -24,7 +24,7 @@ jest.mock(
   }),
 );
 
-jest.mock('react-use/lib/useObservable', () => () => { });
+jest.mock('react-use/lib/useObservable', () => () => {});
 jest.mock('./last-alerts-stat/last-alerts-service', () => ({
   getLast24HoursAlerts: jest.fn().mockReturnValue({
     count: 100,
@@ -32,7 +32,7 @@ jest.mock('./last-alerts-stat/last-alerts-service', () => ({
       field: 'cluster.name',
       name: 'master',
     },
-    indexPatternName: 'wazuh-alerts-*',
+    indexPatternId: 'wazuh-alerts-*',
   }),
 }));
 
@@ -43,14 +43,14 @@ jest.mock('../../../kibana-services', () => ({
       getUrlForApp: () => 'http://url',
     },
     uiSettings: {
-      get: () => true
-    }
+      get: () => true,
+    },
   }),
 }));
 
 jest.mock('../../../react-services/common-services', () => ({
   getErrorOrchestrator: () => ({
-    handleError: options => { },
+    handleError: options => {},
   }),
 }));
 


### PR DESCRIPTION
### Description
This pull request fixes the hardcoded value of index pattern on the filters of home KPI links.

Side changes:
- Fix a problem in the home KPI links when using a index pattern with different title and id.
 
### Issues Resolved
#6776

### Evidence
![image](https://github.com/wazuh/wazuh-dashboard-plugins/assets/34042064/fe341d09-1509-46bf-b3ef-361914399012)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With an index pattern with the same title and ID, go to Home > Overview, the KPI links should display and redirect correctly to the Discover app and the filters should be applied without errors | :black_circle: | :black_circle: | :black_circle: |
| With an index pattern with a different title and ID, go to Home > Overview, the KPI links should display and redirect correctly to the Discover app and the filters should be applied without errors | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With an index pattern with the same title and ID, go to Home > Overview, the KPI links should display and redirect correctly to the Discover app and the filters should be applied without errors</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With an index pattern with a different title and ID, go to Home > Overview, the KPI links should display and redirect correctly to the Discover app and the filters should be applied without errors</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
