### PR TITLE
Checking the internal tab when changing agent on FIM > Inventory > Windows registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed styles in small height viewports [#6747](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6747)
 - Fixed behavior in Configuration Assessment when changing API [#6770](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6770)
 - Fixed the fixed maximum width of the clear session button in the ruleset test view [#6871](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6871)
+- Fixed redirection to FIM > Inventory > Files from FIM > Inventory > Windows Registry when switching to non-Windows agent. [#6880](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6880)
 
 ### Removed
 


### PR DESCRIPTION
### Description

Solution to change tab from Windows registry to Files when you have an agent pinned with windows and you switch to a non-windows agent.
 
### Issues Resolved

- #6879 

### Evidence

https://github.com/user-attachments/assets/2b457a7c-5e44-4834-9bb6-cbfbdb135acf


### Preconditions

Have 2 agents 1 windows and 1 from another operating system connected

### Test

1. Navigate to 'FIM > Inventory > Windows registry'
2. Change the pinned agent to the one of the other operating system
3. Windows registry tab should be changed for Files

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
