### PR TITLE
Fix scroll in vulnerabilities inventory table

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
@@ -5,11 +5,6 @@
     height: max-content !important;
   }
 
-  // This makes the table not generate an unnecessary scroll when filtering data from 1 page and then do another search for more pages.
-  .vulsInventoryDataGrid {
-    height: calc(100vh - 216px) !important;
-  }
-
   .euiDataGrid--fullScreen {
     height: calc(100vh - 49px);
     bottom: 0;


### PR DESCRIPTION
### Description
This pull request removes the fixed height in the vulnerabilities inventory table so it can scroll with large pages and it's consistent with the Events table behavior.
 
### Issues Resolved
- #7101 

### Evidence

![Peek 2024-10-22 13-38](https://github.com/user-attachments/assets/7fb5617b-c08e-45e4-80bc-cbbb0ed3baf6)


### Test

- Check the table allows scrolling when the content of the page it's larger than the viewport
- Check that docking the side-nav doesn't cause nested scrolling or weird behaviors
- Check the table full-screen feature works properly and allows to navigate the results without rendering nested scrolls

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
