### PR TITLE
Fix when generating a PDF report, the open report button in safari does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing options depending on agent operating system in the agent configuration report [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
 - Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 - Fixed a problem updating the API host registry in the GET /api/check-stored-api [#6995](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6995)
-- Fixed, when generating a PDF report, the open report button in safari does not work [#7019](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7019)
+- Fixed the `Open report` button of the toast and the `Download report` icon of the reporting table in Safari [#7019](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7019)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing options depending on agent operating system in the agent configuration report [#6983](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6983)
 - Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 - Fixed a problem updating the API host registry in the GET /api/check-stored-api [#6995](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6995)
+- Fixed, when generating a PDF report, the open report button in safari does not work [#7019](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7019)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed an style that affected the Discover plugin [#6989](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6989)
 - Fixed a problem updating the API host registry in the GET /api/check-stored-api [#6995](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6995)
 - Fixed the `Open report` button of the toast and the `Download report` icon of the reporting table in Safari [#7019](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7019)
+- Fixed style when unnpinned an agent in endpoint summary section [#7015](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7015)
 
 ### Changed
 

--- a/plugins/main/public/controllers/management/components/management/reporting/utils/columns-main.js
+++ b/plugins/main/public/controllers/management/components/management/reporting/utils/columns-main.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiButtonEmpty } from '@elastic/eui';
 import ReportingHandler from './reporting-handler';
 import moment from 'moment-timezone';
-import { WzButton } from '../../../../../../components/common/buttons';
 import { getHttp, getUiSettings } from '../../../../../../kibana-services';
 import { formatUIDate } from '../../../../../../react-services/time-service';
 export default class ReportingColums {
@@ -41,15 +40,17 @@ export default class ReportingColums {
           return (
             <div>
               <EuiToolTip position='top' content={`Download report`}>
-                <EuiButtonIcon
+                <EuiButtonEmpty
                   aria-label='Dowload report'
                   iconType='importAction'
-                  onClick={() => this.goReport(item.name)}
+                  href={getHttp().basePath.prepend(`/reports/${item.name}`)}
+                  target='_blank'
                   color='primary'
+                  contentProps={{ className: 'wz-no-padding' }}
                 />
               </EuiToolTip>
 
-              <WzButton
+              <EuiButtonEmpty
                 buttonType='icon'
                 aria-label='Delete report'
                 iconType='trash'
@@ -60,6 +61,7 @@ export default class ReportingColums {
                 }}
                 color='danger'
                 isDisabled={item.name === 'default'}
+                contentProps={{ className: 'wz-no-padding' }}
               />
             </div>
           );
@@ -68,14 +70,6 @@ export default class ReportingColums {
     };
 
     this.buildColumns();
-  }
-
-  /**
-   * Downloads the report
-   * @param {*} name The name of the report
-   */
-  goReport(name) {
-    window.open(getHttp().basePath.prepend(`/reports/${name}`), '_blank');
   }
 
   /**

--- a/plugins/main/public/react-services/reporting.js
+++ b/plugins/main/public/react-services/reporting.js
@@ -22,7 +22,7 @@ import store from '../redux/store';
 import domtoimage from '../utils/dom-to-image-more';
 import dateMath from '@elastic/datemath';
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import { reporting } from '../utils/applications';
 import { RedirectAppLinks } from '../../../../src/plugins/opensearch_dashboards_react/public';
 import {
@@ -93,29 +93,12 @@ export class ReportingService {
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
-              onClick={() => {
-                // Open the new tab immediately
-                const windowReference = window.open('', '_blank');
-
-                // Verify if the new tab was locked
-                if (windowReference) {
-                  // Get the URL (in this case, it is obtained directly, but it can be asynchronous)
-                  const url = getHttp().basePath.prepend(
-                    `/reports/${filename}`,
-                  );
-
-                  // Then assign the URL to the new tab
-                  windowReference.location = url;
-                } else {
-                  // If the tab is locked, it displays an alert to the user.
-                  alert('The tab was blocked. Please enable pop-up windows.');
-                }
-              }}
-              size='s'
+            <EuiLink
+              href={getHttp().basePath.prepend(`/reports/${filename}`)}
+              target='_blank'
             >
               Open report
-            </EuiButton>
+            </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>,

--- a/plugins/main/public/react-services/reporting.js
+++ b/plugins/main/public/react-services/reporting.js
@@ -94,12 +94,24 @@ export class ReportingService {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
-              onClick={() =>
-                window.open(
-                  getHttp().basePath.prepend(`/reports/${filename}`),
-                  '_blank',
-                )
-              }
+              onClick={() => {
+                // Open the new tab immediately
+                const windowReference = window.open('', '_blank');
+
+                // Verify if the new tab was locked
+                if (windowReference) {
+                  // Get the URL (in this case, it is obtained directly, but it can be asynchronous)
+                  const url = getHttp().basePath.prepend(
+                    `/reports/${filename}`,
+                  );
+
+                  // Then assign the URL to the new tab
+                  windowReference.location = url;
+                } else {
+                  // If the tab is locked, it displays an alert to the user.
+                  alert('The tab was blocked. Please enable pop-up windows.');
+                }
+              }}
               size='s'
             >
               Open report


### PR DESCRIPTION
### Description

Fix when generating a PDF report, the open report button in safari does not work

### Issues Resolved

#7018 

### Evidence

https://github.com/user-attachments/assets/fe9b1073-f442-489a-8b9c-99dd2244d17c

### Test
[Provide instructions to test this PR

- Go to some module

- Click on generate pdf report

- Click on open report button

### Check List
- [x] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
