### PR TITLE
Columns-selector in events show firsts the picked columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Upgraded the `axios` dependency to `1.7.4` [#6919](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6919)
 - Improved MITRE ATT&CK intelligence flyout details readability [#6954](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6954)
+- Upgraded Event-tab column selector showing first the picked columns [#6984](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6984)
 
 ## Wazuh v4.9.0 - OpenSearch Dashboards 2.13.0 - Revision 07
 

--- a/plugins/main/public/components/common/data-grid/use-data-grid.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid.ts
@@ -149,9 +149,26 @@ export const useDataGrid = (props: tDataGridProps): EuiDataGridProps => {
     ];
   }, [results]);
 
+  const filterColumns = () => {
+    const allColumns = parseColumns(indexPattern?.fields || [], defaultColumns);
+    const [columnMatch, columnNonMatch] = allColumns.reduce(
+      ([matches, nonMatches], item) => {
+        if (columnVisibility.includes(item.name)) {
+          matches.push(item);
+        } else {
+          nonMatches.push(item);
+        }
+        return [matches, nonMatches];
+      },
+      [[], []],
+    );
+    columnMatch.sort((a, b) => a.name.localeCompare(b.name));
+    return [...columnMatch, ...columnNonMatch];
+  };
+
   return {
     'aria-labelledby': props.ariaLabelledBy,
-    columns: parseColumns(indexPattern?.fields || [], defaultColumns),
+    columns: filterColumns(),
     columnVisibility: {
       visibleColumns: columnVisibility,
       setVisibleColumns: setVisibility,

--- a/plugins/main/public/components/common/data-grid/use-data-grid.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid.ts
@@ -162,15 +162,26 @@ export const useDataGrid = (props: tDataGridProps): EuiDataGridProps => {
       },
       [[], []],
     );
-    columnMatch.sort((a, b) => a.name.localeCompare(b.name));
     return [...columnMatch, ...columnNonMatch];
+  };
+
+  const defaultColumnsPosition = (columnsVisibility, defaultColumns) => {
+    const defaults = defaultColumns
+      .map(item => item.id)
+      .filter(id => columnsVisibility.includes(id));
+
+    const nonDefaults = columnsVisibility.filter(
+      item => !defaultColumns.map(item => item.id).includes(item),
+    );
+
+    return [...defaults, ...nonDefaults];
   };
 
   return {
     'aria-labelledby': props.ariaLabelledBy,
     columns: filterColumns(),
     columnVisibility: {
-      visibleColumns: columnVisibility,
+      visibleColumns: defaultColumnsPosition(columnVisibility, defaultColumns),
       setVisibleColumns: setVisibility,
     },
     renderCellValue: renderCellValue,

--- a/plugins/main/public/components/common/data-grid/use-data-grid.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid.ts
@@ -151,17 +151,17 @@ export const useDataGrid = (props: tDataGridProps): EuiDataGridProps => {
 
   const filterColumns = () => {
     const allColumns = parseColumns(indexPattern?.fields || [], defaultColumns);
-    const [columnMatch, columnNonMatch] = allColumns.reduce(
-      ([matches, nonMatches], item) => {
-        if (columnVisibility.includes(item.name)) {
-          matches.push(item);
-        } else {
-          nonMatches.push(item);
-        }
-        return [matches, nonMatches];
-      },
-      [[], []],
-    );
+    const columnMatch = [];
+    const columnNonMatch = [];
+
+    for (const item of allColumns) {
+      if (columnVisibility.includes(item.name)) {
+        columnMatch.push(item);
+      } else {
+        columnNonMatch.push(item);
+      }
+    }
+
     return [...columnMatch, ...columnNonMatch];
   };
 


### PR DESCRIPTION
### Description

The Events tab has a column selector that shows all available columns. Selected columns appear in this selector, ordered alphabetically. This PR moves the selected columns to the beginning.

Additionally, add functionality to the table so that default columns maintain their position even when they are added or removed.
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/6978

### Evidence

![image](https://github.com/user-attachments/assets/eca59bd0-01d6-4d49-8480-f9f0337f746f)


### Test

- Go to any app with event tabs
- Click on the columns selector and make sure that when a column is selected, it appears before the unselected columns
- Add and remove columns and check that appears first the default columns

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
