### PR TITLE
Repair mac deployment-agent-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed windows-agent-deployment-command from deploy new agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
-- Fixed mac-agent-deployment-command from deploy new agent [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
+- Fixed the temporal directory variable on the the command to deploy a new Windows agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
+- Fixed an error on the command to deploy a new macOS agent that could cause the registration password had a wrong value because a `\n` could be included [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)
 - Fixed an error on Dev Tools when using payload properties as arrays [#6908](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6908)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed windows-agent-deployment-command from deploy new agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
+- Fixed mac-agent-deployment-command from deploy new agent [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 03

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
@@ -205,7 +205,7 @@ describe('transformOptionalsParamatersMacOSCommand', () => {
 
 describe('getMacOsInstallCommand', () => {
   it('should return the correct macOS installation script', () => {
-    let expected = `curl -so wazuh-agent.pkg ${test.urlPackage} && echo "${test.optionals.serverAddress} && ${test.optionals.agentGroups} && ${test.optionals.agentName} && ${test.optionals.wazuhPassword}\\n\" > /tmp/wazuh_envs && sudo installer -pkg ./wazuh-agent.pkg -target /`;
+    let expected = `curl -so wazuh-agent.pkg ${test.urlPackage} && echo "${test.optionals.serverAddress} && ${test.optionals.agentGroups} && ${test.optionals.agentName} && ${test.optionals.wazuhPassword}\" > /tmp/wazuh_envs && sudo installer -pkg ./wazuh-agent.pkg -target /`;
 
     const withAllOptionals = getMacOsInstallCommand(test);
     expect(withAllOptionals).toEqual(expected);

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
@@ -149,7 +149,7 @@ export const getMacOsInstallCommand = (
     // We need to remove the " added by JSON.stringify
     optionalsForCommand.wazuhPassword = `${JSON.stringify(
       optionalsForCommand?.wazuhPassword,
-    ).substring(1, scapedPasswordLength - 1)}\\n`;
+    ).substring(1, scapedPasswordLength - 1)}`;
   }
 
   // Set macOS installation script with environment variables


### PR DESCRIPTION
### Description

Mac deployment-agent-command adds `\n` into the end of the `WAZUH_REGISTRATION_PASSWORD` variable. This PR removes the new line.
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6906

### Evidence

![image](https://github.com/user-attachments/assets/260db535-4af6-46b0-9b59-cff746217e19)


### Test

> To test this PR it must be tested with a real manager.

1. In manager files > Go to /var/ossec/etc/ossec.conf
2. Add (in auth section) <use_password>yes</use_password>
3. Create (in /var/ossec/etc/) authd.pass file

  `echo "<CUSTOM_PASSWORD>" > /var/ossec/etc/authd.pass`

4. Restart manager
5. (In dashboard) Go to Endpoints summary > Deploy new agent. Select a mac os agent deployment.
6. Check that '\n' doesn't show in the `WAZUH_REGISTRATION_PASSWORD` variable in the deployment command.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
