### PR TITLE
Add colours to GitHub dashboard metric visualisations

### DIFF
--- a/plugins/main/public/components/overview/github/dashboards/dashboard-panels.ts
+++ b/plugins/main/public/components/overview/github/dashboards/dashboard-panels.ts
@@ -889,10 +889,16 @@ const getVisStateMetricOrganizationsCount = (indexPatternId: string) => {
       metric: {
         percentageMode: false,
         useRanges: false,
-        colorSchema: 'Green to Red',
-        metricColorMode: 'None',
+        colorSchema: 'Greens',
+        metricColorMode: 'Labels',
         colorsRange: [
           {
+            type: 'range',
+            from: 0,
+            to: 0,
+          },
+          {
+            type: 'range',
             from: 0,
             to: 0,
           },
@@ -904,7 +910,6 @@ const getVisStateMetricOrganizationsCount = (indexPatternId: string) => {
         style: {
           bgFill: '#000',
           bgColor: false,
-          labelColor: false,
           subText: '',
           fontSize: 40,
         },
@@ -954,10 +959,16 @@ const getVisStateMetricRepositoriesCount = (indexPatternId: string) => {
       metric: {
         percentageMode: false,
         useRanges: false,
-        colorSchema: 'Green to Red',
-        metricColorMode: 'None',
+        colorSchema: 'Blues',
+        metricColorMode: 'Labels',
         colorsRange: [
           {
+            type: 'range',
+            from: 0,
+            to: 0,
+          },
+          {
+            type: 'range',
             from: 0,
             to: 0,
           },
@@ -1019,10 +1030,16 @@ const getVisStateMetricActorsCount = (indexPatternId: string) => {
       metric: {
         percentageMode: false,
         useRanges: false,
-        colorSchema: 'Green to Red',
-        metricColorMode: 'None',
+        colorSchema: 'Reds',
+        metricColorMode: 'Labels',
         colorsRange: [
           {
+            type: 'range',
+            from: 0,
+            to: 0,
+          },
+          {
+            type: 'range',
             from: 0,
             to: 0,
           },


### PR DESCRIPTION
### Description

Add colours to the metric visualisations on the GitHub dashboard with the 3 colors allowed for such visualisations.
 
### Issues Resolved

- #6856 

### Evidence

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/577a8140-db8b-4441-bade-8a1a85898290">

### Test

1. Navigate to `Github > Dashboard`
2. Check the colors of the metrics visualizations 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
