### PR TITLE
Filter deprecated actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed read-only users could not access to Statistics application [#7001](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7001)
-- Fixed no-agent-alert spawn with selected agent in agent-welcome view[#7029](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7029)
+- Fixed no-agent-alert spawn with selected agent in agent-welcome view [#7029](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7029)
+- Fixed security policy exception when it contained deprecated actions [#7042](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7042)
 
 ### Removed
 

--- a/plugins/main/public/components/security/policies/edit-policy.tsx
+++ b/plugins/main/public/components/security/policies/edit-policy.tsx
@@ -137,7 +137,7 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
   const loadResources = () => {
     let allResources = [];
     addedActions
-      .filter(x => !!availableActions[x.action]) // Remove configured actions no longer available on the API
+      .filter(x => !!availableActions?.[x.action]) // Remove configured actions no longer available on the API
       .forEach(x => {
         const res = availableActions[x.action]?.['resources'];
         allResources = allResources.concat(res);

--- a/plugins/main/public/components/security/policies/edit-policy.tsx
+++ b/plugins/main/public/components/security/policies/edit-policy.tsx
@@ -130,16 +130,18 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
           ),
         };
       })
-      .sort((a, b) => a.value.localeCompare(b.value));
+      .sort((a, b) => a.value?.localeCompare(b.value));
     setActions(actions);
   }
 
   const loadResources = () => {
     let allResources = [];
-    addedActions.forEach(x => {
-      const res = (availableActions[x.action] || {})['resources'];
-      allResources = allResources.concat(res);
-    });
+    addedActions
+      .filter(x => !!availableActions[x.action]) // Remove configured actions no longer available on the API
+      .forEach(x => {
+        const res = availableActions[x.action]?.['resources'];
+        allResources = allResources.concat(res);
+      });
     const allResourcesSet = new Set(allResources);
     const resources = Array.from(allResourcesSet)
       .map((x, idx) => {
@@ -159,7 +161,7 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
           ),
         };
       })
-      .sort((a, b) => a.value.localeCompare(b.value));
+      .sort((a, b) => a.value?.localeCompare(b.value));
     setResources(resources);
   };
 


### PR DESCRIPTION
### Description
The goal of this pull request is to filter deprecated / not listed actions in Wazuh API `/security/actions` endpoint. 
 
### Issues Resolved
Closes #7031 

### Test
- Go to Server management -> Security -> Policies
- Click on the policy that has the `security:revoke` action
- Check it doesn't throw an exception

![Peek 2024-10-01 12-41](https://github.com/user-attachments/assets/86759212-c445-4126-8cdf-51fbe72f65e4)



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
