### PR TITLE
Changed follow redirects versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Upgraded the `axios` dependency to `1.7.4` [#6919](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6919)
 - Improved MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
+- Upgraded versions of `follow-redirects`[#6982](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6982)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Upgraded the `axios` dependency to `1.7.4` [#6919](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6919)
 - Improved MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
-- Upgraded versions of `follow-redirects`[#6982](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6982)
+- Upgraded the `follow-redirects` dependency to `1.15.6` [#6982](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6982)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 

--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -16,7 +16,7 @@
   "license": "GPL-2.0",
   "resolutions": {
     "**/es5-ext": "^0.10.63",
-    "**/follow-redirects": "^1.15.4"
+    "**/follow-redirects": "^1.15.6"
   },
   "repository": {
     "type": "git",

--- a/plugins/main/yarn.lock
+++ b/plugins/main/yarn.lock
@@ -2136,7 +2136,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.15.0, follow-redirects@^1.15.4, follow-redirects@^1.15.6:
+follow-redirects@^1.15.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==

--- a/plugins/wazuh-check-updates/package.json
+++ b/plugins/wazuh-check-updates/package.json
@@ -7,6 +7,9 @@
   },
   "description": "Wazuh Check Updates",
   "private": true,
+  "resolutions": {
+    "**/follow-redirects": "^1.15.6"
+  },
   "scripts": {
     "build": "yarn plugin-helpers build --opensearch-dashboards-version=$OPENSEARCH_DASHBOARDS_VERSION",
     "plugin-helpers": "node ../../scripts/plugin_helpers",

--- a/plugins/wazuh-core/package.json
+++ b/plugins/wazuh-core/package.json
@@ -7,6 +7,9 @@
   },
   "description": "Wazuh Core",
   "private": true,
+  "resolutions": {
+    "**/follow-redirects": "^1.15.6"
+  },
   "scripts": {
     "build": "yarn plugin-helpers build --opensearch-dashboards-version=$OPENSEARCH_DASHBOARDS_VERSION",
     "plugin-helpers": "node ../../scripts/plugin_helpers",


### PR DESCRIPTION
### Description

Some vulnerabilities are resolved in follow-redirects >= 1.15.6
This PR adds and updates package.json in the plugins.
 
### Issues Resolved

- https://github.com/wazuh/internal-devel-requests/issues/1533

### Evidence

- Check-update-plugin

```
node@osd:~/kbn/plugins/wazuh-check-updates$ cat yarn.lock | grep follow
    follow-redirects "^1.15.6"
follow-redirects@^1.15.6:
  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#[...]"
```

- Core-plugin

```
node@osd:~/kbn/plugins/wazuh-core$ cat yarn.lock | grep follow
    follow-redirects "^1.15.6"
follow-redirects@^1.15.6:
  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#[...]"
```

- Wazuh-plugin

```
node@osd:~/kbn/plugins/wazuh$ cat yarn.lock | grep follow
    follow-redirects "^1.15.0"
    follow-redirects "^1.15.6"
follow-redirects@^1.15.0, follow-redirects@^1.15.6:
  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#[...]"
```

### Test

- Check follow-redirects version are >=1.15.6 
- Checks environment up correctly

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
