### PR TITLE
Filter expands outside the viewport and cannot be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a problem updating the API host registry in the GET /api/check-stored-api [#6995](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6995)
 - Fixed the `Open report` button of the toast and the `Download report` icon of the reporting table in Safari [#7019](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7019)
 - Fixed style when unnpinned an agent in endpoint summary section [#7015](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7015)
+- Fixed overflow style on a long value filter [#7021](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7021)
 
 ### Changed
 

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -89,10 +89,10 @@ export const WzSearchBar = ({
                   showQueryBar={false}
                   useDefaultBehaviors={false}
                 />
-                {postFilters ? (
-                  <EuiFlexItem grow={false}>{postFilters}</EuiFlexItem>
-                ) : null}
               </EuiFlexItem>
+              {postFilters ? (
+                <EuiFlexItem grow={false}>{postFilters}</EuiFlexItem>
+              ) : null}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -53,7 +53,7 @@ export const WzSearchBar = ({
         </EuiFlexGroup>
       ) : null}
       {showFilters ? (
-        <EuiFlexGroup gutterSize='s' direction='column'>
+        <EuiFlexGroup gutterSize='s'>
           {hideFixedFilters ? null : (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup
@@ -76,17 +76,24 @@ export const WzSearchBar = ({
               </EuiFlexGroup>
             </EuiFlexItem>
           )}
-          <EuiFlexItem>
-            <div>
-              <SearchBar
-                {...restProps}
-                showQueryBar={false}
-                useDefaultBehaviors={false}
-              />
-              {postFilters ? (
-                <EuiFlexItem grow={false}>{postFilters}</EuiFlexItem>
-              ) : null}
-            </div>
+          <EuiFlexItem className='overflow-hidden'>
+            <EuiFlexGroup
+              gutterSize='s'
+              alignItems='center'
+              responsive={false}
+              wrap={true}
+            >
+              <EuiFlexItem className='overflow-hidden'>
+                <SearchBar
+                  {...restProps}
+                  showQueryBar={false}
+                  useDefaultBehaviors={false}
+                />
+                {postFilters ? (
+                  <EuiFlexItem grow={false}>{postFilters}</EuiFlexItem>
+                ) : null}
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : null}

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -53,7 +53,7 @@ export const WzSearchBar = ({
         </EuiFlexGroup>
       ) : null}
       {showFilters ? (
-        <EuiFlexGroup gutterSize='s'>
+        <EuiFlexGroup gutterSize='s' direction="column">
           {hideFixedFilters ? null : (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup
@@ -77,23 +77,16 @@ export const WzSearchBar = ({
             </EuiFlexItem>
           )}
           <EuiFlexItem>
-            <EuiFlexGroup
-              gutterSize='s'
-              alignItems='center'
-              responsive={false}
-              wrap={true}
-            >
-              <EuiFlexItem>
-                <SearchBar
-                  {...restProps}
-                  showQueryBar={false}
-                  useDefaultBehaviors={false}
-                />
-              </EuiFlexItem>
+            <div>
+              <SearchBar
+                {...restProps}
+                showQueryBar={false}
+                useDefaultBehaviors={false}
+              />
               {postFilters ? (
                 <EuiFlexItem grow={false}>{postFilters}</EuiFlexItem>
               ) : null}
-            </EuiFlexGroup>
+            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : null}

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -53,7 +53,7 @@ export const WzSearchBar = ({
         </EuiFlexGroup>
       ) : null}
       {showFilters ? (
-        <EuiFlexGroup gutterSize='s' direction="column">
+        <EuiFlexGroup gutterSize='s' direction='column'>
           {hideFixedFilters ? null : (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup


### PR DESCRIPTION
### Description
When filtering by value in the datagrid used in the vulnerability module, the filter goes out of the viewport and cannot be closed.
 
### Issues Resolved
#7017 

### Evidence
![image](https://github.com/user-attachments/assets/1ae7a89a-ebe0-49b3-969a-6ace97f619dd)



### Test
1. Open any application.
2. Apply any filter.
3. Edit the filter value to a longer text.


https://github.com/user-attachments/assets/3015191e-ef20-48de-9e1e-e1e3a5c496ff


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
