### PR TITLE
Fix data grid pagination with relative index per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.10.0
 - Added sample data for YARA [#6964](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6964)
-- Added a custom filter and visualization for vulnerability.under_evaluation field [#6968](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6968)
+- Added a custom filter and visualization for vulnerability.under_evaluation field [#6968](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6968) [#7044](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7044)
 
 ### Changed
 

--- a/plugins/main/public/components/common/data-grid/use-data-grid.tsx
+++ b/plugins/main/public/components/common/data-grid/use-data-grid.tsx
@@ -166,7 +166,10 @@ export const useDataGrid = (props: tDataGridProps): EuiDataGridProps => {
 
       // Format the value using the field formatter
       // https://github.com/opensearch-project/OpenSearch-Dashboards/blob/2.16.0/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx#L80-L89
-      const formattedValue = indexPattern.formatField(rows[rowIndex], columnId);
+      const formattedValue = indexPattern.formatField(
+        rows[relativeRowIndex],
+        columnId,
+      );
       if (typeof formattedValue === 'undefined') {
         return <span>-</span>;
       } else {


### PR DESCRIPTION
### Description
This pull request fixes the relative index per page. Previously the absolute result index was used and the index was not found in the page array.
 
### Issues Resolved
#7043

### Evidence
![Peek 2024-10-01 18-13](https://github.com/user-attachments/assets/b3f6d14a-8598-4c34-99d2-d63e1e7ccaa6)


### Test
- Add vulnerabilities sample data
- Go to Vulnerabilities / Inventory
- Change between pages
- Verify it works and the information is consistent

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
