### PR TITLE
Repair mac deployment-agent-command

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
@@ -149,7 +149,7 @@ export const getMacOsInstallCommand = (
     // We need to remove the " added by JSON.stringify
     optionalsForCommand.wazuhPassword = `${JSON.stringify(
       optionalsForCommand?.wazuhPassword,
-    ).substring(1, scapedPasswordLength - 1)}\\n`;
+    ).substring(1, scapedPasswordLength - 1)}`;
   }
 
   // Set macOS installation script with environment variables


### PR DESCRIPTION
### Description


Mac deployment-agent-command adds `\n` into the end of the `WAZUH_REGISTRATION_PASSWORD` variable. This PR removes the new line.
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6906

### Evidence

![image](https://github.com/user-attachments/assets/260db535-4af6-46b0-9b59-cff746217e19)


### Test

> To test this PR it must be tested with a real manager.

1. In manager files > Go to /var/ossec/etc/ossec.conf
2. Add (in auth section) <use_password>yes</use_password>
3. Create (in /var/ossec/etc/) authd.pass file

  `echo "<CUSTOM_PASSWORD>" > /var/ossec/etc/authd.pass`

4. Restart manager
5. (In dashboard) Go to Endpoints summary > Deploy new agent. Select a mac os agent deployment.
6. Check that '\n' doesn't show in the `WAZUH_REGISTRATION_PASSWORD` variable in the deployment command.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
