### PR TITLE
Fix endpoints summary agent action buttons navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Improve margins and paddings in the Events, Inventory and Control tabs [#6708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6708)
 - Refactored the search bar to correctly handle fixed and user-added filters [#6716](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6716) [#6755](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6755) [#6833](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6833)
 - Generate URL with predefined filters [#6745](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6745)
-- Migrated AngularJS routing to ReactJS [#6689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6689) [#6775](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6775) [#6790](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6790)
+- Migrated AngularJS routing to ReactJS [#6689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6689) [#6775](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6775) [#6790](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6790) [#6893](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6893)
 - Improvement of the filter management system by implementing new standard modules [#6534](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6534) [#6772](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6772) [#6873](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6873)
 - Changed permalink field in the Events tab table in Virustotal to show an external link [#6839](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6839)
 - Changed the logging system to use the provided by the platform [#6161](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6161)

--- a/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
@@ -35,9 +35,9 @@ export const agentsTableActions = (
     color: 'primary',
     enabled: agent => agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
     onClick: agent =>
-      NavigationService.getInstance().navigateToApp(endpointSummary.id, {
-        path: `#/agents?tab=welcome&agent=${agent.id}`,
-      }),
+      NavigationService.getInstance().navigate(
+        `/agents?tab=welcome&agent=${agent.id}`,
+      ),
   },
   {
     name: agent => {
@@ -57,9 +57,9 @@ export const agentsTableActions = (
     icon: 'wrench',
     type: 'icon',
     onClick: agent =>
-      NavigationService.getInstance().navigateToApp(endpointSummary.id, {
-        path: `#/agents?tab=configuration&agent=${agent.id}`,
-      }),
+      NavigationService.getInstance().navigate(
+        `/agents?tab=configuration&agent=${agent.id}`,
+      ),
     enabled: agent => agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
     'data-test-subj': 'action-configuration',
   },


### PR DESCRIPTION
### Description
Hi team,
this pull request fixes the navigation method of the endpoint summary table action buttons, so the buttons use an in-module navigation method.
 
### Issues Resolved
Closes #6892 

### Evidence
![Peek 2024-08-01 11-51](https://github.com/user-attachments/assets/af243dbe-825c-4ac2-8ec1-8d4f465d665e)


### Test

1. Go to Endpoints summary
2. Click on the :eye: button of an agent row to navigate to the agent details. Then go back in the browser history.
3. Click on the `...` button of an agent row to expand the actions, then click on `View agent details` to test the navigation.
4. Click on the `...` button of an agent row to expand the actions, then click on `Agent configuration` to navigate to the agent configuration.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
