### PR TITLE
Changed windows-agent-deployment command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-
 - Fixed windows-agent-deployment-command from deploy new agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)
-
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.9.1
 
+### Fixed
+
+- Fixed windows-agent-deployment-command from deploy new agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
+
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 03
 
 ### Added

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
@@ -145,7 +145,7 @@ describe('getLinuxStartCommand', () => {
 
 describe('getWindowsInstallCommand', () => {
   it('should return the correct install command', () => {
-    let expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \${env.tmp}\\wazuh-agent; msiexec.exe /i \${env.tmp}\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} `;
+    let expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \$env:tmp\\wazuh-agent; msiexec.exe /i \$env:tmp\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} `;
 
     const withAllOptionals = getWindowsInstallCommand(test);
     expect(withAllOptionals).toEqual(expected);
@@ -153,7 +153,7 @@ describe('getWindowsInstallCommand', () => {
     delete test.optionals.wazuhPassword;
     delete test.optionals.agentName;
 
-    expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \${env.tmp}\\wazuh-agent; msiexec.exe /i \${env.tmp}\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.agentGroups} `;
+    expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \$env:tmp\\wazuh-agent; msiexec.exe /i \$env:tmp\\wazuh-agent /q ${test.optionals.serverAddress} ${test.optionals.agentGroups} `;
     const withServerAddresAndAgentGroupsOptions =
       getWindowsInstallCommand(test);
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
@@ -111,7 +111,7 @@ export const getWindowsInstallCommand = (
   props: tOSEntryInstallCommand<tOptionalParameters>,
 ) => {
   const { optionals, urlPackage, name } = props;
-  return `Invoke-WebRequest -Uri ${urlPackage} -OutFile \${env.tmp}\\wazuh-agent; msiexec.exe /i \${env.tmp}\\wazuh-agent /q ${
+  return `Invoke-WebRequest -Uri ${urlPackage} -OutFile \$env:tmp\\wazuh-agent; msiexec.exe /i \$env:tmp\\wazuh-agent /q ${
     optionals && getAllOptionals(optionals, name)
   }`;
 };


### PR DESCRIPTION
### Description

The windows-agent-deployment command uses `${env.tmp}` instead of `$env:tmp`. Then the pull changes the command.
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6518

### Evidence

![image](https://github.com/user-attachments/assets/4332aff6-13a5-476e-ab09-a829e93fdf53)

```powershell
Invoke-WebRequest -Uri https://packages.wazuh.com/4.x/windows/wazuh-agent-4.9.1-1.msi -OutFile $env:tmp\wazuh-agent; msiexec.exe /i $env:tmp\wazuh-agent /q WAZUH_MANAGER='0' 
```

### Test

Go to Endpoints summary > Deploy new agent. Mark Windows deployment and check that the command in step 4 uses `$env:tmp` instead of `${env.tmp}`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
