### PR TITLE
Fix ability to filter form FIM details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.10.0 - OpenSearch Dashboards 2.16.0 - Revision 03
 
-## Fixed
-
-- Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
-
 ### Added
 
 - Support for Wazuh 4.10.0
 - Added sample data for YARA [#6964](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6964)
 - Added a custom filter and visualization for vulnerability.under_evaluation field [#6968](https://github.com/wazuh/wazuh-dashboard-plugins/issues/6968) [#7044](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7044) [#7046](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7046)
+- Added ability to filter from File Integrity Monitoring registry inventory [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
+- Added new field columns and ability to select the visible fields in the File Integrity Monitoring Files and Registry tables [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
 
 ### Changed
 
@@ -35,6 +33,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed export formatted csv data with special characters from tables [#7048](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7048)
 - Fixed column reordering feature [#7072](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7072)
 - Fixed filter management to prevent hiding when adding multiple filters [#7077](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7077)
+- Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
+- Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
 
 ### Removed
 

--- a/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
@@ -198,6 +198,7 @@ export class FileDetails extends Component {
         name: 'Last analysis',
         grow: 2,
         icon: 'clock',
+        link: true,
         transformValue: formatUIDate,
       },
       {
@@ -205,6 +206,7 @@ export class FileDetails extends Component {
         name: 'Last modified',
         grow: 2,
         icon: 'clock',
+        link: true,
         transformValue: formatUIDate,
       },
     ];
@@ -290,21 +292,19 @@ export class FileDetails extends Component {
   }
 
   addFilter(field, value) {
-    const { filters, onFiltersChange } = this.props;
-    const newBadge: ICustomBadges = { field: 'q', value: '' };
+    const { onFiltersChange } = this.props;
+    let filterUQL = '';
     if (field === 'date' || field === 'mtime') {
       const value_max = moment(value).add(1, 'day');
-      newBadge.value = `${field}>${moment(value).format(
+      filterUQL = `${field}>${moment(value).format(
         'YYYY-MM-DD',
-      )} AND ${field}<${value_max.format('YYYY-MM-DD')}`;
+      )};${field}<${value_max.format('YYYY-MM-DD')}`;
     } else {
-      newBadge.value = `${field}=${
+      filterUQL = `${field}=${
         field === 'size' ? this.props.currentFile[field] : value
       }`;
     }
-    !filters.some(
-      item => item.field === newBadge.field && item.value === newBadge.value,
-    ) && onFiltersChange([...filters, newBadge]);
+    onFiltersChange({ q: filterUQL });
     this.props.closeFlyout();
   }
 


### PR DESCRIPTION
### Description
This pull request fixes the ability to filter from the FIM inventory details and add some enhancements.

Changes:
- Fix FIM inventory flyout filters for Files and Registry tabs
- Add ability to filter from Last analysis and Last modified fields from
  Registry details
- Add ability to select the visible columns in the Files and Registry
  tables
- Add to Files table the columns: date (hidden), md5 (hidden), sha1 (hidden), sha256 (hidden)
- Add to Registry table the columns: date (hidden)
- Renamed Last Modified to Last modified in the Files table

### Issues Resolved
#7082

### Evidence
![image](https://github.com/user-attachments/assets/6d0014cb-6eb2-4ba8-b9c4-9318478ed3d0)
![image](https://github.com/user-attachments/assets/41fa2ab5-f0cd-4cd5-a770-e02aba5eb331)
![image](https://github.com/user-attachments/assets/84727c53-38e6-40ae-bd0a-0567dc82093f)

![image](https://github.com/user-attachments/assets/052df53a-61ac-4ffc-9d72-7216e53930ab)
![image](https://github.com/user-attachments/assets/1e4034c3-c609-4d1b-bc1d-93c850466b9f)
![image](https://github.com/user-attachments/assets/1a55d74c-f7b1-487d-8295-c57e4a22b3c6)
![image](https://github.com/user-attachments/assets/c25ad21f-992a-4caf-8cdf-1e0dcc345f93)

### Test
# wdp-pr-7119

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With FIM data in an agent, go to File Integrity Monitoring > Files and select a file, add a field filter from the details flyout should add the filter to the main table. Try with different fields and ensure the table data is filtered according to the search. | :black_circle: | :black_circle: | :black_circle: |
| With FIM data in an agent, go to File Integrity Monitoring > Registry (Windows host) and select a file, add a field filter from the details flyout should add the filter to the main table. Try with different fields and ensure the table data is filtered according to the search. | :black_circle: | :black_circle: | :black_circle: |
| With FIM data in an agent, go to File Integrity Monitoring > Files, change the visibility of fields columns using the field selector (gear icon) | :black_circle: | :black_circle: | :black_circle: |
| With FIM data in an agent, go to File Integrity Monitoring > Registry, change the visibility of fields columns using the field selector (gear icon) | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With FIM data in an agent, go to File Integrity Monitoring > Files and select a file, add a field filter from the details flyout should add the filter to the main table. Try with different fields and ensure the table data is filtered according to the search.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM data in an agent, go to File Integrity Monitoring > Registry (Windows host) and select a file, add a field filter from the details flyout should add the filter to the main table. Try with different fields and ensure the table data is filtered according to the search.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM data in an agent, go to File Integrity Monitoring > Files, change the visibility of fields columns using the field selector (gear icon)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM data in an agent, go to File Integrity Monitoring > Registry, change the visibility of fields columns using the field selector (gear icon)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
