### PR TITLE
Avoid filter hiding when adding too many of them

### DIFF
--- a/plugins/main/public/styles/common.scss
+++ b/plugins/main/public/styles/common.scss
@@ -1439,7 +1439,6 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
 }
 
 .globalFilterGroup__wrapper {
-  max-height: 100px;
   height: auto !important;
 }
 

--- a/plugins/main/public/styles/media-queries.scss
+++ b/plugins/main/public/styles/media-queries.scss
@@ -124,4 +124,10 @@
       margin-top: 10px;
     }
   }
+
+  @media only screen and (max-width: 574px) {
+    .globalFilterGroup__wrapper-isVisible {
+      margin-top: -6px;
+    }
+  }
 }


### PR DESCRIPTION
### Description
Avoid filter hiding when adding too many of them
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7049

### Evidence

https://github.com/user-attachments/assets/c9e213ee-b750-4b34-8567-d6551866a8ff


https://github.com/user-attachments/assets/5441f914-8a42-4833-a89b-fa36031579f8

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
