### PR TITLE
Fix filter by value in document details in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
+- Fixed filter by value in document details in safari [#7151](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7151)
 
 ### Removed
 

--- a/plugins/main/public/components/common/doc-viewer/doc-viewer.scss
+++ b/plugins/main/public/components/common/doc-viewer/doc-viewer.scss
@@ -23,6 +23,7 @@
     font-family: $euiCodeFontFamily;
   }
 
+  td,
   tr {
     position: relative;
   }


### PR DESCRIPTION
### Description

Filters on event flyouts were not appearing in safari 
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7157

### Evidence

<details><summary>Safari</summary>

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/3291bf61-c5df-459b-8b8b-aaf43288f22a">

</details> 

<details><summary>Firefox</summary>

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/b17beb66-9b89-49df-ae12-9c5821ec9682">

</details> 

<details><summary>Chrome</summary>

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/03a6de3b-5f64-4e56-859b-a9d6cf397a22">

</details> 

### Test

1. Navigate to "Threat Hunting"
2. Go to the Events tab
3. Click on the open row details
4. Hover in a row

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
