### PR TITLE
Increase the font size of the kpi subtitles and the features descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed the registration id of the Settings application for compatibility with OpenSearch Dashboard 2.16.0 [#6938](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6938)
 - Changed Malware detection dashboard visualizations [#6964](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6964)
 - Changed malware feature description [#7036](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7036)
-- Changed the font size of the kpi subtitles and the features descriptions [#7027](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7027)
+- Changed the font size of the kpi subtitles and the features descriptions [#7033](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7033)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed the registration id of the Settings application for compatibility with OpenSearch Dashboard 2.16.0 [#6938](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6938)
 - Changed Malware detection dashboard visualizations [#6964](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6964)
 - Changed malware feature description [#7036](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7036)
+- Changed the font size of the kpi subtitles and the features descriptions [#7027](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7027)
 
 ### Fixed
 

--- a/plugins/main/public/components/common/welcome/welcome.scss
+++ b/plugins/main/public/components/common/welcome/welcome.scss
@@ -6,7 +6,6 @@
 
 .wz-welcome-page .euiCard .euiText,
 .wz-module-body .euiCard .euiText {
-  font-size: 12px;
   font-family: sans-serif;
 }
 

--- a/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
+++ b/plugins/main/public/controllers/overview/components/__snapshots__/stats.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
                       </p>
                     </div>
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiText euiText--small"
                       css="margin-top: 0.7vh"
                     >
                       Rule level 15 or higher
@@ -184,7 +184,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
                       </p>
                     </div>
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiText euiText--small"
                       css="margin-top: 0.7vh"
                     >
                       Rule level 12 to 14
@@ -229,7 +229,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
                       </p>
                     </div>
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiText euiText--small"
                       css="margin-top: 0.7vh"
                     >
                       Rule level 7 to 11
@@ -274,7 +274,7 @@ exports[`Stats component renders correctly to match the snapshot 1`] = `
                       </p>
                     </div>
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiText euiText--small"
                       css="margin-top: 0.7vh"
                     >
                       Rule level 0 to 6

--- a/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
+++ b/plugins/main/public/controllers/overview/components/last-alerts-stat/last-alerts-stat.tsx
@@ -150,7 +150,7 @@ export function LastAlertsStat({
           titleColor={severity.color}
           textAlign='center'
         />
-        <EuiText size='xs' css='margin-top: 0.7vh'>
+        <EuiText size='s' css='margin-top: 0.7vh'>
           {'Rule level ' +
             ruleLevelRange.minRuleLevel +
             (ruleLevelRange.maxRuleLevel


### PR DESCRIPTION
### Description
Text sizes: We want to increase the font size of the KPI subtitles and the features descriptions.
 
### Issues Resolved
[#7027](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7027) 

### Evidence
![image](https://github.com/user-attachments/assets/7131587d-6481-41b2-a15e-f360fbcd97e0)
![image](https://github.com/user-attachments/assets/e1a66395-1b3e-4631-b5bb-a2f256545808)


### Test
Go to Overview page and check the size of the KPI subtitles and the features descriptions

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
