### PR TITLE
Change the registration id of the setting application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.10.0
 
+### Changed
+
+- Changed the registration id of the Settings application for compatibility with Opensearch Dashboard 2.16.0 [#6938](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6938)
+
 ## Wazuh v4.9.1 - OpenSearch Dashboards 2.13.0 - Revision 00
 
 ### Added

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -682,7 +682,7 @@ export const reporting = {
 
 export const settings = {
   category: 'wz-category-server-management',
-  id: 'app-settings',
+  id: 'dashboards-settings',
   title: i18n.translate('wz-app-settings-title', {
     defaultMessage: 'Settings',
   }),

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -682,7 +682,7 @@ export const reporting = {
 
 export const settings = {
   category: 'wz-category-server-management',
-  id: 'settings',
+  id: 'app-settings',
   title: i18n.translate('wz-app-settings-title', {
     defaultMessage: 'Settings',
   }),


### PR DESCRIPTION
### Description

In opensearch 2.16.0 compatibility they add the option to have a new menu, and because of this change new plugins were registered that conflict with ours so we had to change the settings id. 
 
### Issues Resolved
- #6920 

### Evidence

![image](https://github.com/user-attachments/assets/ce3a22bf-fd5a-4948-8efb-2fe438a7e131)

### Test

Using OSD 2.16.0 it should work as expected.
the url of Server management> Settings should be /app/dashboards-settings

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
