### PR TITLE
Remove `rule.mitre_techniques` column from the Threat Hunting

### DIFF
--- a/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
@@ -82,19 +82,4 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
         <div>{renderMitreTechnique(value)}</div>
       ),
   },
-  {
-    id: 'rule.mitre_techniques',
-    render: value =>
-      Array.isArray(value) ? (
-        <div style={{ display: 'flex', gap: 10 }}>
-          {value?.map((technique, index) => (
-            <div key={`${technique}-${index}`}>
-              {renderMitreTechnique(technique)}
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div>{renderMitreTechnique(value)}</div>
-      ),
-  },
 ];

--- a/plugins/main/public/components/overview/threat-hunting/events/threat-hunting-columns.tsx
+++ b/plugins/main/public/components/overview/threat-hunting/events/threat-hunting-columns.tsx
@@ -23,9 +23,6 @@ export const threatHuntingTableDefaultColumns: tDataGridColumn[] = [
     id: 'rule.mitre.tactic',
   },
   {
-    id: 'rule.mitre_technique',
-  },
-  {
     id: 'rule.description',
   },
   {
@@ -48,9 +45,6 @@ export const threatHuntingTableAgentColumns: EuiDataGridColumn[] = [
   },
   {
     id: 'rule.mitre.tactic',
-  },
-  {
-    id: 'rule.mitre_technique',
   },
   {
     id: 'rule.description',


### PR DESCRIPTION
### Description

Remove `rule.mitre_techniques` column from the Threat Hunting
 
### Issues Resolved

#6830 

### Evidence

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/5cbd6e84-c0fc-4b09-8b9f-bf81b49649eb">

### Test

- Go to the `Threat Hunting` module and verify that the field `rule.mitre_techniques` does not appear in the table on the `Dashboard` tab.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
