### PR TITLE
Add Vulnerabilities Detection and Office 365 links to agent menu on Endpoints Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed an error on the command to deploy a new macOS agent that could cause the registration password had a wrong value because a `\n` could be included [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)
 - Fixed an error on Dev Tools when using payload properties as arrays [#6908](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6908)
+- Fixed missing link to Vulnerabilities detection and Office 365 in the agent menu of `Endpoints Summary` [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
+- Fixed missing options depending on agent operating system in the agent configuration report [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
 
 ### Changed
 

--- a/plugins/main/public/components/agents/export-configuration.js
+++ b/plugins/main/public/components/agents/export-configuration.js
@@ -20,9 +20,8 @@ import {
 } from '@elastic/eui';
 
 import PropTypes from 'prop-types';
-import { UnsupportedComponents } from '../../utils/components-os-support';
-import { WAZUH_AGENTS_OS_TYPE } from '../../../common/constants';
 import { withErrorBoundary } from '../common/hocs';
+import { hasAgentSupportModule } from '../../react-services';
 
 export const ExportConfiguration = withErrorBoundary(
   class ExportConfiguration extends Component {
@@ -57,11 +56,7 @@ export const ExportConfiguration = withErrorBoundary(
       list.forEach((x, idx) => {
         if (
           typeof x === 'string' ||
-          (x.name &&
-            !(
-              UnsupportedComponents[this.props.agentPlatform] ||
-              UnsupportedComponents[WAZUH_AGENTS_OS_TYPE.OTHERS]
-            ).includes(x.name))
+          (x.name && hasAgentSupportModule(this.props.agent, x.name))
         ) {
           this.options.push({ id: `${idx}`, label: x.desc || x });
         }

--- a/plugins/main/public/controllers/management/components/management/configuration/configuration-settings.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/configuration-settings.js
@@ -12,6 +12,7 @@
 
 import { hasAgentSupportModule } from '../../../../../react-services/wz-agents';
 import { WAZUH_MODULES_ID } from '../../../../../../common/constants';
+import { docker as dockerApp } from '../../../../../utils/applications';
 
 export default [
   {
@@ -158,7 +159,7 @@ export default [
         description:
           'Monitor and collect the activity from Docker containers such as creation, running, starting, stopping or pausing events',
         goto: 'docker-listener',
-        when: agent => hasAgentSupportModule(agent, WAZUH_MODULES_ID.DOCKER),
+        when: agent => hasAgentSupportModule(agent, dockerApp.id),
       },
     ],
   },

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -475,7 +475,7 @@ export const office365 = {
   euiIconType: LogoOffice365,
   order: 503,
   showInOverviewApp: true,
-  showInAgentMenu: false,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=office&tabView=dashboard${
       store.getState()?.appStateReducers?.currentAgentData?.id

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -198,7 +198,7 @@ export const vulnerabilityDetection = {
   euiIconType: 'heartbeatApp',
   order: 301,
   showInOverviewApp: true,
-  showInAgentMenu: false,
+  showInAgentMenu: true,
   redirectTo: () =>
     `/overview/?tab=vuls&tabView=dashboard${
       store.getState()?.appStateReducers?.currentAgentData?.id

--- a/plugins/main/public/utils/components-os-support.js
+++ b/plugins/main/public/utils/components-os-support.js
@@ -35,4 +35,4 @@ export const UnsupportedComponents = {
 };
 
 // Office 365 is only compatible with Linux, macOS and Windows
-// https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/office365-module.html#office365
+// https://documentation.wazuh.com/4.9/user-manual/reference/ossec-conf/office365-module.html#office365

--- a/plugins/main/public/utils/components-os-support.js
+++ b/plugins/main/public/utils/components-os-support.js
@@ -10,11 +10,29 @@
  * Find more information about this on the LICENSE file.
  */
 import { WAZUH_AGENTS_OS_TYPE, WAZUH_MODULES_ID } from '../../common/constants';
+import { vulnerabilityDetection, docker, office365 } from './applications';
 
 export const UnsupportedComponents = {
   [WAZUH_AGENTS_OS_TYPE.LINUX]: [],
-  [WAZUH_AGENTS_OS_TYPE.WINDOWS]: [WAZUH_MODULES_ID.AUDITING, WAZUH_MODULES_ID.DOCKER, WAZUH_MODULES_ID.OPEN_SCAP],
-  [WAZUH_AGENTS_OS_TYPE.DARWIN]: [WAZUH_MODULES_ID.AUDITING, WAZUH_MODULES_ID.DOCKER, WAZUH_MODULES_ID.OPEN_SCAP],
-  [WAZUH_AGENTS_OS_TYPE.SUNOS]: [WAZUH_MODULES_ID.VULNERABILITIES],
-  [WAZUH_AGENTS_OS_TYPE.OTHERS]: [WAZUH_MODULES_ID.AUDITING, WAZUH_MODULES_ID.DOCKER, WAZUH_MODULES_ID.OPEN_SCAP, WAZUH_MODULES_ID.VULNERABILITIES]
+  [WAZUH_AGENTS_OS_TYPE.WINDOWS]: [
+    WAZUH_MODULES_ID.AUDITING,
+    docker.id,
+    WAZUH_MODULES_ID.OPEN_SCAP,
+  ],
+  [WAZUH_AGENTS_OS_TYPE.DARWIN]: [
+    WAZUH_MODULES_ID.AUDITING,
+    docker.id,
+    WAZUH_MODULES_ID.OPEN_SCAP,
+  ],
+  [WAZUH_AGENTS_OS_TYPE.SUNOS]: [vulnerabilityDetection.id, office365.id],
+  [WAZUH_AGENTS_OS_TYPE.OTHERS]: [
+    WAZUH_MODULES_ID.AUDITING,
+    docker.id,
+    WAZUH_MODULES_ID.OPEN_SCAP,
+    vulnerabilityDetection.id,
+    office365.id,
+  ],
 };
+
+// Office 365 is only compatible with Linux, macOS and Windows
+// https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/office365-module.html#office365


### PR DESCRIPTION
### Description
This pull request adds the Vulnerabilities detection and Office 365 links to the agent menu on the Endpoints summary application and fixes a problem of missing options depending on the agent operating system in the agent configuration report.

Side changes:
- Enhance the definition and management of unsupported modules by the agent operating system
 
### Issues Resolved
#6972

### Evidence
![image](https://github.com/user-attachments/assets/d7fbd8e8-cd60-405b-a451-250bafc562f0)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With a Windows agent, go to agent overview from Endpoints Summary and ensure the Vulnerabilities detection and Office 365 links appear in the agent menu | :black_circle: | :black_circle: | :black_circle: |
| With a Linux agent, go to agent overview from Endpoints Summary and ensure the Vulnerabilities detection and Office 365 links appear in the agent menu | :black_circle: | :black_circle: | :black_circle: |
| With a Linux agent, go to agent configuration, click on Export PDF button and ensure the Docker listener and OpenSCAP option appear | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With a Windows agent, go to agent overview from Endpoints Summary and ensure the Vulnerabilities detection and Office 365 links appear in the agent menu</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With a Linux agent, go to agent overview from Endpoints Summary and ensure the Vulnerabilities detection and Office 365 links appear in the agent menu</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With a Linux agent, go to agent configuration, click on Export PDF button and ensure the Docker listener and OpenSCAP option appear</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
