### PR TITLE
Fixed donut card legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Change how the configuration is managed in the backend side [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337) [#6519](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6519) [#6573](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6573)
 - Change the view of API is down and check connection to Server APIs application [#6337](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6337)
 - Changed the usage of the endpoint GET /groups/{group_id}/files/{file_name} [#6385](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6385)
-- Refactoring and redesign endpoints summary visualizations [#6268](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6268)
+- Refactoring and redesign endpoints summary visualizations [#6268](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6268) [#6832](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6832)
 - Move AngularJS settings controller to ReactJS [#6580](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6580)
 - Move AngularJS controller and view for manage groups to ReactJS [#6543](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6543)
 - Move AngularJS controllers and views of Tools and Dev Tools to ReactJS [#6544](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6544)

--- a/plugins/main/public/components/common/charts/visualizations/legend.scss
+++ b/plugins/main/public/components/common/charts/visualizations/legend.scss
@@ -3,7 +3,7 @@
   overflow: auto;
   scrollbar-width: none;
   @media (min-width: 1024px) {
-    width: 160px;
+    width: 195px;
   }
 }
 

--- a/plugins/main/public/components/endpoints-summary/dashboard/components/donut-card.tsx
+++ b/plugins/main/public/components/endpoints-summary/dashboard/components/donut-card.tsx
@@ -41,7 +41,10 @@ const DonutCard = ({
       betaBadgeLabel={betaBadgeLabel}
     >
       <EuiFlexGroup>
-        <EuiFlexItem className='align-items-center'>
+        <EuiFlexItem
+          className='align-items-center'
+          style={{ margin: '12px 0px' }}
+        >
           <VisualizationBasic
             isLoading={isLoading}
             type='donut'


### PR DESCRIPTION
## Description
This PR fixes the legend of the donut-card component to adjust the available space the legend has, allowing more text to be rendered.
 
## Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/244

## Evidence

### Breakpoint 425px

![image](https://github.com/user-attachments/assets/b290c618-437d-4dcf-8aa9-3b775eb64c42)

### Breakpoint 768px

![image](https://github.com/user-attachments/assets/552afbca-b39f-49fd-a1db-49cdbaf89b91)

### Breakpoint 1024px

![image](https://github.com/user-attachments/assets/af89f029-cad3-40fc-b491-880a294d9007)

### Breakpoint 1440px

![image](https://github.com/user-attachments/assets/50839fb6-c8cf-4bd6-b421-2e7509d1c2b7)

## Test

- Go to `Server management -> Endpoints Summary`
- Check that the legends of the donut cards, especially those of Agents by status, are complete.

## Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
