### PR TITLE
Fix pinned agent was not keet on refrshing page

### DIFF
--- a/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
+++ b/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
@@ -42,15 +42,16 @@ export class PinnedAgentManager {
     const includesAgentViewURL = this.navigationService
       .getPathname()
       .includes(this.AGENT_VIEW_URL);
-    this.navigationService
-      .getParams()
-      .set(
-        includesAgentViewURL
-          ? PinnedAgentManager.AGENT_ID_VIEW_KEY
-          : PinnedAgentManager.AGENT_ID_URL_VIEW_KEY,
-        String(agentData?.id),
-      );
-    this.navigationService.renewURL(this.navigationService.getParams());
+
+    const urlSearchParams = this.navigationService.getParams();
+
+    urlSearchParams.set(
+      includesAgentViewURL
+        ? PinnedAgentManager.AGENT_ID_VIEW_KEY
+        : PinnedAgentManager.AGENT_ID_URL_VIEW_KEY,
+      String(agentData?.id),
+    );
+    this.navigationService.renewURL(urlSearchParams);
   }
 
   unPinAgent(): void {


### PR DESCRIPTION
### Description
This pull request fixes a problem of pinned agent is not kept when refreshing the page.
 
### Issues Resolved
#6788

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
