### PR TITLE
Fixed Invalid date filter applied on FIM details flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
+- Fixed Invalid date filter applied on FIM details flyout [#7160]()
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the Mitre ATT&CK exception in the agent view, the redirections of ID, Tactics, Dashboard Icon and Event Icon in the drop-down menu and the card not displaying information when the flyout was opened [#7116](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7116)
 - Fixed the filter are displayed cropped on screens of 575px to 767px in vulnerability detection module [#7047](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7047)
 - Fixed ability to filter from files inventory details flyout of File Integrity Monitoring [#7119](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7119)
-- Fixed Invalid date filter applied on FIM details flyout [#7160]()
+- Fixed Invalid date filter applied on FIM details flyout [#7160](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7160)
 
 ### Removed
 

--- a/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
@@ -301,8 +301,9 @@ export class FileDetails extends Component {
         'YYYY-MM-DD',
       )};${field}<${value_max.format('YYYY-MM-DD')}`;
     } else {
-      filterUQL = `${field}=${field === 'size' ? this.props.currentFile[field] : value
-        }`;
+      filterUQL = `${field}=${
+        field === 'size' ? this.props.currentFile[field] : value
+      }`;
     }
     onFiltersChange({ q: filterUQL });
     this.props.closeFlyout();
@@ -312,7 +313,7 @@ export class FileDetails extends Component {
     const { view } = this.props;
     const columns =
       this.props.type === 'registry_key' ||
-        this.props.currentFile.type === 'registry_key'
+      this.props.currentFile.type === 'registry_key'
         ? this.registryDetails()
         : this.details();
     const generalDetails = columns.map((item, idx) => {
@@ -357,7 +358,12 @@ export class FileDetails extends Component {
                       >
                         <EuiButtonIcon
                           onClick={() => {
-                            this.addFilter(item.field, item.field === 'date' || item.field === 'mtime' ? rawValue : value);
+                            this.addFilter(
+                              item.field,
+                              item.field === 'date' || item.field === 'mtime'
+                                ? rawValue
+                                : value,
+                            );
                           }}
                           iconType='magnifyWithPlus'
                           aria-label='Next'
@@ -382,7 +388,7 @@ export class FileDetails extends Component {
                     this.userSvg
                   )}
                   {item.name === 'Permissions' &&
-                    agentPlatform === 'windows' ? (
+                  agentPlatform === 'windows' ? (
                     ''
                   ) : (
                     <span className='detail-title'>{item.name}</span>
@@ -462,84 +468,84 @@ export class FileDetails extends Component {
     const agentId = this.props.agent?.id;
     return agentId
       ? [
-        {
-          id: 'timestamp',
-          isSortable: true,
-          defaultSortDirection: 'desc',
-          displayAsText: 'Time',
-          render: value => formatUIDate(value),
-        },
-        {
-          id: 'syscheck.event',
-          displayAsText: 'Action',
-        },
-        { id: 'rule.description', displayAsText: 'Description' },
-        { id: 'rule.level', displayAsText: 'Level' },
-        {
-          id: 'rule.id',
-          displayAsText: 'Rule ID',
-          render: value => (
-            <RedirectAppLinks application={getCore().application}>
-              <EuiLink
-                href={getCore().application.getUrlForApp(rules.id, {
-                  path: `#/manager/?tab=rules&redirectRule=${value}`,
-                })}
-              >
-                {value}
-              </EuiLink>
-            </RedirectAppLinks>
-          ),
-        },
-      ]
+          {
+            id: 'timestamp',
+            isSortable: true,
+            defaultSortDirection: 'desc',
+            displayAsText: 'Time',
+            render: value => formatUIDate(value),
+          },
+          {
+            id: 'syscheck.event',
+            displayAsText: 'Action',
+          },
+          { id: 'rule.description', displayAsText: 'Description' },
+          { id: 'rule.level', displayAsText: 'Level' },
+          {
+            id: 'rule.id',
+            displayAsText: 'Rule ID',
+            render: value => (
+              <RedirectAppLinks application={getCore().application}>
+                <EuiLink
+                  href={getCore().application.getUrlForApp(rules.id, {
+                    path: `#/manager/?tab=rules&redirectRule=${value}`,
+                  })}
+                >
+                  {value}
+                </EuiLink>
+              </RedirectAppLinks>
+            ),
+          },
+        ]
       : [
-        {
-          id: 'timestamp',
-          isSortable: true,
-          defaultSortDirection: 'desc',
-          displayAsText: 'Time',
-          render: value => formatUIDate(value),
-        },
-        {
-          id: 'agent.id',
-          displayAsText: 'Agent',
-          render: value => (
-            <RedirectAppLinks application={getCore().application}>
-              <EuiLink
-                href={getCore().application.getUrlForApp(endpointSummary.id, {
-                  path: `#/agents/?tab=welcome&agent=${value}`,
-                })}
-              >
-                {value}
-              </EuiLink>
-            </RedirectAppLinks>
-          ),
-        },
-        {
-          id: 'agent.name',
-          displayAsText: 'Agent name',
-        },
-        {
-          id: 'syscheck.event',
-          displayAsText: 'Action',
-        },
-        { id: 'rule.description', displayAsText: 'Description' },
-        { id: 'rule.level', displayAsText: 'Level' },
-        {
-          id: 'rule.id',
-          displayAsText: 'Rule ID',
-          render: value => (
-            <RedirectAppLinks application={getCore().application}>
-              <EuiLink
-                href={getCore().application.getUrlForApp(rules.id, {
-                  path: `#/manager/?tab=rules&redirectRule=${value}`,
-                })}
-              >
-                {value}
-              </EuiLink>
-            </RedirectAppLinks>
-          ),
-        },
-      ];
+          {
+            id: 'timestamp',
+            isSortable: true,
+            defaultSortDirection: 'desc',
+            displayAsText: 'Time',
+            render: value => formatUIDate(value),
+          },
+          {
+            id: 'agent.id',
+            displayAsText: 'Agent',
+            render: value => (
+              <RedirectAppLinks application={getCore().application}>
+                <EuiLink
+                  href={getCore().application.getUrlForApp(endpointSummary.id, {
+                    path: `#/agents/?tab=welcome&agent=${value}`,
+                  })}
+                >
+                  {value}
+                </EuiLink>
+              </RedirectAppLinks>
+            ),
+          },
+          {
+            id: 'agent.name',
+            displayAsText: 'Agent name',
+          },
+          {
+            id: 'syscheck.event',
+            displayAsText: 'Action',
+          },
+          { id: 'rule.description', displayAsText: 'Description' },
+          { id: 'rule.level', displayAsText: 'Level' },
+          {
+            id: 'rule.id',
+            displayAsText: 'Rule ID',
+            render: value => (
+              <RedirectAppLinks application={getCore().application}>
+                <EuiLink
+                  href={getCore().application.getUrlForApp(rules.id, {
+                    path: `#/manager/?tab=rules&redirectRule=${value}`,
+                  })}
+                >
+                  {value}
+                </EuiLink>
+              </RedirectAppLinks>
+            ),
+          },
+        ];
   }
 
   getImplicitFilters() {

--- a/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
@@ -301,9 +301,8 @@ export class FileDetails extends Component {
         'YYYY-MM-DD',
       )};${field}<${value_max.format('YYYY-MM-DD')}`;
     } else {
-      filterUQL = `${field}=${
-        field === 'size' ? this.props.currentFile[field] : value
-      }`;
+      filterUQL = `${field}=${field === 'size' ? this.props.currentFile[field] : value
+        }`;
     }
     onFiltersChange({ q: filterUQL });
     this.props.closeFlyout();
@@ -313,11 +312,12 @@ export class FileDetails extends Component {
     const { view } = this.props;
     const columns =
       this.props.type === 'registry_key' ||
-      this.props.currentFile.type === 'registry_key'
+        this.props.currentFile.type === 'registry_key'
         ? this.registryDetails()
         : this.details();
     const generalDetails = columns.map((item, idx) => {
       let value = this.props.currentFile[item.field] || '-';
+      let rawValue = value;
       if (item.transformValue) {
         value = item.transformValue(value, this.props);
       }
@@ -357,7 +357,7 @@ export class FileDetails extends Component {
                       >
                         <EuiButtonIcon
                           onClick={() => {
-                            this.addFilter(item.field, value);
+                            this.addFilter(item.field, item.field === 'date' || item.field === 'mtime' ? rawValue : value);
                           }}
                           iconType='magnifyWithPlus'
                           aria-label='Next'
@@ -382,7 +382,7 @@ export class FileDetails extends Component {
                     this.userSvg
                   )}
                   {item.name === 'Permissions' &&
-                  agentPlatform === 'windows' ? (
+                    agentPlatform === 'windows' ? (
                     ''
                   ) : (
                     <span className='detail-title'>{item.name}</span>
@@ -462,84 +462,84 @@ export class FileDetails extends Component {
     const agentId = this.props.agent?.id;
     return agentId
       ? [
-          {
-            id: 'timestamp',
-            isSortable: true,
-            defaultSortDirection: 'desc',
-            displayAsText: 'Time',
-            render: value => formatUIDate(value),
-          },
-          {
-            id: 'syscheck.event',
-            displayAsText: 'Action',
-          },
-          { id: 'rule.description', displayAsText: 'Description' },
-          { id: 'rule.level', displayAsText: 'Level' },
-          {
-            id: 'rule.id',
-            displayAsText: 'Rule ID',
-            render: value => (
-              <RedirectAppLinks application={getCore().application}>
-                <EuiLink
-                  href={getCore().application.getUrlForApp(rules.id, {
-                    path: `#/manager/?tab=rules&redirectRule=${value}`,
-                  })}
-                >
-                  {value}
-                </EuiLink>
-              </RedirectAppLinks>
-            ),
-          },
-        ]
+        {
+          id: 'timestamp',
+          isSortable: true,
+          defaultSortDirection: 'desc',
+          displayAsText: 'Time',
+          render: value => formatUIDate(value),
+        },
+        {
+          id: 'syscheck.event',
+          displayAsText: 'Action',
+        },
+        { id: 'rule.description', displayAsText: 'Description' },
+        { id: 'rule.level', displayAsText: 'Level' },
+        {
+          id: 'rule.id',
+          displayAsText: 'Rule ID',
+          render: value => (
+            <RedirectAppLinks application={getCore().application}>
+              <EuiLink
+                href={getCore().application.getUrlForApp(rules.id, {
+                  path: `#/manager/?tab=rules&redirectRule=${value}`,
+                })}
+              >
+                {value}
+              </EuiLink>
+            </RedirectAppLinks>
+          ),
+        },
+      ]
       : [
-          {
-            id: 'timestamp',
-            isSortable: true,
-            defaultSortDirection: 'desc',
-            displayAsText: 'Time',
-            render: value => formatUIDate(value),
-          },
-          {
-            id: 'agent.id',
-            displayAsText: 'Agent',
-            render: value => (
-              <RedirectAppLinks application={getCore().application}>
-                <EuiLink
-                  href={getCore().application.getUrlForApp(endpointSummary.id, {
-                    path: `#/agents/?tab=welcome&agent=${value}`,
-                  })}
-                >
-                  {value}
-                </EuiLink>
-              </RedirectAppLinks>
-            ),
-          },
-          {
-            id: 'agent.name',
-            displayAsText: 'Agent name',
-          },
-          {
-            id: 'syscheck.event',
-            displayAsText: 'Action',
-          },
-          { id: 'rule.description', displayAsText: 'Description' },
-          { id: 'rule.level', displayAsText: 'Level' },
-          {
-            id: 'rule.id',
-            displayAsText: 'Rule ID',
-            render: value => (
-              <RedirectAppLinks application={getCore().application}>
-                <EuiLink
-                  href={getCore().application.getUrlForApp(rules.id, {
-                    path: `#/manager/?tab=rules&redirectRule=${value}`,
-                  })}
-                >
-                  {value}
-                </EuiLink>
-              </RedirectAppLinks>
-            ),
-          },
-        ];
+        {
+          id: 'timestamp',
+          isSortable: true,
+          defaultSortDirection: 'desc',
+          displayAsText: 'Time',
+          render: value => formatUIDate(value),
+        },
+        {
+          id: 'agent.id',
+          displayAsText: 'Agent',
+          render: value => (
+            <RedirectAppLinks application={getCore().application}>
+              <EuiLink
+                href={getCore().application.getUrlForApp(endpointSummary.id, {
+                  path: `#/agents/?tab=welcome&agent=${value}`,
+                })}
+              >
+                {value}
+              </EuiLink>
+            </RedirectAppLinks>
+          ),
+        },
+        {
+          id: 'agent.name',
+          displayAsText: 'Agent name',
+        },
+        {
+          id: 'syscheck.event',
+          displayAsText: 'Action',
+        },
+        { id: 'rule.description', displayAsText: 'Description' },
+        { id: 'rule.level', displayAsText: 'Level' },
+        {
+          id: 'rule.id',
+          displayAsText: 'Rule ID',
+          render: value => (
+            <RedirectAppLinks application={getCore().application}>
+              <EuiLink
+                href={getCore().application.getUrlForApp(rules.id, {
+                  path: `#/manager/?tab=rules&redirectRule=${value}`,
+                })}
+              >
+                {value}
+              </EuiLink>
+            </RedirectAppLinks>
+          ),
+        },
+      ];
   }
 
   getImplicitFilters() {

--- a/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/plugins/main/public/components/agents/fim/inventory/fileDetail.tsx
@@ -309,6 +309,10 @@ export class FileDetails extends Component {
     this.props.closeFlyout();
   }
 
+  getFilterValue(fieldType, value, rawValue) {
+    return fieldType === 'date' || fieldType === 'mtime' ? rawValue : value;
+  }
+
   getDetails() {
     const { view } = this.props;
     const columns =
@@ -360,9 +364,7 @@ export class FileDetails extends Component {
                           onClick={() => {
                             this.addFilter(
                               item.field,
-                              item.field === 'date' || item.field === 'mtime'
-                                ? rawValue
-                                : value,
+                              this.getFilterValue(item.field, value, rawValue),
                             );
                           }}
                           iconType='magnifyWithPlus'


### PR DESCRIPTION
### Description

This PR solves the problem when applying a date type filter by clicking on the fields of the FIM details flyout.
This problem only occurred in Firefox and Safari browsers.

Closes #7146

## Before

https://github.com/user-attachments/assets/c79b97c9-f2ca-43b9-9285-d700a357ae08

<img width="1509" alt="Screenshot 2024-11-12 at 11 56 08 AM" src="https://github.com/user-attachments/assets/0211f100-637f-49aa-bd82-b4b1946f24d3">



## After

### Chrome


https://github.com/user-attachments/assets/17b90257-eb7c-462d-b0c7-3617071ec664


### Safari

https://github.com/user-attachments/assets/e3f725ce-2863-475a-bc21-b35a7afd2feb


### Firefox


https://github.com/user-attachments/assets/7a47238f-5eb3-42f3-8347-91f90e782684


## Test

1. Go to File Integrity Monitoring > Inventory Tab
2. Select an Agent
3. Click on the File table row
4. Apply the date filter by clicking the add filter button in the header time field
5. Repeat test for Safari, Chrome and Firefox browsers

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
