### PR TITLE
Keep the appState filters on refreshing page

### DIFF
--- a/plugins/main/public/utils/migrate_legacy_query.ts
+++ b/plugins/main/public/utils/migrate_legacy_query.ts
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { has } from 'lodash';
+import { Query } from 'src/plugins/data/public';
+
+/**
+ * Creates a standardized query object from old queries that were either strings or pure OpenSearch query DSL
+ *
+ * @param query - a legacy query, what used to be stored in SearchSource's query property
+ * @return Object
+ */
+
+export function migrateLegacyQuery(
+  query: Query | { [key: string]: any } | string,
+): Query {
+  // Lucene was the only option before, so language-less queries are all lucene
+  if (!has(query, 'language')) {
+    return { query, language: 'lucene' };
+  }
+
+  return query as Query;
+}


### PR DESCRIPTION
### Description
This pull request fixes a problem with the filters are not kept when refreshing the page.

> This pull request does not contain an entry in the changelog because the entry was added to the entry of https://github.com/wazuh/wazuh-dashboard-plugins/issues/6120 that includes multiple pull requests
 
### Issues Resolved
#6937

### Evidence
![image](https://github.com/user-attachments/assets/10522f1a-e9bd-49f0-911d-9f5a0e8e4584)

### Test

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
