### PR TITLE
Vulnerability dashboard error loading for read only user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
+- Fixed issue causing vulnerability dashboard to fail loading for read-only users [#6933](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6993)
 - Fixed the temporal directory variable on the the command to deploy a new Windows agent [#6905](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6905)
 - Fixed an error on the command to deploy a new macOS agent that could cause the registration password had a wrong value because a `\n` could be included [#6906](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6906)
 - Fixed rendering an active response as disabled when is active [#6901](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6901)

--- a/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
+++ b/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
@@ -77,8 +77,11 @@ type tUseDataSourceNotLoadedReturns = {
   filterManager: null;
 };
 
-export function useDataSource<T extends tParsedIndexPattern, K extends PatternDataSource>(
-  props: tUseDataSourceProps<T, K>
+export function useDataSource<
+  T extends tParsedIndexPattern,
+  K extends PatternDataSource,
+>(
+  props: tUseDataSourceProps<T, K>,
 ): tUseDataSourceLoadedReturns<K> | tUseDataSourceNotLoadedReturns {
   const navigationService = NavigationService.getInstance();
   const config = getUiSettings();
@@ -87,8 +90,10 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
     useHash: config.get(OSD_URL_STATE_STORAGE_ID),
     history: history,
   });
-  const appDefaultFilters = osdUrlStateStorage.get<{ filters: [] }>('_a')?.filters ?? [];
-  const globalDefaultFilters = osdUrlStateStorage.get<{ filters: [] }>('_g')?.filters ?? [];
+  const appDefaultFilters =
+    osdUrlStateStorage.get<{ filters: [] }>('_a')?.filters ?? [];
+  const globalDefaultFilters =
+    osdUrlStateStorage.get<{ filters: [] }>('_g')?.filters ?? [];
   const defaultFilters = [...appDefaultFilters, ...globalDefaultFilters];
   const {
     filters: initialFilters = [...defaultFilters],
@@ -141,7 +146,10 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
       try {
         const factory = injectedFactory || new PatternDataSourceFactory();
         const patternsData = await repository.getAll();
-        const dataSources = await factory.createAll(DataSourceConstructor, patternsData);
+        const dataSources = await factory.createAll(
+          DataSourceConstructor,
+          patternsData,
+        );
         const selector = new PatternDataSourceSelector(dataSources, repository);
         const dataSource = await selector.getSelectedDataSource();
         if (!dataSource) {
@@ -153,14 +161,16 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
           dataSource,
           initialFilters,
           injectedFilterManager,
-          initialFetchFilters
+          initialFetchFilters,
         );
         // what the filters update
         subscription = dataSourceFilterManager.getUpdates$().subscribe({
           next: () => {
             if (!isComponentMounted()) return;
             // this is necessary to remove the hidden filters from the filter manager and not show them in the search bar
-            dataSourceFilterManager.setFilters(dataSourceFilterManager.getFilters());
+            dataSourceFilterManager.setFilters(
+              dataSourceFilterManager.getFilters(),
+            );
             setAllFilters(dataSourceFilterManager.getFilters());
             setFetchFilters(dataSourceFilterManager.getFetchFilters());
             setFixedFilters(dataSourceFilterManager.getFixedFilters());

--- a/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
+++ b/plugins/main/public/components/common/data-source/hooks/use-data-source.ts
@@ -11,7 +11,6 @@ import {
   PatternDataSourceFilterManager,
   tFilterManager,
 } from '../index';
-import { TimeRange } from '../../../../../../../src/plugins/data/public';
 import { createOsdUrlStateStorage } from '../../../../../../../src/plugins/opensearch_dashboards_utils/public';
 import NavigationService from '../../../../react-services/navigation-service';
 import { OSD_URL_STATE_STORAGE_ID } from '../../../../../common/constants';
@@ -56,7 +55,6 @@ type tUseDataSourceLoadedReturns<K> = {
   fetchData: (params: Omit<tSearchParams, 'filters'>) => Promise<any>;
   setFilters: (filters: tFilter[]) => void;
   filterManager: PatternDataSourceFilterManager;
-  fetchDateRange: TimeRange;
 };
 
 type tUseDataSourceNotLoadedReturns = {
@@ -89,8 +87,8 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
     useHash: config.get(OSD_URL_STATE_STORAGE_ID),
     history: history,
   });
-  const appDefaultFilters = osdUrlStateStorage.get('_a')?.filters ?? [];
-  const globalDefaultFilters = osdUrlStateStorage.get('_g')?.filters ?? [];
+  const appDefaultFilters = osdUrlStateStorage.get<{ filters: [] }>('_a')?.filters ?? [];
+  const globalDefaultFilters = osdUrlStateStorage.get<{ filters: [] }>('_g')?.filters ?? [];
   const defaultFilters = [...appDefaultFilters, ...globalDefaultFilters];
   const {
     filters: initialFilters = [...defaultFilters],
@@ -115,7 +113,6 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
   const [allFilters, setAllFilters] = useState<tFilter[]>([]);
   const pinnedAgentManager = new PinnedAgentManager();
   const pinnedAgent = pinnedAgentManager.getPinnedAgent();
-  const [fetchDateRange, setFetchDateRange] = useState<TimeRange>();
   const { isComponentMounted, getAbortController } = useIsMounted();
 
   const setFilters = (filters: tFilter[]) => {
@@ -214,7 +211,6 @@ export function useDataSource<T extends tParsedIndexPattern, K extends PatternDa
       fetchData,
       setFilters,
       filterManager: dataSourceFilterManager as PatternDataSourceFilterManager,
-      fetchDateRange,
     };
   }
 }

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.test.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.test.ts
@@ -22,7 +22,7 @@ describe('PatternDataSource', () => {
       updateSavedObject: jest.fn(),
     };
     // @ts-expect-error
-    patternDataSource.patternService = patternService
+    patternDataSource.patternService = patternService;
   });
 
   it('should throw error when pattern not found', () => {
@@ -30,7 +30,7 @@ describe('PatternDataSource', () => {
     expect(async () => {
       await patternDataSource.select();
     }).rejects.toThrow(
-      'Error selecting index pattern: Error: Error selecting index pattern: pattern not found'
+      'Error selecting index pattern: Error: Error selecting index pattern: pattern not found',
     );
   });
 

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.test.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.test.ts
@@ -1,0 +1,47 @@
+import { IndexPatternsService } from '../../../../../../../src/plugins/data/common';
+import { RecordMock } from '../../../../../test/types';
+import { PatternDataSource } from './pattern-data-source';
+
+let patternService: RecordMock<IndexPatternsService>;
+let patternDataSource: PatternDataSource;
+const TEST_ID = 'test-id';
+const TEST_TITLE = 'test-title';
+
+describe('PatternDataSource', () => {
+  beforeEach(() => {
+    patternDataSource = new PatternDataSource(TEST_ID, TEST_TITLE);
+    // @ts-expect-error
+    patternService = {
+      get: jest.fn().mockImplementation(() => ({
+        getScriptedFields: jest.fn().mockImplementation(() => []),
+        fields: {
+          replaceAll: jest.fn(),
+        },
+      })),
+      getFieldsForIndexPattern: jest.fn().mockResolvedValue([]),
+      updateSavedObject: jest.fn(),
+    };
+    // @ts-expect-error
+    patternDataSource.patternService = patternService
+  });
+
+  it('should throw error when pattern not found', () => {
+    patternService.get.mockResolvedValue(undefined);
+    expect(async () => {
+      await patternDataSource.select();
+    }).rejects.toThrow(
+      'Error selecting index pattern: Error: Error selecting index pattern: pattern not found'
+    );
+  });
+
+  it('should throw error when get fields for index pattern rejects', () => {
+    patternService.getFieldsForIndexPattern.mockRejectedValue(null);
+    expect(async () => {
+      await patternDataSource.select();
+    }).rejects.toThrow('Error selecting index pattern: null');
+  });
+
+  it('should not throw error when selecting from pattern data source', async () => {
+    await expect(patternDataSource.select()).resolves.not.toThrow();
+  });
+});

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -50,8 +50,9 @@ export class PatternDataSource implements tDataSource {
       if (!pattern)
         throw new Error('Error selecting index pattern: pattern not found');
 
-      const fields =
-        await this.patternService.getFieldsForIndexPattern(pattern);
+      const fields = await this.patternService.getFieldsForIndexPattern(
+        pattern,
+      );
       const scripted = pattern.getScriptedFields().map(field => field.spec);
       pattern.fields.replaceAll([...fields, ...scripted]);
     } catch (error) {

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -60,8 +60,7 @@ export class PatternDataSource implements tDataSource {
     try {
       // Vulnerability dashboard error loading for read only user
       await this.patternService.updateSavedObject(pattern);
-    } catch {
-    }
+    } catch {}
   }
 
   async fetch(params: tSearchParams) {

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -1,14 +1,6 @@
-import {
-  tDataSource,
-  tSearchParams,
-  tFilter,
-  tParsedIndexPattern,
-} from '../index';
+import { tDataSource, tSearchParams, tFilter, tParsedIndexPattern } from '../index';
 import { getDataPlugin } from '../../../../kibana-services';
-import {
-  IndexPatternsContract,
-  IndexPattern,
-} from '../../../../../../../src/plugins/data/public';
+import { IndexPatternsService, IndexPattern } from '../../../../../../../src/plugins/data/public';
 import { search } from '../../search-bar/search-bar-service';
 import { PatternDataSourceFilterManager } from './pattern-data-source-filter-manager';
 
@@ -16,7 +8,7 @@ export class PatternDataSource implements tDataSource {
   id: string;
   title: string;
   fields: any[];
-  patternService: IndexPatternsContract;
+  patternService: IndexPatternsService;
   indexPattern: IndexPattern;
 
   constructor(id: string, title: string) {
@@ -44,21 +36,20 @@ export class PatternDataSource implements tDataSource {
   }
 
   async select() {
+    let pattern: IndexPattern;
     try {
-      const pattern = await this.patternService.get(this.id);
-      if (pattern) {
-        const fields = await this.patternService.getFieldsForIndexPattern(
-          pattern,
-        );
-        const scripted = pattern.getScriptedFields().map(field => field.spec);
-        pattern.fields.replaceAll([...fields, ...scripted]);
-        await this.patternService.updateSavedObject(pattern);
-      } else {
-        throw new Error('Error selecting index pattern: pattern not found');
-      }
+      pattern = await this.patternService.get(this.id);
+      if (!pattern) throw new Error('Error selecting index pattern: pattern not found');
+
+      const fields = await this.patternService.getFieldsForIndexPattern(pattern);
+      const scripted = pattern.getScriptedFields().map((field) => field.spec);
+      pattern.fields.replaceAll([...fields, ...scripted]);
     } catch (error) {
       throw new Error(`Error selecting index pattern: ${error}`);
     }
+    try {
+      await this.patternService.updateSavedObject(pattern);
+    } catch {}
   }
 
   async fetch(params: tSearchParams) {

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -1,6 +1,14 @@
-import { tDataSource, tSearchParams, tFilter, tParsedIndexPattern } from '../index';
+import {
+  tDataSource,
+  tSearchParams,
+  tFilter,
+  tParsedIndexPattern,
+} from '../index';
 import { getDataPlugin } from '../../../../kibana-services';
-import { IndexPatternsService, IndexPattern } from '../../../../../../../src/plugins/data/public';
+import {
+  IndexPatternsService,
+  IndexPattern,
+} from '../../../../../../../src/plugins/data/public';
 import { search } from '../../search-bar/search-bar-service';
 import { PatternDataSourceFilterManager } from './pattern-data-source-filter-manager';
 
@@ -39,10 +47,12 @@ export class PatternDataSource implements tDataSource {
     let pattern: IndexPattern;
     try {
       pattern = await this.patternService.get(this.id);
-      if (!pattern) throw new Error('Error selecting index pattern: pattern not found');
+      if (!pattern)
+        throw new Error('Error selecting index pattern: pattern not found');
 
-      const fields = await this.patternService.getFieldsForIndexPattern(pattern);
-      const scripted = pattern.getScriptedFields().map((field) => field.spec);
+      const fields =
+        await this.patternService.getFieldsForIndexPattern(pattern);
+      const scripted = pattern.getScriptedFields().map(field => field.spec);
       pattern.fields.replaceAll([...fields, ...scripted]);
     } catch (error) {
       throw new Error(`Error selecting index pattern: ${error}`);

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -60,7 +60,8 @@ export class PatternDataSource implements tDataSource {
     try {
       // Vulnerability dashboard error loading for read only user
       await this.patternService.updateSavedObject(pattern);
-    } catch {}
+    } catch {
+    }
   }
 
   async fetch(params: tSearchParams) {

--- a/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/pattern-data-source.ts
@@ -48,6 +48,7 @@ export class PatternDataSource implements tDataSource {
       throw new Error(`Error selecting index pattern: ${error}`);
     }
     try {
+      // Vulnerability dashboard error loading for read only user
       await this.patternService.updateSavedObject(pattern);
     } catch {}
   }

--- a/plugins/main/test/types/index.ts
+++ b/plugins/main/test/types/index.ts
@@ -1,12 +1,14 @@
 export type RecordMock<T> = {
-  [K in keyof T]: T[K] extends Function ? jest.Mock : T[K] extends {} ? RecordMock<T[K]> : T[K];
+  [K in keyof T]: T[K] extends Function
+    ? jest.Mock
+    : T[K] extends {}
+      ? RecordMock<T[K]>
+      : T[K];
 };
-export type PartialRecordMock<T> = Partial<
-  {
-    [K in keyof T]: T[K] extends Function
-      ? jest.Mock
-      : T[K] extends {}
+export type PartialRecordMock<T> = Partial<{
+  [K in keyof T]: T[K] extends Function
+    ? jest.Mock
+    : T[K] extends {}
       ? PartialRecordMock<T[K]>
       : T[K];
-  }
->;
+}>;

--- a/plugins/main/test/types/index.ts
+++ b/plugins/main/test/types/index.ts
@@ -2,13 +2,13 @@ export type RecordMock<T> = {
   [K in keyof T]: T[K] extends Function
     ? jest.Mock
     : T[K] extends {}
-      ? RecordMock<T[K]>
-      : T[K];
+    ? RecordMock<T[K]>
+    : T[K];
 };
 export type PartialRecordMock<T> = Partial<{
   [K in keyof T]: T[K] extends Function
     ? jest.Mock
     : T[K] extends {}
-      ? PartialRecordMock<T[K]>
-      : T[K];
+    ? PartialRecordMock<T[K]>
+    : T[K];
 }>;

--- a/plugins/main/test/types/index.ts
+++ b/plugins/main/test/types/index.ts
@@ -1,0 +1,12 @@
+export type RecordMock<T> = {
+  [K in keyof T]: T[K] extends Function ? jest.Mock : T[K] extends {} ? RecordMock<T[K]> : T[K];
+};
+export type PartialRecordMock<T> = Partial<
+  {
+    [K in keyof T]: T[K] extends Function
+      ? jest.Mock
+      : T[K] extends {}
+      ? PartialRecordMock<T[K]>
+      : T[K];
+  }
+>;


### PR DESCRIPTION
### Description
Vulnerability dashboard not working for read-only user
 
### Issues Resolved
#6985 

### Evidence
![image](https://github.com/user-attachments/assets/c3572e49-da61-4176-be8a-a2754c2fc38f)
![image](https://github.com/user-attachments/assets/004dd9e3-8ec3-4270-b40e-0e0a5c778ba0)

### Test

1. Create a readonly user following these steps https://documentation.wazuh.com/4.9/user-manual/user-administration/rbac.html
2. Ensure the Vulnerabilities detection in the Wazuh server is enabled and this can connect with the Wazuh indexer
3. Ensure the vulnerabilities states index was created
4. With a user with write permission on the selected tenant, go to Vulnerabilities Detection > Dashboard / Inventory, and it should create the index pattern
5. Login with the readonly user and go to Vulnerabilities Detection > Dashboard / Inventory.
6. The application should not be infinitely loading.

### UNIT TESTS
![image](https://github.com/user-attachments/assets/1357797c-236e-472a-b1db-b9493e15044f)


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
