### PR TITLE
Remove processes state column in macOS agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed agent RBAC filters from dashboard queries [#6945](https://github.com/wazuh/wazuh-dashboard-plugins/pull/6945)
 - Removed GET /elastic/statistics API endpoint [#7001](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7001)
 - Removed VirusTotal application in favor of Malware Detection [#7038](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7038)
+- Removed processes state column in macOS agents [#7122](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7122)
 
 ## Wazuh v4.9.1 - OpenSearch Dashboards 2.13.0 - Revision 04
 

--- a/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
+++ b/plugins/main/public/components/agents/syscollector/__snapshots__/inventory.test.tsx.snap
@@ -2085,31 +2085,6 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
                           </span>
                         </button>
                       </th>
-                      <th
-                        aria-live="polite"
-                        aria-sort="none"
-                        class="euiTableHeaderCell"
-                        data-test-subj="tableHeaderCell_state_6"
-                        role="columnheader"
-                        scope="col"
-                        style="width:15%"
-                      >
-                        <button
-                          class="euiTableHeaderButton"
-                          data-test-subj="tableHeaderSortButton"
-                          type="button"
-                        >
-                          <span
-                            class="euiTableCellContent"
-                          >
-                            <span
-                              class="euiTableCellContent__text"
-                            >
-                              State
-                            </span>
-                          </span>
-                        </button>
-                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2118,7 +2093,7 @@ exports[`Inventory component A Apple agent should be well rendered. 1`] = `
                     >
                       <td
                         class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                        colspan="7"
+                        colspan="6"
                       >
                         <div
                           class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/plugins/main/public/components/agents/syscollector/columns/process-columns.ts
+++ b/plugins/main/public/components/agents/syscollector/columns/process-columns.ts
@@ -1,4 +1,16 @@
-import { KeyEquivalence } from "../../../../../common/csv-key-equivalence";
+import { KeyEquivalence } from '../../../../../common/csv-key-equivalence';
+
+const mapFieldName = ({
+  field,
+  ...rest
+}: {
+  field: string;
+  name?: string;
+}) => ({
+  ...rest,
+  field,
+  name: rest.name || KeyEquivalence[field] || field,
+});
 
 const windowsColumns = [
   { field: 'name', searchable: true, sortable: true, width: '10%' },
@@ -8,7 +20,8 @@ const windowsColumns = [
   { field: 'priority', searchable: true, sortable: true },
   { field: 'nlwp', searchable: true, sortable: true },
   { field: 'cmd', searchable: true, sortable: true, width: '30%' },
-].map(({field, ...rest}) => ({...rest, field, name: rest.name || KeyEquivalence[field] || field}));
+].map(mapFieldName);
+
 const linuxColumns = [
   { field: 'name', searchable: true, sortable: true, width: '10%' },
   { field: 'euser', searchable: true, sortable: true },
@@ -22,7 +35,8 @@ const linuxColumns = [
   { field: 'session', searchable: true, sortable: true },
   { field: 'nice', searchable: true, sortable: true },
   { field: 'state', searchable: true, sortable: true, width: '15%' },
-].map(({field, ...rest}) => ({...rest, field, name: rest.name || KeyEquivalence[field] || field}));
+].map(mapFieldName);
+
 const macColumns = [
   { field: 'name', searchable: true, sortable: true, width: '10%' },
   { field: 'euser', searchable: true, sortable: true },
@@ -30,8 +44,7 @@ const macColumns = [
   { field: 'ppid', searchable: true, sortable: true },
   { field: 'vm_size', searchable: true, sortable: true },
   { field: 'nice', searchable: true, sortable: true },
-  { field: 'state', searchable: true, sortable: true, width: '15%' },
-].map(({field, ...rest}) => ({...rest, field, name: rest.name || KeyEquivalence[field] || field}));
+].map(mapFieldName);
 
 export const processColumns = {
   windows: windowsColumns,

--- a/plugins/main/public/components/agents/syscollector/columns/process-columns.ts
+++ b/plugins/main/public/components/agents/syscollector/columns/process-columns.ts
@@ -1,12 +1,6 @@
 import { KeyEquivalence } from '../../../../../common/csv-key-equivalence';
 
-const mapFieldName = ({
-  field,
-  ...rest
-}: {
-  field: string;
-  name?: string;
-}) => ({
+const mapColumns = ({ field, ...rest }: { field: string; name?: string }) => ({
   ...rest,
   field,
   name: rest.name || KeyEquivalence[field] || field,
@@ -20,7 +14,7 @@ const windowsColumns = [
   { field: 'priority', searchable: true, sortable: true },
   { field: 'nlwp', searchable: true, sortable: true },
   { field: 'cmd', searchable: true, sortable: true, width: '30%' },
-].map(mapFieldName);
+].map(mapColumns);
 
 const linuxColumns = [
   { field: 'name', searchable: true, sortable: true, width: '10%' },
@@ -35,7 +29,7 @@ const linuxColumns = [
   { field: 'session', searchable: true, sortable: true },
   { field: 'nice', searchable: true, sortable: true },
   { field: 'state', searchable: true, sortable: true, width: '15%' },
-].map(mapFieldName);
+].map(mapColumns);
 
 const macColumns = [
   { field: 'name', searchable: true, sortable: true, width: '10%' },
@@ -44,7 +38,7 @@ const macColumns = [
   { field: 'ppid', searchable: true, sortable: true },
   { field: 'vm_size', searchable: true, sortable: true },
   { field: 'nice', searchable: true, sortable: true },
-].map(mapFieldName);
+].map(mapColumns);
 
 export const processColumns = {
   windows: windowsColumns,


### PR DESCRIPTION
### Description
Remove processes state column in macOS agents.
 
### Issues Resolved
Closes #7121

### Evidence
![image](https://github.com/user-attachments/assets/84e2b27c-63f0-4eef-84c2-cb449d978e2a)

### Test
1. Go to Server Management > Endpoints Summary.
2. Choose a "macOS High Sierra agent."
3. Click on "Inventory Data."
4. Verify that the Processes table does not have a state column.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
