### PR TITLE
Fix permalink field in Events tab in Virustotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Generate URL with predefined filters [#6745](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6745)
 - Migrated AngularJS routing to ReactJS [#6689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6689) [#6775](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6775) [#6790](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6790
 - Improvement of the filter management system by implementing new standard modules [#6534](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6534) [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772)
+- Changed permalink field in the Events tab table in Virustotal to show an external link [#6839](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6839)
 
 ### Fixed
 

--- a/plugins/main/public/components/overview/virustotal/events/virustotal-columns.tsx
+++ b/plugins/main/public/components/overview/virustotal/events/virustotal-columns.tsx
@@ -14,11 +14,17 @@ export const virustotalColumns: tDataGridColumn[] = [
   },
   {
     id: 'data.virustotal.permalink',
-    render: value => (
-      <EuiLink href={value} target='_blank' external>
-        {value}
-      </EuiLink>
-    ),
+    render: value => {
+      if (!value) {
+        return '-';
+      } else {
+        return (
+          <EuiLink href={value} target='_blank' external>
+            {value}
+          </EuiLink>
+        );
+      }
+    },
   },
   {
     id: 'data.virustotal.malicious',

--- a/plugins/main/public/components/overview/virustotal/events/virustotal-columns.tsx
+++ b/plugins/main/public/components/overview/virustotal/events/virustotal-columns.tsx
@@ -1,4 +1,6 @@
 import { tDataGridColumn } from '../../../common/data-grid';
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
 
 export const virustotalColumns: tDataGridColumn[] = [
   {
@@ -12,6 +14,11 @@ export const virustotalColumns: tDataGridColumn[] = [
   },
   {
     id: 'data.virustotal.permalink',
+    render: value => (
+      <EuiLink href={value} target='_blank' external>
+        {value}
+      </EuiLink>
+    ),
   },
   {
     id: 'data.virustotal.malicious',


### PR DESCRIPTION
## Description
This PR fixes `data.virustotal.permalink` column of the table in Events tab in Virustotal module. Para ello se cambia el render de ese campo usando un `EuiLink` con atributos de URL externo.
 
## Issues Resolved
- #6838 

## Evidence

### data.virustotal.permalink as link

![image](https://github.com/user-attachments/assets/843b026c-f1f8-471c-919d-6bed779dce7b)

### Redirected page

![image](https://github.com/user-attachments/assets/101286bb-04e7-4a45-bcdc-705e09cb4f69)

### Evidence external link

![image](https://github.com/user-attachments/assets/cf18a4d2-1fdc-490e-9530-3f8a9a08052e)


## Test
- Go to Virustotal module
- Go to Events tab
- Check  `data.virustotal.permalink` column shows links
- Chequear el correcto funcionamiento de los enlaces

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
