### PR TITLE
Add ability to edit the wazuh.updates.disabled setting from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added new field columns and ability to select the visible fields in the File Integrity Monitoring Files and Registry tables [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
 - Added filter by value to document details fields [#7081](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7081)
 - Added pinned agent mechanic to inventory data, stats, and configuration for consistent functionality [#7135](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7135)
+- Added ability to edit the `wazuh.updates.disabled` configuration setting from UI [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
 
 ### Changed
 
@@ -43,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
+- Fixed the check updates UI was displayed despite it could be configured as disabled [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
 
 ### Removed
 

--- a/plugins/main/public/components/wz-updates-notification/wz-updates-notification.tsx
+++ b/plugins/main/public/components/wz-updates-notification/wz-updates-notification.tsx
@@ -23,7 +23,8 @@ const mapStateToProps = state => {
 export const WzUpdatesNotification = connect(mapStateToProps)(
   ({ appConfig }) => {
     const isUpdatesEnabled =
-      !appConfig?.isLoading && !appConfig?.data?.['wazuh.updates.disabled'];
+      !appConfig?.isLoading &&
+      appConfig?.data?.['wazuh.updates.disabled'] === false;
     const { UpdatesNotification } = getWazuhCheckUpdatesPlugin();
 
     return isUpdatesEnabled ? <UpdatesNotification /> : <></>;

--- a/plugins/wazuh-core/common/constants.ts
+++ b/plugins/wazuh-core/common/constants.ts
@@ -1747,16 +1747,16 @@ hosts:
   },
   'wazuh.updates.disabled': {
     title: 'Check updates',
-    description: 'Define if the check updates service is active.',
+    description: 'Define if the check updates service is disabled.',
     category: SettingCategory.GENERAL,
     type: EpluginSettingType.switch,
     defaultValue: false,
     store: {
       file: {
-        configurableManaged: false,
+        configurableManaged: true,
       },
     },
-    isConfigurableFromSettings: false,
+    isConfigurableFromSettings: true,
     options: {
       switch: {
         values: {


### PR DESCRIPTION
### Description
This pull request adds the ability to edit the `wazuh.updates.disabled` setting from UI.

Changes:
- Add the ability to edit the `wazuh.updates.disabled` setting from UI.
- Fix a problem when the wazuh.updates.disabled setting was enabled, the UI was displayed

### Issues Resolved
#7132

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
