### PR TITLE
Style breaks when unpinned an agent in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing options depending on agent operating system in the agent configuration report [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
 - Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 - Fixed a problem updating the API host registry in the GET /api/check-stored-api [#6995](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6995)
+- Fixed style when unnpinned an agent in endpoint summary section [#7015](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7015)
 
 ### Changed
 

--- a/plugins/main/public/components/endpoints-summary/agent/index.tsx
+++ b/plugins/main/public/components/endpoints-summary/agent/index.tsx
@@ -46,6 +46,7 @@ export const AgentView = compose(
               You need to select an agent or return to
               <RedirectAppLinks application={getCore().application}>
                 <EuiLink
+                  className='eui-textCenter'
                   aria-label='go to Endpoint summary'
                   href={`${endpointSummary.id}#/agents-preview`}
                   onClick={() =>


### PR DESCRIPTION
### Description

Style breaks when unpinned an agent in safari
 
### Issues Resolved

#7011 

### Evidence

<img width="1792" alt="Captura de pantalla 2024-09-25 a la(s) 11 29 00 a  m" src="https://github.com/user-attachments/assets/dc04e74d-c0ea-4154-9ac5-2b0d0b5d4336">

### Test

- Navigate to endpoint summary
- Click on an agent
- Unpinned the agent

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
