### PR TITLE
Fix vulnerability inventory table scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.9.2
 
+### Fixed
+
+- Fixed vulnerabilities inventory table scroll [#7128](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7128)
+
 ## Wazuh v4.9.1 - OpenSearch Dashboards 2.13.0 - Revision 04
 
 ### Added

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.scss
@@ -5,11 +5,6 @@
     height: max-content !important;
   }
 
-  // This makes the table not generate an unnecessary scroll when filtering data from 1 page and then do another search for more pages.
-  .vulsInventoryDataGrid {
-    height: calc(100vh - 216px) !important;
-  }
-
   .euiDataGrid--fullScreen {
     height: calc(100vh - 49px);
     bottom: 0;


### PR DESCRIPTION
### Description
This pull request removes the fixed height in the vulnerabilities inventory table so it can scroll with large pages and it's consistent with the Events table behavior.
 
### Issues Resolved
- #7127 

### Evidence

![Peek 2024-10-25 12-56](https://github.com/user-attachments/assets/1de78940-8216-4f72-8bed-70cfeb6ebf11)



### Test

- Check the table allows scrolling when the content of the page it's larger than the viewport
- Check that docking the side-nav doesn't cause nested scrolling or weird behaviors
- Check the table full-screen feature works properly and allows to navigate the results without rendering nested scrolls

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
