### PR TITLE
Fixed error when pinned agent in vulnerabilities

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/common/vulnerability_detector_adapters.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/common/vulnerability_detector_adapters.tsx
@@ -1,7 +1,6 @@
 import {
   AUTHORIZED_AGENTS,
   VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER,
-  WAZUH_ALERTS_PATTERN,
 } from '../../../../../common/constants';
 import { AppState } from '../../../../react-services';
 import { FilterHandler } from '../../../../utils/filter-handler';
@@ -113,7 +112,7 @@ export const restorePrevIndexFiltersAdapter = (
   cleanedFilters.unshift(managerFilter);
   const implicitPinnedAgent = getImplicitPinnedAgent(
     previousFilters,
-    toIndexPattern ?? WAZUH_ALERTS_PATTERN,
+    toIndexPattern ?? AppState.getCurrentPattern(),
   );
   if (implicitPinnedAgent) {
     const cleanedFiltersWithoutNormalAgents = cleanedFilters.filter(x => {
@@ -143,7 +142,7 @@ export const onUpdateAdapter = (
    */
   const cleanedFilters = cleanFilters(
     filters,
-    prevStoragePattern ?? WAZUH_ALERTS_PATTERN,
+    prevStoragePattern ?? AppState.getCurrentPattern(),
   );
   if (storagePreviousFilters) {
     const previousFilters = JSON.parse(storagePreviousFilters);
@@ -152,7 +151,7 @@ export const onUpdateAdapter = (
     );
     const cleanedPreviousImplicitFilters = cleanFilters(
       previousImplicitFilters,
-      prevStoragePattern ?? WAZUH_ALERTS_PATTERN,
+      prevStoragePattern ?? AppState.getCurrentPattern(),
     );
     /* Normal filters added to storagePreviousFilters are added to keep them between dashboard and inventory tab */
     const newFilters = filters.filter(


### PR DESCRIPTION
## Description
This PR solves filter error when pinning an agent when an index pattern is used for wazuh-alerts that is not `wazuh-alerts-*`.
 
## Issues Resolved


## Evidence

### Before

![Before](https://github.com/user-attachments/assets/8284bb06-af04-4e66-8dab-59f4cb9d1a50)

### After

![After](https://github.com/user-attachments/assets/6f6803e5-79cd-4800-bfd4-4ba331a5c78f)

## Test

1. It is necessary to remove both the index and the index pattern from wazuh-alerts-*.
2. To emulate the problem, the indexes generated with sample data will be used, so sample data must be added.
3. The default index pattern name in AppSettings must be changed. In this case I changed to wazuh-alerts-4.x-sample-security to take advantage of the sample data.
4. An index pattern named wazuh-alerts-4.x-sample-security must be created to match the wazuh-alerts-4.x-sample-security index of sample data.
5. Go to the vulnerabilities module, pin an agent in Dashboard/Inventory and then go to the Events tab.
6. Check that the pinned agent filter appears correctly without error.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
