### PR TITLE
Fixed error message to prevent pass no strings to the wazuh logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Invalid date filter applied on FIM details flyout [#7160](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7160)
 - Fixed the check updates UI was displayed despite it could be configured as disabled [#7156](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7156)
 - Fixed filter by value in document details in safari [#7151](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7151)
+- Fixed error message to prevent pass no strings to the wazuh logger [#7167](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7167)
 
 ### Removed
 

--- a/plugins/main/server/lib/extract-error-message.ts
+++ b/plugins/main/server/lib/extract-error-message.ts
@@ -1,6 +1,6 @@
 export function extractErrorMessage(error: any) {
-  if (error.isAxiosError) {
+  if (error?.isAxiosError) {
     return error.response?.data?.detail;
   }
-  return error.message || error;
+  return error?.message || error || 'Unknown error';
 }

--- a/plugins/main/server/lib/extract-error-message.ts
+++ b/plugins/main/server/lib/extract-error-message.ts
@@ -1,0 +1,6 @@
+export function extractErrorMessage(error: any) {
+  if (error.isAxiosError) {
+    return error.response?.data?.detail;
+  }
+  return error.message || error;
+}


### PR DESCRIPTION
### Description

This PR  resolves some cases when the wazuh logger receives an unexpected object and cannot log correctly the error message

Closes #7165


<img width="1512" alt="Screenshot 2024-11-20 at 6 45 10 PM" src="https://github.com/user-attachments/assets/f5222084-4e93-466a-9180-47f14aa51876">

https://github.com/user-attachments/assets/a1ac33fc-e60c-400d-8ab3-7dc2b0539eb0


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
