### PR TITLE
Add saved queries button to search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Upgraded versions of `follow-redirects` and `es5-ext` [#6626](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6626)
 - Changed agent log collector socket API response controller component [#6660](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6660)
 - Improve margins and paddings in the Events, Inventory and Control tabs [#6708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6708)
-- Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716) [#6755](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6755)
+- Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716) [#6755](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6755) [#6833](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6833)
 - Generate URL with predefined filters [#6745](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6745)
 - Migrated AngularJS routing to ReactJS [#6689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6689) [#6775](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6775) [#6790](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6790
 - Improvement of the filter management system by implementing new standard modules [#6534](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6534) [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772)

--- a/plugins/main/public/components/common/search-bar/search-bar.scss
+++ b/plugins/main/public/components/common/search-bar/search-bar.scss
@@ -1,3 +1,13 @@
 .wz-search-bar-no-padding .globalQueryBar:not(:empty) {
   padding: 0px !important;
 }
+
+.wz-search-bar {
+  > .euiFlexGroup {
+    &:first-child {
+      #GlobalFilterGroup {
+        display: none;
+      }
+    }
+  }
+}

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -6,7 +6,6 @@ import {
   SearchBarProps,
   Filter,
 } from '../../../../../../src/plugins/data/public';
-import useSearchBar from './use-search-bar';
 
 export interface WzSearchBarProps extends SearchBarProps {
   fixedFilters?: Filter[];
@@ -49,9 +48,7 @@ export const WzSearchBar = ({
         >
           {preQueryBar ? <EuiFlexItem>{preQueryBar}</EuiFlexItem> : null}
           <EuiFlexItem grow={!preQueryBar}>
-            <SearchBar
-              {...restProps}
-              showFilterBar={false} />
+            <SearchBar {...restProps} />
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : null}
@@ -68,10 +65,11 @@ export const WzSearchBar = ({
                 {fixedFilters?.map((filter, idx) => (
                   <EuiFlexItem grow={false} key={idx}>
                     <EuiBadge className='globalFilterItem' color='hollow'>
-                      {`${filter.meta.key}: ${typeof filter.meta.value === 'function'
-                        ? filter.meta.value()
-                        : filter.meta.value
-                        }`}
+                      {`${filter.meta.key}: ${
+                        typeof filter.meta.value === 'function'
+                          ? filter.meta.value()
+                          : filter.meta.value
+                      }`}
                     </EuiBadge>
                   </EuiFlexItem>
                 ))}


### PR DESCRIPTION
### Description

Add the save query button to the search bar of the dashboards.
 
### Issues Resolved

- #6829 

### Evidence

<img width="959" alt="image" src="https://github.com/user-attachments/assets/563db50a-5f75-46a3-8518-1456a9ef375b">

### Test

- Navigate to the different dashboards and events. 
- See that the Saved queries button appears and saves the filters external to the dashboard.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
