### PR TITLE
refactor: Update malware detection group values in data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
+- Update malware detection group values in data sources [#6963](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6963)
 - Changed the registration id of the Settings application for compatibility with Opensearch Dashboard 2.16.0 [#6938](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6938)
 
 ### Removed
@@ -644,7 +645,7 @@ All notable changes to the Wazuh app project will be documented in this file.
   [#3367](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3367)
   [#3373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3373)
   [#3374](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3374)
-  [#3390](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3390)  
+  [#3390](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3390)
   [#3410](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3410)
   [#3408](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3408)
   [#3429](https://github.com/wazuh/wazuh-dashboard-plugins/pull/3429)

--- a/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
@@ -1,9 +1,10 @@
 import { tFilter } from '../../../index';
 import { DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP } from '../../../../../../../common/constants';
 import { AlertsDataSource } from '../alerts-data-source';
+import { FILTER_OPERATOR, PatternDataSourceFilterManager } from '../../..'
 
 const MALWARE_DETECTION_GROUP_KEY = 'rule.groups';
-const MALWARE_DETECTION_GROUP_VALUE = 'rootcheck';
+const MALWARE_DETECTION_GROUP_VALUES = ['rootcheck', 'virustotal', 'yara'];
 
 export class MalwareDetectionDataSource extends AlertsDataSource {
   constructor(id: string, title: string) {
@@ -11,11 +12,14 @@ export class MalwareDetectionDataSource extends AlertsDataSource {
   }
 
   getRuleGroupsFilter() {
-    return super.getRuleGroupsFilter(
-      MALWARE_DETECTION_GROUP_KEY,
-      MALWARE_DETECTION_GROUP_VALUE,
-      DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP,
-    );
+    return [
+      PatternDataSourceFilterManager.createFilter(FILTER_OPERATOR.IS_ONE_OF,
+        MALWARE_DETECTION_GROUP_KEY,
+        MALWARE_DETECTION_GROUP_VALUES,
+        this.id,
+        DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP
+      )
+    ]
   }
 
   getFixedFilters(): tFilter[] {

--- a/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
@@ -1,7 +1,7 @@
 import { tFilter } from '../../../index';
 import { DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP } from '../../../../../../../common/constants';
 import { AlertsDataSource } from '../alerts-data-source';
-import { FILTER_OPERATOR, PatternDataSourceFilterManager } from '../../..'
+import { FILTER_OPERATOR, PatternDataSourceFilterManager } from '../../..';
 
 const MALWARE_DETECTION_GROUP_KEY = 'rule.groups';
 const MALWARE_DETECTION_GROUP_VALUES = ['rootcheck', 'virustotal', 'yara'];
@@ -13,13 +13,14 @@ export class MalwareDetectionDataSource extends AlertsDataSource {
 
   getRuleGroupsFilter() {
     return [
-      PatternDataSourceFilterManager.createFilter(FILTER_OPERATOR.IS_ONE_OF,
+      PatternDataSourceFilterManager.createFilter(
+        FILTER_OPERATOR.IS_ONE_OF,
         MALWARE_DETECTION_GROUP_KEY,
         MALWARE_DETECTION_GROUP_VALUES,
         this.id,
         DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP
-      )
-    ]
+      ),
+    ];
   }
 
   getFixedFilters(): tFilter[] {

--- a/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/malware-detection/malware-detection-data-source.ts
@@ -18,7 +18,7 @@ export class MalwareDetectionDataSource extends AlertsDataSource {
         MALWARE_DETECTION_GROUP_KEY,
         MALWARE_DETECTION_GROUP_VALUES,
         this.id,
-        DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP
+        DATA_SOURCE_FILTER_CONTROLLED_MALWARE_DETECTION_RULE_GROUP,
       ),
     ];
   }

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source-filter-manager.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source-filter-manager.ts
@@ -325,7 +325,7 @@ export class PatternDataSourceFilterManager
   static createFilter(
     type: FILTER_OPERATOR,
     key: string,
-    value: string | [],
+    value: string | string[],
     indexPatternId: string,
     controlledBy?: string,
   ) {


### PR DESCRIPTION
### Description
Change the Endpoint security > Malware detection module filters to "rule.groups is one of rootcheck,virustotal,yara"
 
### Issues Resolved

#6963 

### Evidence
![image](https://github.com/user-attachments/assets/98c6d426-7db3-464b-a9bc-bb39ef3cb157)

### Test
1. Click on "Menu"
2. Expand "Endpoint security"
3. Click on "Malware Detection"
4. Select "Events" tab
5. Click on "«number» columns hidden"

![image](https://github.com/user-attachments/assets/3a7820b0-3f05-4e80-bbfb-07d1013b05b4)

6. Activate column "rule.groups"
7. See the result

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
