### PR TITLE
Fix styles that truncates Discover plugin rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed an error on the command to deploy a new macOS agent that could cause the registration password had a wrong value because a `\n` could be included [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)
 - Fixed an error on Dev Tools when using payload properties as arrays [#6908](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6908)
+- Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing options depending on agent operating system in the agent configuration report [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
 - Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 
-
 ### Changed
 
 - Change the text of the query limit tooltip [#6981](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6981)

--- a/plugins/main/public/styles/layout.scss
+++ b/plugins/main/public/styles/layout.scss
@@ -373,14 +373,3 @@
     font-kerning: normal !important;
   }
 }
-
-.table > thead > tr > th,
-.table > tbody > tr > th,
-.table > tfoot > tr > th,
-.table > thead > tr > td,
-.table > tbody > tr > td,
-.table > tfoot > tr > td {
-  font-size: 13px !important;
-  font-kerning: normal !important;
-  padding: 8px !important;
-}


### PR DESCRIPTION
### Description
This PR aims to remove an unnecessary style that truncates the rows in the Discover plugin. As it is a style from the Wazuh plugin, it also makes the wazuh dashboard inconsistent, because if the user refreshes the page inside the Discover plugin, the style is not loaded. 
 
### Issues Resolved
#6976 

### Evidence
**Before**
![image](https://github.com/user-attachments/assets/3bde340e-7731-476c-ac9e-491a3b7256ef)

**After**
![image](https://github.com/user-attachments/assets/1bc2ff9b-3051-4840-bf3d-6e214bd3ba32)

### Test
- Navigate to the discover plugin and confirm that the text is not truncated
- Verify that there are no broken pages after this change 

>[!NOTE]
>The text in Discover may be a little bit truncated as it is a problem that [is also present](https://playground.opensearch.org/app/data-explorer/discover#) in OpenSearch.

>[!NOTE]
>The size of the rows in the flyouts may be a little smaller, but the text should be completely legible

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
