### PR TITLE
Improve intelligence flyout details readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Upgraded the `axios` dependency to `1.7.4` [#6919](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6919)
+- Upgraded MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Upgraded the `axios` dependency to `1.7.4` [#6919](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6919)
-- Upgraded MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
+- Improved MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 05
 

--- a/plugins/main/public/components/overview/mitre/intelligence/resource_detail_flyout.tsx
+++ b/plugins/main/public/components/overview/mitre/intelligence/resource_detail_flyout.tsx
@@ -16,10 +16,7 @@ import { MitreAttackResources } from './resources';
 import { ReferencesTable } from './resource_detail_references_table';
 
 import {
-  EuiFlyout,
   EuiFlyoutHeader,
-  EuiOverlayMask,
-  EuiOutsideClickDetector,
   EuiTitle,
   EuiText,
   EuiFlexGroup,
@@ -64,7 +61,7 @@ export const ModuleMitreAttackIntelligenceFlyout = ({
                   <div>
                     <strong>{detailProperty.label}</strong>
                   </div>
-                  <EuiText color='subdued'>
+                  <EuiText>
                     {detailProperty.render
                       ? detailProperty.render(details[detailProperty.id])
                       : details[detailProperty.id]}
@@ -79,7 +76,7 @@ export const ModuleMitreAttackIntelligenceFlyout = ({
             <div>
               <strong>Description</strong>
             </div>
-            <EuiText color='subdued'>
+            <EuiText>
               {details.description ? (
                 <Markdown markdown={details.description} />
               ) : (


### PR DESCRIPTION
### Description

The description in the MITRE ATT&CK -> Intelligence -> details flyout get darker
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6951

### Evidence

#### Before

![image](https://github.com/user-attachments/assets/e7a89c75-4ea5-4bbb-8912-7dc3abc7c610)
![image](https://github.com/user-attachments/assets/c59295f5-e6c7-492b-9e55-2bcf75f76d76)

#### After

![image](https://github.com/user-attachments/assets/317c2091-469c-4316-b5c9-05128cecb109)
![image](https://github.com/user-attachments/assets/0b51f930-99fc-4b82-9566-c86a4d8457d3)


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
