### PR TITLE
Fixed no agent alert spawn with selected agent in agent welcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed read-only users could not access to Statistics application [#7001](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7001)
+- Fixed no-agent-alert spawn with selected agent in agent-welcome view[#7029](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7029)
 
 ### Removed
 

--- a/plugins/main/public/components/common/hocs/withAgentSync.tsx
+++ b/plugins/main/public/components/common/hocs/withAgentSync.tsx
@@ -1,0 +1,26 @@
+/*
+ * Wazuh app - React HOCs handles rendering errors
+ * Copyright (C) 2015-2022 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { PinnedAgentManager } from '../../wz-agent-selector/wz-agent-selector-service';
+import { withGuardAsync } from './withGuard';
+
+export const withAgentSync = WrappedComponent => props => {
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    const pinnedAgentManager = new PinnedAgentManager();
+    pinnedAgentManager.syncPinnedAgentSources().finally(() => {
+      setLoading(false);
+    });
+  }, []);
+  return loading ? null : <WrappedComponent {...props}></WrappedComponent>;
+};

--- a/plugins/main/public/components/endpoints-summary/agent/index.tsx
+++ b/plugins/main/public/components/endpoints-summary/agent/index.tsx
@@ -27,6 +27,7 @@ import { PromptNoSelectedAgent } from '../../agents/prompts';
 import { RedirectAppLinks } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { getCore } from '../../../kibana-services';
 import { endpointSummary } from '../../../utils/applications';
+import { withAgentSync } from '../../common/hocs/withAgentSync';
 
 const mapStateToProps = state => ({
   agent: state.appStateReducers?.currentAgentData,
@@ -36,6 +37,7 @@ export const AgentView = compose(
   withErrorBoundary,
   withRouteResolvers({ enableMenu, ip, nestedResolve, savedSearch }),
   connect(mapStateToProps),
+  withAgentSync,
   withGuard(
     props => !(props.agent && props.agent.id),
     () => (


### PR DESCRIPTION
### Description

This PR add a new hoc to controll the render of no-agent-alert when navigate to a agent-welcome page
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7020

### Evidence

https://github.com/user-attachments/assets/2d2630b2-0c31-4b89-82e8-d267e5215b3a

### Test

When navigating to agent-welcome for the first time, the error appears. Try navigating from the endpoints summary, not just by clicking on the agents, but also using the side options to verify that the 'no agents' alert does not render.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
