### PR TITLE
Add ability to edit the wazuh.updates.disabled setting from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added new field columns and ability to select the visible fields in the File Integrity Monitoring Files and Registry tables [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
 - Added filter by value to document details fields [#7081](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7081)
 - Added pinned agent mechanic to inventory data, stats, and configuration for consistent functionality [#7135](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7135)
-- Added ability to edit the `wazuh.updates.disabled` configuration setting from UI [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
+- Added ability to edit the `wazuh.updates.disabled` configuration setting from UI [#7156](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7156)
 
 ### Changed
 
@@ -44,7 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
-- Fixed the check updates UI was displayed despite it could be configured as disabled [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
+- Fixed the check updates UI was displayed despite it could be configured as disabled [#7156](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7156)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added new field columns and ability to select the visible fields in the File Integrity Monitoring Files and Registry tables [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
 - Added filter by value to document details fields [#7081](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7081)
 - Added pinned agent mechanic to inventory data, stats, and configuration for consistent functionality [#7135](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7135)
+- Added ability to edit the `wazuh.updates.disabled` configuration setting from UI [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
 
 ### Changed
 
@@ -43,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
+- Fixed the check updates UI was displayed despite it could be configured as disabled [#7155](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7155)
 
 ### Removed
 

--- a/plugins/main/public/components/wz-updates-notification/__snapshots__/index.test.tsx.snap
+++ b/plugins/main/public/components/wz-updates-notification/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WzUpdatesNotification tests should render a WzUpdatesNotification 1`] = `
+exports[`WzUpdatesNotification tests should not render a WzUpdatesNotification because is disabled 1`] = `<div />`;
+
+exports[`WzUpdatesNotification tests should not render a WzUpdatesNotification is not defined 1`] = `<div />`;
+
+exports[`WzUpdatesNotification tests should render a WzUpdatesNotification is enabled 1`] = `
 <div>
   <div>
     Updates notification

--- a/plugins/main/public/components/wz-updates-notification/index.test.tsx
+++ b/plugins/main/public/components/wz-updates-notification/index.test.tsx
@@ -10,7 +10,7 @@ jest.mock('../../kibana-services', () => ({
 }));
 
 describe('WzUpdatesNotification tests', () => {
-  test('should render a WzUpdatesNotification', () => {
+  test('should render a WzUpdatesNotification is enabled', () => {
     const { container } = renderWithProviders(<WzUpdatesNotification />, {
       preloadedState: {
         appConfig: {
@@ -20,6 +20,26 @@ describe('WzUpdatesNotification tests', () => {
         },
       },
     });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should not render a WzUpdatesNotification because is disabled', () => {
+    const { container } = renderWithProviders(<WzUpdatesNotification />, {
+      preloadedState: {
+        appConfig: {
+          data: {
+            'wazuh.updates.disabled': true,
+          },
+        },
+      },
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should not render a WzUpdatesNotification is not defined', () => {
+    const { container } = renderWithProviders(<WzUpdatesNotification />);
 
     expect(container).toMatchSnapshot();
   });

--- a/plugins/main/public/components/wz-updates-notification/index.test.tsx
+++ b/plugins/main/public/components/wz-updates-notification/index.test.tsx
@@ -11,7 +11,15 @@ jest.mock('../../kibana-services', () => ({
 
 describe('WzUpdatesNotification tests', () => {
   test('should render a WzUpdatesNotification', () => {
-    const { container } = renderWithProviders(<WzUpdatesNotification />);
+    const { container } = renderWithProviders(<WzUpdatesNotification />, {
+      preloadedState: {
+        appConfig: {
+          data: {
+            'wazuh.updates.disabled': false,
+          },
+        },
+      },
+    });
 
     expect(container).toMatchSnapshot();
   });

--- a/plugins/main/public/components/wz-updates-notification/wz-updates-notification.tsx
+++ b/plugins/main/public/components/wz-updates-notification/wz-updates-notification.tsx
@@ -23,7 +23,8 @@ const mapStateToProps = state => {
 export const WzUpdatesNotification = connect(mapStateToProps)(
   ({ appConfig }) => {
     const isUpdatesEnabled =
-      !appConfig?.isLoading && !appConfig?.data?.['wazuh.updates.disabled'];
+      !appConfig?.isLoading &&
+      appConfig?.data?.['wazuh.updates.disabled'] === false;
     const { UpdatesNotification } = getWazuhCheckUpdatesPlugin();
 
     return isUpdatesEnabled ? <UpdatesNotification /> : <></>;

--- a/plugins/main/public/redux/render-with-redux-provider.tsx
+++ b/plugins/main/public/redux/render-with-redux-provider.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { render } from '@testing-library/react';
-import storeRedux from './store';
+import storeRedux, { setupStore } from './store';
 import { Provider } from 'react-redux';
 import type { RenderOptions } from '@testing-library/react';
 
@@ -13,13 +13,16 @@ interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
 
 export function renderWithProviders(
   ui: React.ReactElement,
-  {
+  options: ExtendedRenderOptions = {},
+) {
+  const {
     preloadedState = {},
     // Automatically create a store instance if no store was passed in
-    store = storeRedux,
+    store = setupStore(preloadedState),
     ...renderOptions
-  }: ExtendedRenderOptions = {},
-) {
+  } = options;
+
+  // const store = preloadedState ? setupStore(preloadedState) : _store;
   function Wrapper({ children }: PropsWithChildren<{}>): JSX.Element {
     return <Provider store={store}>{children}</Provider>;
   }

--- a/plugins/main/public/redux/render-with-redux-provider.tsx
+++ b/plugins/main/public/redux/render-with-redux-provider.tsx
@@ -17,12 +17,11 @@ export function renderWithProviders(
 ) {
   const {
     preloadedState = {},
-    // Automatically create a store instance if no store was passed in
+    // Automatically create a store instance with the preloadedState
     store = setupStore(preloadedState),
     ...renderOptions
   } = options;
 
-  // const store = preloadedState ? setupStore(preloadedState) : _store;
   function Wrapper({ children }: PropsWithChildren<{}>): JSX.Element {
     return <Provider store={store}>{children}</Provider>;
   }

--- a/plugins/main/public/redux/store.js
+++ b/plugins/main/public/redux/store.js
@@ -22,3 +22,8 @@ import rootReducer from './reducers/rootReducers';
 const store = createStore(rootReducer, applyMiddleware(thunk));
 
 export default store;
+
+// This is used by some tests to preload a state
+export function setupStore(preloadedState) {
+  return createStore(rootReducer, preloadedState, applyMiddleware(thunk));
+}

--- a/plugins/wazuh-core/common/constants.ts
+++ b/plugins/wazuh-core/common/constants.ts
@@ -1747,16 +1747,16 @@ hosts:
   },
   'wazuh.updates.disabled': {
     title: 'Check updates',
-    description: 'Define if the check updates service is active.',
+    description: 'Define if the check updates service is disabled.',
     category: SettingCategory.GENERAL,
     type: EpluginSettingType.switch,
     defaultValue: false,
     store: {
       file: {
-        configurableManaged: false,
+        configurableManaged: true,
       },
     },
-    isConfigurableFromSettings: false,
+    isConfigurableFromSettings: true,
     options: {
       switch: {
         values: {


### PR DESCRIPTION
### Description
This pull request adds the ability to edit the `wazuh.updates.disabled` setting from UI.

Changes:
- Add the ability to edit the `wazuh.updates.disabled` setting from UI.
- Fix a problem when the wazuh.updates.disabled setting was enabled, the UI was displayed

### Issues Resolved
#7152

### Evidence
![image](https://github.com/user-attachments/assets/6bb1eeb8-d3a0-437d-b4ec-9ab7f1d33ebe)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Go to Dashboard management > App Settings and ensure the wazuh.updates.disabled is displayed and can be configured (try to save both possible values). | :black_circle: | :black_circle: | :black_circle: |
| With wazuh.updates.disabled enabled (true), the UI related to check updates (bottom bar, data in Server APIs) should not appear. | :black_circle: | :black_circle: | :black_circle: |
| With wazuh.updates.disabled disabled (false), the UI related to check updates (bottom bar, data in Server APIs) should appear (ensure you did not dismiss it). | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Go to Dashboard management > App Settings and ensure the wazuh.updates.disabled is displayed and can be configured (try to save both possible values).</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With wazuh.updates.disabled enabled (true), the UI related to check updates (bottom bar, data in Server APIs) should not appear.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With wazuh.updates.disabled disabled (false), the UI related to check updates (bottom bar, data in Server APIs) should appear (ensure you did not dismiss it).</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
