### PR TITLE
Support for CDB lists beginning with quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Added ending quotes to CDB Lists keys [#7159](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7159)
+- Fixed rendering of rows in CDB list table when it starts with quotes. [#7171](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7171)
 
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 00
 

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -74,6 +74,8 @@ describe('WzListEditor', () => {
   const messagesError = {
     quotesError: 'Must start and end with quotes or have no quotes at all',
     colonError: 'Must start and end with quotes when using colon',
+    simbolsError:
+      'Must not contain simbols when using quotes(only letters, numbers and colon)',
   };
 
   beforeEach(() => {
@@ -204,19 +206,19 @@ describe('WzListEditor', () => {
   );
 
   it.each`
-    key            | value              | quotesError                  | colonError
-    ${'":key'}     | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError}
-    ${'key'}       | ${'":value'}       | ${messagesError.quotesError} | ${messagesError.colonError}
-    ${'key"key'}   | ${'value'}         | ${messagesError.quotesError} | ${''}
-    ${'key'}       | ${'value"value'}   | ${messagesError.quotesError} | ${''}
-    ${'key'}       | ${'value"'}        | ${messagesError.quotesError} | ${''}
-    ${'key'}       | ${'"value'}        | ${messagesError.quotesError} | ${''}
-    ${'"key"key"'} | ${'value'}         | ${messagesError.quotesError} | ${''}
-    ${'key'}       | ${'"value"value"'} | ${messagesError.quotesError} | ${''}
-    ${'key:key'}   | ${'value'}         | ${''}                        | ${messagesError.colonError}
-    ${'key:"key"'} | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError}
-    ${'key'}       | ${':value'}        | ${''}                        | ${messagesError.colonError}
-    ${'"key:key"'} | ${'"value":'}      | ${messagesError.quotesError} | ${messagesError.colonError}
+    key            | value              | quotesError                  | colonError                  | simbolsError
+    ${'":key'}     | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
+    ${'".key"'}    | ${'":value'}       | ${messagesError.quotesError} | ${messagesError.colonError} | ${messagesError.simbolsError}
+    ${'key"key'}   | ${'"value(*&"'}    | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+    ${'key'}       | ${'value"value'}   | ${messagesError.quotesError} | ${''}                       | ${''}
+    ${'"key!@#"'}  | ${'value"'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+    ${'"key."'}    | ${'"value'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+    ${'"key"key"'} | ${'value'}         | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+    ${'key'}       | ${'"value"value"'} | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+    ${'key:key'}   | ${'"value;"'}      | ${''}                        | ${messagesError.colonError} | ${messagesError.simbolsError}
+    ${'key:"key"'} | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
+    ${'key'}       | ${':value'}        | ${''}                        | ${messagesError.colonError} | ${''}
+    ${'"key:key"'} | ${'"value":'}      | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
   `(
     'should render the message when try to add invalid key($key) or value($value)',
     ({
@@ -224,11 +226,13 @@ describe('WzListEditor', () => {
       value,
       quotesError,
       colonError,
+      simbolsError,
     }: {
       key: string;
       value: string;
       quotesError: string;
       colonError: string;
+      simbolsError: string;
     }) => {
       const button = screen.getByText('Add new entry');
       fireEvent.click(button);
@@ -253,6 +257,12 @@ describe('WzListEditor', () => {
         expect(screen.getByText(colonError)).toBeInTheDocument();
       } else {
         expect(screen.queryByText(messagesError.colonError)).toBeFalsy();
+      }
+
+      if (simbolsError) {
+        expect(screen.getByText(simbolsError)).toBeInTheDocument();
+      } else {
+        expect(screen.queryByText(messagesError.simbolsError)).toBeFalsy();
       }
     },
   );

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -29,69 +29,31 @@ describe('WzListEditor', () => {
       value: '":testValue"',
     },
     {
-      key: 'key',
+      key: 'test1',
       value: '":key"',
     },
     {
-      key: '":key1"',
+      key: '":test1"',
       value: 'value1',
     },
     {
-      key: '"key2"',
+      key: '"test2"',
       value: '"value2"',
     },
     {
-      key: 'key3',
+      key: 'test3',
       value: '',
     },
     {
       key: '"a0:a0:a0:a0:a0:a0"',
       value: '',
     },
-    {
-      key: '"b1:b1:b1:b1:b1:b1"',
-      value: '"test:6"',
-    },
   ];
 
-  const cdblistErrors = [
-    {
-      key: '":key',
-      value: 'value',
-    },
-    {
-      key: 'key',
-      value: '":value',
-    },
-    {
-      key: 'key"key',
-      value: 'value',
-    },
-    {
-      key: 'key',
-      value: 'value"value',
-    },
-    {
-      key: 'key',
-      value: 'value"',
-    },
-    {
-      key: 'key',
-      value: '"value',
-    },
-    {
-      key: '"key"key"',
-      value: 'value',
-    },
-    {
-      key: 'key',
-      value: '"value"value"',
-    },
-    {
-      key: 'key:"key',
-      value: 'value',
-    },
-  ];
+  const messagesError = {
+    quotesError: 'Must start and end with quotes or have no quotes at all',
+    colonError: 'Must start and end with quotes when using colon',
+  };
 
   beforeEach(() => {
     const cdblistMap = cdblist.map(item => {
@@ -112,29 +74,109 @@ describe('WzListEditor', () => {
   it('should render the component', () => {
     cdblist.forEach(item => {
       expect(screen.getByText(item.key)).toBeInTheDocument();
-      if (!item.value === '') {
+      if (!(item.value === '')) {
         expect(screen.getByText(item.value)).toBeInTheDocument();
       }
       expect(screen.queryByText(`${item.key}:${item.value}`)).toBeFalsy();
     });
   });
 
-  it('shoudl render the message when try to add invalid key or value', () => {
-    const button = screen.getByText('Add new entry');
+  it('should delete the item correctly', async () => {
+    const deleteButton = screen.queryAllByTestId('deleteButton');
+    fireEvent.click(deleteButton[0].closest('button'));
 
-    fireEvent.click(button);
-
-    const keyInput = screen.getByPlaceholderText('Key');
-    const valueInput = screen.getByPlaceholderText('Value');
-
-    cdblistErrors.forEach(item => {
-      fireEvent.change(keyInput, { target: { value: item.key } });
-      fireEvent.change(valueInput, { target: { value: item.value } });
-      expect(
-        screen.getByText(
-          'Must start and end with quotes or have no quotes at all',
-        ),
-      ).toBeInTheDocument();
-    });
+    expect(screen.queryByText(cdblist[0].key)).toBeFalsy();
   });
+
+  it.each`
+    key                      | value
+    ${'key'}                 | ${'value'}
+    ${'"key"'}               | ${'value'}
+    ${'"key"'}               | ${'"value"'}
+    ${'"key:key"'}           | ${'value'}
+    ${'"key:key"'}           | ${'"value:value"'}
+    ${'"key"'}               | ${'"value:value"'}
+    ${'key'}                 | ${'"value:value"'}
+    ${'key'}                 | ${''}
+    ${'"key"'}               | ${''}
+    ${'"key:key"'}           | ${''}
+    ${'"b1:b1:b1:b1:b1:b1"'} | ${'test6'}
+  `(
+    'should add keys($key) and values($value) correctly',
+    ({ key, value }: { key: string; value: string }) => {
+      const button = screen.getByText('Add new entry');
+      fireEvent.click(button);
+
+      const keyInput = screen.getByPlaceholderText('Key');
+      const valueInput = screen.getByPlaceholderText('Value');
+
+      fireEvent.change(keyInput, { target: { value: key } });
+      fireEvent.change(valueInput, { target: { value: value } });
+
+      const addButton = screen.getByText('Add');
+
+      expect(addButton.closest('button')).not.toBeDisabled();
+
+      fireEvent.click(addButton);
+
+      expect(screen.getByText(key)).toBeInTheDocument();
+      if (!(value === '')) {
+        expect(screen.getByText(value)).toBeInTheDocument();
+      }
+    },
+  );
+
+  it.each`
+    key            | value              | quotesError                  | colonError
+    ${'":key'}     | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError}
+    ${'key'}       | ${'":value'}       | ${messagesError.quotesError} | ${messagesError.colonError}
+    ${'key"key'}   | ${'value'}         | ${messagesError.quotesError} | ${''}
+    ${'key'}       | ${'value"value'}   | ${messagesError.quotesError} | ${''}
+    ${'key'}       | ${'value"'}        | ${messagesError.quotesError} | ${''}
+    ${'key'}       | ${'"value'}        | ${messagesError.quotesError} | ${''}
+    ${'"key"key"'} | ${'value'}         | ${messagesError.quotesError} | ${''}
+    ${'key'}       | ${'"value"value"'} | ${messagesError.quotesError} | ${''}
+    ${'key:key'}   | ${'value'}         | ${''}                        | ${messagesError.colonError}
+    ${'key:"key"'} | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError}
+    ${'key'}       | ${':value'}        | ${''}                        | ${messagesError.colonError}
+    ${'"key:key"'} | ${'"value":'}      | ${messagesError.quotesError} | ${messagesError.colonError}
+  `(
+    'should render the message when try to add invalid key($key) or value($value)',
+    ({
+      key,
+      value,
+      quotesError,
+      colonError,
+    }: {
+      key: string;
+      value: string;
+      quotesError: string;
+      colonError: string;
+    }) => {
+      const button = screen.getByText('Add new entry');
+      fireEvent.click(button);
+
+      const keyInput = screen.getByPlaceholderText('Key');
+      const valueInput = screen.getByPlaceholderText('Value');
+
+      fireEvent.change(keyInput, { target: { value: key } });
+      fireEvent.change(valueInput, { target: { value: value } });
+
+      const addButton = screen.getByText('Add');
+
+      expect(addButton.closest('button')).toBeDisabled();
+
+      if (quotesError) {
+        expect(screen.getByText(quotesError)).toBeInTheDocument();
+      } else {
+        expect(screen.queryByText(messagesError.quotesError)).toBeFalsy();
+      }
+
+      if (colonError) {
+        expect(screen.getByText(colonError)).toBeInTheDocument();
+      } else {
+        expect(screen.queryByText(messagesError.colonError)).toBeFalsy();
+      }
+    },
+  );
 });

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import WzListEditor from './list-editor';
+
+const mockStore = configureMockStore();
+const store = mockStore({
+  appStateReducers: {
+    userAccount: {
+      administrator: true,
+    },
+    withUserLogged: true,
+    userPermissions: {
+      'lists:read': { '*:*:*': 'allow' },
+    },
+  },
+});
+
+describe('WzListEditor', () => {
+  const cdblist = [
+    {
+      key: 'test',
+      value: 'testValue',
+    },
+    {
+      key: '":test"',
+      value: '":testValue"',
+    },
+    {
+      key: 'key',
+      value: '":key"',
+    },
+    {
+      key: '":key1"',
+      value: 'value1',
+    },
+    {
+      key: '"key2"',
+      value: '"value2"',
+    },
+    {
+      key: 'key3',
+      value: '',
+    },
+  ];
+
+  it('should render the component', () => {
+    const cdblistMap = cdblist.map(item => {
+      return `${item.key}:${item.value}`;
+    });
+
+    const listContent = {
+      content: `${cdblistMap.join('\n')}`,
+    };
+
+    render(
+      <Provider store={store}>
+        <WzListEditor listContent={listContent} />
+      </Provider>,
+    );
+
+    cdblist.forEach(item => {
+      expect(screen.getByText(item.key)).toBeInTheDocument();
+      if (!item.value === '') {
+        expect(screen.getByText(item.value)).toBeInTheDocument();
+      }
+      expect(screen.queryByText(`${item.key}:${item.value}`)).toBeFalsy();
+    });
+  });
+});

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -4,14 +4,10 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import WzListEditor from './list-editor';
-import {
-  ResourcesConstants,
-  ResourcesHandler,
-} from '../../common/resources-handler';
 
 jest.mock('../../../../../../react-services/common-services', () => ({
   getErrorOrchestrator: () => ({
-    handleError: options => {},
+    handleError: () => {},
   }),
 }));
 
@@ -111,6 +107,33 @@ describe('WzListEditor', () => {
     fireEvent.click(deleteButton[0].closest('button'));
 
     expect(screen.queryByText(cdblist[0].key)).toBeFalsy();
+  });
+
+  it('should edit the value correctly or cancel the edit', async () => {
+    expect(screen.queryByText('newValue')).toBeFalsy();
+
+    const editButton = screen.queryAllByTestId('editButton');
+    fireEvent.click(editButton[0]);
+
+    const valueInput = screen.getByPlaceholderText('New value');
+
+    fireEvent.change(valueInput, { target: { value: 'newValue' } });
+
+    const saveEditButton = screen.getByTestId('saveEditButton');
+
+    fireEvent.click(saveEditButton.closest('button'));
+
+    expect(screen.getByText('newValue')).toBeInTheDocument();
+
+    fireEvent.click(editButton[1]);
+
+    fireEvent.change(valueInput, { target: { value: 'newValue2' } });
+
+    const cancelButton = screen.getByTestId('cancelEditButton');
+
+    fireEvent.click(cancelButton.closest('button'));
+
+    expect(screen.queryByText('newValue2')).toBeFalsy();
   });
 
   it('should update file correctly', async () => {

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -13,7 +13,12 @@ jest.mock('../../../../../../react-services/common-services', () => ({
 
 jest.mock('../../common/resources-handler', () => ({
   ResourcesHandler: jest.fn().mockImplementation(() => ({
-    updateFile: jest.fn().mockResolvedValue({ data: {} }),
+    updateFile: jest.fn().mockResolvedValue({
+      data: {
+        error: 0,
+        data: 'Success',
+      },
+    }),
   })),
   ResourcesConstants: {
     LISTS: 'lists',
@@ -24,6 +29,13 @@ jest.mock('../../common/resources-handler', () => ({
       permissionResource: value => `list:file:${value}`,
     },
   },
+}));
+
+const mockAdd = jest.fn();
+jest.mock('../../../../../../kibana-services', () => ({
+  getToasts: () => ({
+    add: mockAdd,
+  }),
 }));
 
 const mockStore = configureMockStore();
@@ -40,157 +52,35 @@ const store = mockStore({
 });
 
 describe('WzListEditor', () => {
-  const cdblist = [
-    {
-      key: 'test',
-      value: 'testValue',
-    },
-    {
-      key: '":test"',
-      value: '":testValue"',
-    },
-    {
-      key: 'test1',
-      value: '":key"',
-    },
-    {
-      key: '":test1"',
-      value: 'value1',
-    },
-    {
-      key: '"test2"',
-      value: '"value2"',
-    },
-    {
-      key: 'test3',
-      value: '',
-    },
-    {
-      key: '"a0:a0:a0:a0:a0:a0"',
-      value: '',
-    },
-  ];
+  describe('Without data in the list', () => {
+    it('should handle empty list content correctly', async () => {
+      const emptyListContent = {
+        content: '',
+        name: false,
+        path: '/lists/startTest',
+      };
 
-  const messagesError = {
-    quotesError: 'Must start and end with quotes or have no quotes at all',
-    colonError: 'Must start and end with quotes when using colon',
-    simbolsError:
-      'Must not contain simbols when using quotes(only letters, numbers and colon)',
-  };
+      render(
+        <Provider store={store}>
+          <WzListEditor listContent={emptyListContent} />
+        </Provider>,
+      );
 
-  beforeEach(() => {
-    const cdblistMap = cdblist.map(item => {
-      return `${item.key}:${item.value}`;
-    });
+      expect(screen.getByText('No results...')).toBeInTheDocument();
 
-    const listContent = {
-      content: `${cdblistMap.join('\n')}`,
-    };
+      const saveButton = screen.getByText('Save');
 
-    render(
-      <Provider store={store}>
-        <WzListEditor listContent={listContent} />
-      </Provider>,
-    );
-  });
+      expect(saveButton.closest('button')).toBeDisabled();
 
-  it('should render the component', () => {
-    cdblist.forEach(item => {
-      expect(screen.getByText(item.key)).toBeInTheDocument();
-      if (!(item.value === '')) {
-        expect(screen.getByText(item.value)).toBeInTheDocument();
-      }
-      expect(screen.queryByText(`${item.key}:${item.value}`)).toBeFalsy();
-    });
-  });
+      const addNewEntryButton = screen.getByText('Add new entry');
 
-  it('should delete the item correctly', async () => {
-    const deleteButton = screen.queryAllByTestId('deleteButton');
-    fireEvent.click(deleteButton[0].closest('button'));
-
-    expect(screen.queryByText(cdblist[0].key)).toBeFalsy();
-  });
-
-  it('should edit the value correctly or cancel the edit', async () => {
-    expect(screen.queryByText('newValue')).toBeFalsy();
-
-    const editButton = screen.queryAllByTestId('editButton');
-    fireEvent.click(editButton[0]);
-
-    const valueInput = screen.getByPlaceholderText('New value');
-
-    fireEvent.change(valueInput, { target: { value: 'newValue' } });
-
-    const saveEditButton = screen.getByTestId('saveEditButton');
-
-    fireEvent.click(saveEditButton.closest('button'));
-
-    expect(screen.getByText('newValue')).toBeInTheDocument();
-
-    fireEvent.click(editButton[1]);
-
-    fireEvent.change(valueInput, { target: { value: 'newValue2' } });
-
-    const cancelButton = screen.getByTestId('cancelEditButton');
-
-    fireEvent.click(cancelButton.closest('button'));
-
-    expect(screen.queryByText('newValue2')).toBeFalsy();
-  });
-
-  it('should update file correctly', async () => {
-    const button = screen.getByText('Add new entry');
-
-    fireEvent.click(button);
-
-    const keyInput = screen.getByPlaceholderText('Key');
-    const valueInput = screen.getByPlaceholderText('Value');
-
-    fireEvent.change(keyInput, { target: { value: 'newKey' } });
-    fireEvent.change(valueInput, { target: { value: 'newValue' } });
-
-    const addButton = screen.getByText('Add');
-
-    expect(addButton.closest('button')).not.toBeDisabled();
-
-    fireEvent.click(addButton);
-
-    const saveButton = screen.getByText('Save');
-
-    expect(saveButton.closest('button')).not.toBeDisabled();
-
-    fireEvent.click(saveButton);
-
-    expect(screen.getByText('newKey')).toBeInTheDocument();
-    expect(screen.getByText('newValue')).toBeInTheDocument();
-
-    // TODO: Add expect to check information message or Restart button
-  });
-
-  it.each`
-    key                      | value
-    ${'key'}                 | ${'value'}
-    ${'"key"'}               | ${'value'}
-    ${'"key"'}               | ${'"value"'}
-    ${'"key:key"'}           | ${'value'}
-    ${'"key:key"'}           | ${'"value:value"'}
-    ${'"key"'}               | ${'"value:value"'}
-    ${'key'}                 | ${'"value:value"'}
-    ${'key'}                 | ${''}
-    ${'"key"'}               | ${''}
-    ${'"key:key"'}           | ${''}
-    ${'"b1:b1:b1:b1:b1:b1"'} | ${'test6'}
-  `(
-    'should add keys($key) and values($value) correctly',
-    ({ key, value }: { key: string; value: string }) => {
-      const button = screen.getByText('Add new entry');
-      fireEvent.click(button);
+      fireEvent.click(addNewEntryButton);
 
       const keyInput = screen.getByPlaceholderText('Key');
       const valueInput = screen.getByPlaceholderText('Value');
 
-      fireEvent.change(keyInput, { target: { value: key } });
-      fireEvent.change(valueInput, { target: { value: value } });
+      fireEvent.change(keyInput, { target: { value: 'testAddKey' } });
+      fireEvent.change(valueInput, { target: { value: 'testAddValue' } });
 
       const addButton = screen.getByText('Add');
 
@@ -198,72 +88,323 @@ describe('WzListEditor', () => {
 
       fireEvent.click(addButton);
 
-      expect(screen.getByText(key)).toBeInTheDocument();
-      if (!(value === '')) {
-        expect(screen.getByText(value)).toBeInTheDocument();
-      }
-    },
-  );
+      expect(screen.getByText('testAddKey')).toBeInTheDocument();
+      expect(screen.getByText('testAddValue')).toBeInTheDocument();
 
-  it.each`
-    key            | value              | quotesError                  | colonError                  | simbolsError
-    ${'":key'}     | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
-    ${'".key"'}    | ${'":value'}       | ${messagesError.quotesError} | ${messagesError.colonError} | ${messagesError.simbolsError}
-    ${'key"key'}   | ${'"value(*&"'}    | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
-    ${'key'}       | ${'value"value'}   | ${messagesError.quotesError} | ${''}                       | ${''}
-    ${'"key!@#"'}  | ${'value"'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
-    ${'"key."'}    | ${'"value'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
-    ${'"key"key"'} | ${'value'}         | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
-    ${'key'}       | ${'"value"value"'} | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
-    ${'key:key'}   | ${'"value;"'}      | ${''}                        | ${messagesError.colonError} | ${messagesError.simbolsError}
-    ${'key:"key"'} | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
-    ${'key'}       | ${':value'}        | ${''}                        | ${messagesError.colonError} | ${''}
-    ${'"key:key"'} | ${'"value":'}      | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
-  `(
-    'should render the message when try to add invalid key($key) or value($value)',
-    ({
-      key,
-      value,
-      quotesError,
-      colonError,
-      simbolsError,
-    }: {
-      key: string;
-      value: string;
-      quotesError: string;
-      colonError: string;
-      simbolsError: string;
-    }) => {
+      expect(saveButton.closest('button')).not.toBeDisabled();
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockAdd).toHaveBeenCalledWith({
+          title: 'Invalid name',
+          color: 'warning',
+          text: 'CDB list name cannot be empty',
+          toastLifeTimeMs: 3000,
+        });
+      });
+
+      const nameInput = screen.getByPlaceholderText('New CDB list name');
+
+      fireEvent.change(nameInput, { target: { value: 'test' } });
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockAdd).toHaveBeenCalledWith({
+          title: 'Success',
+          color: 'success',
+          text: 'CBD List successfully created',
+          toastLifeTimeMs: 3000,
+        });
+      });
+    });
+  });
+
+  describe('With data in the list', () => {
+    const cdblist = [
+      {
+        key: 'test',
+        value: 'testValue',
+      },
+      {
+        key: '":test"',
+        value: '":testValue"',
+      },
+      {
+        key: 'test1',
+        value: '":key"',
+      },
+      {
+        key: '":test1"',
+        value: 'value1',
+      },
+      {
+        key: '"test2"',
+        value: '"value2"',
+      },
+      {
+        key: 'test3',
+        value: '',
+      },
+      {
+        key: '"a0:a0:a0:a0:a0:a0"',
+        value: '',
+      },
+    ];
+
+    const messagesError = {
+      quotesError: 'Must start and end with quotes or have no quotes at all',
+      colonError: 'Must start and end with quotes when using colon',
+      simbolsError:
+        'Must not contain simbols when using quotes(only letters, numbers and colon)',
+    };
+
+    beforeEach(() => {
+      const cdblistMap = cdblist.map(item => {
+        return `${item.key}:${item.value}`;
+      });
+
+      const listContent = {
+        name: 'testName',
+        content: `${cdblistMap.join('\n')}`,
+        path: '/lists/test',
+      };
+
+      render(
+        <Provider store={store}>
+          <WzListEditor listContent={listContent} />
+        </Provider>,
+      );
+    });
+
+    afterEach(() => {
+      mockAdd.mockClear();
+    });
+
+    it('should render the component', () => {
+      cdblist.forEach(item => {
+        expect(screen.getByText(item.key)).toBeInTheDocument();
+        if (!(item.value === '')) {
+          expect(screen.getByText(item.value)).toBeInTheDocument();
+        }
+        expect(screen.queryByText(`${item.key}:${item.value}`)).toBeFalsy();
+      });
+    });
+
+    it('should delete the item correctly', async () => {
+      const deleteButton = screen.queryAllByTestId('deleteButton');
+      fireEvent.click(deleteButton[0].closest('button'));
+
+      expect(screen.queryByText(cdblist[0].key)).toBeFalsy();
+    });
+
+    it('should edit the value correctly or cancel the edit', async () => {
+      expect(screen.queryByText('newValue')).toBeFalsy();
+
+      const editButton = screen.queryAllByTestId('editButton');
+
+      fireEvent.click(editButton[0]);
+
+      const valueInput = screen.getByPlaceholderText('New value');
+
+      fireEvent.change(valueInput, { target: { value: 'newValue' } });
+
+      const saveEditButton = screen.getByTestId('saveEditButton');
+
+      fireEvent.click(saveEditButton.closest('button'));
+
+      expect(screen.getByText('newValue')).toBeInTheDocument();
+
+      fireEvent.click(editButton[1]);
+
+      fireEvent.change(valueInput, { target: { value: 'newValue2' } });
+
+      const cancelButton = screen.getByTestId('cancelEditButton');
+
+      fireEvent.click(cancelButton.closest('button'));
+
+      expect(screen.queryByText('newValue2')).toBeFalsy();
+    });
+
+    it('should update file correctly', async () => {
+      const button = screen.getByText('Add new entry');
+
+      fireEvent.click(button);
+
+      const keyInput = screen.getByPlaceholderText('Key');
+      const valueInput = screen.getByPlaceholderText('Value');
+
+      fireEvent.change(keyInput, { target: { value: 'newKey' } });
+      fireEvent.change(valueInput, { target: { value: 'newValue' } });
+
+      const addButton = screen.getByText('Add');
+
+      expect(addButton.closest('button')).not.toBeDisabled();
+
+      fireEvent.click(addButton);
+
+      const saveButton = screen.getByText('Save');
+
+      expect(saveButton.closest('button')).not.toBeDisabled();
+
+      fireEvent.click(saveButton);
+
+      expect(screen.getByText('newKey')).toBeInTheDocument();
+      expect(screen.getByText('newValue')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mockAdd).toHaveBeenCalledWith({
+          title: 'Success',
+          color: 'success',
+          text: 'CBD List updated',
+          toastLifeTimeMs: 3000,
+        });
+      });
+    });
+
+    it('should render the message when try to add duplicated key', async () => {
+      expect(screen.queryAllByText('test')).toHaveLength(1);
+
       const button = screen.getByText('Add new entry');
       fireEvent.click(button);
 
       const keyInput = screen.getByPlaceholderText('Key');
       const valueInput = screen.getByPlaceholderText('Value');
 
-      fireEvent.change(keyInput, { target: { value: key } });
-      fireEvent.change(valueInput, { target: { value: value } });
+      fireEvent.change(keyInput, { target: { value: 'test' } });
+      fireEvent.change(valueInput, { target: { value: 'testValue' } });
 
       const addButton = screen.getByText('Add');
+      fireEvent.click(addButton);
 
-      expect(addButton.closest('button')).toBeDisabled();
+      expect(mockAdd).toHaveBeenCalledWith({
+        title: 'Error',
+        color: 'danger',
+        text: (
+          <React.Fragment>
+            <strong>test</strong> key already exists
+          </React.Fragment>
+        ),
+        toastLifeTimeMs: 3000,
+      });
 
-      if (quotesError) {
-        expect(screen.getByText(quotesError)).toBeInTheDocument();
-      } else {
-        expect(screen.queryByText(messagesError.quotesError)).toBeFalsy();
-      }
+      expect(screen.queryAllByText('test')).toHaveLength(1);
+    });
 
-      if (colonError) {
-        expect(screen.getByText(colonError)).toBeInTheDocument();
-      } else {
-        expect(screen.queryByText(messagesError.colonError)).toBeFalsy();
-      }
+    it.each`
+      key                      | value
+      ${'key'}                 | ${'value'}
+      ${'"key"'}               | ${'value'}
+      ${'"key"'}               | ${'"value"'}
+      ${'"key:key"'}           | ${'value'}
+      ${'"key:key"'}           | ${'"value:value"'}
+      ${'"key"'}               | ${'"value:value"'}
+      ${'key'}                 | ${'"value:value"'}
+      ${'key'}                 | ${''}
+      ${'"key"'}               | ${''}
+      ${'"key:key"'}           | ${''}
+      ${'"b1:b1:b1:b1:b1:b1"'} | ${'test6'}
+    `(
+      'should add keys($key) and values($value) correctly',
+      async ({ key, value }: { key: string; value: string }) => {
+        const button = screen.getByText('Add new entry');
+        fireEvent.click(button);
 
-      if (simbolsError) {
-        expect(screen.getByText(simbolsError)).toBeInTheDocument();
-      } else {
-        expect(screen.queryByText(messagesError.simbolsError)).toBeFalsy();
-      }
-    },
-  );
+        const keyInput = screen.getByPlaceholderText('Key');
+        const valueInput = screen.getByPlaceholderText('Value');
+
+        fireEvent.change(keyInput, { target: { value: key } });
+        fireEvent.change(valueInput, { target: { value: value } });
+
+        const addButton = screen.getByText('Add');
+
+        expect(addButton.closest('button')).not.toBeDisabled();
+
+        fireEvent.click(addButton);
+
+        expect(screen.getByText(key)).toBeInTheDocument();
+        if (!(value === '')) {
+          expect(screen.getByText(value)).toBeInTheDocument();
+        }
+
+        const saveButton = screen.getByText('Save');
+
+        expect(saveButton.closest('button')).not.toBeDisabled();
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+          expect(mockAdd).toHaveBeenCalledWith({
+            title: 'Success',
+            color: 'success',
+            text: 'CBD List updated',
+            toastLifeTimeMs: 3000,
+          });
+        });
+      },
+    );
+
+    it.each`
+      key            | value              | quotesError                  | colonError                  | simbolsError
+      ${'":key'}     | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
+      ${'".key"'}    | ${'":value'}       | ${messagesError.quotesError} | ${messagesError.colonError} | ${messagesError.simbolsError}
+      ${'key"key'}   | ${'"value(*&"'}    | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+      ${'key'}       | ${'value"value'}   | ${messagesError.quotesError} | ${''}                       | ${''}
+      ${'"key!@#"'}  | ${'value"'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+      ${'"key."'}    | ${'"value'}        | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+      ${'"key"key"'} | ${'value'}         | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+      ${'key'}       | ${'"value"value"'} | ${messagesError.quotesError} | ${''}                       | ${messagesError.simbolsError}
+      ${'key:key'}   | ${'"value;"'}      | ${''}                        | ${messagesError.colonError} | ${messagesError.simbolsError}
+      ${'key:"key"'} | ${'value'}         | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
+      ${'key'}       | ${':value'}        | ${''}                        | ${messagesError.colonError} | ${''}
+      ${'"key:key"'} | ${'"value":'}      | ${messagesError.quotesError} | ${messagesError.colonError} | ${''}
+    `(
+      'should render the message when try to add invalid key($key) or value($value)',
+      ({
+        key,
+        value,
+        quotesError,
+        colonError,
+        simbolsError,
+      }: {
+        key: string;
+        value: string;
+        quotesError: string;
+        colonError: string;
+        simbolsError: string;
+      }) => {
+        const button = screen.getByText('Add new entry');
+        fireEvent.click(button);
+
+        const keyInput = screen.getByPlaceholderText('Key');
+        const valueInput = screen.getByPlaceholderText('Value');
+
+        fireEvent.change(keyInput, { target: { value: key } });
+        fireEvent.change(valueInput, { target: { value: value } });
+
+        const addButton = screen.getByText('Add');
+
+        expect(addButton.closest('button')).toBeDisabled();
+
+        if (quotesError) {
+          expect(screen.getByText(quotesError)).toBeInTheDocument();
+        } else {
+          expect(screen.queryByText(messagesError.quotesError)).toBeFalsy();
+        }
+
+        if (colonError) {
+          expect(screen.getByText(colonError)).toBeInTheDocument();
+        } else {
+          expect(screen.queryByText(messagesError.colonError)).toBeFalsy();
+        }
+
+        if (simbolsError) {
+          expect(screen.getByText(simbolsError)).toBeInTheDocument();
+        } else {
+          expect(screen.queryByText(messagesError.simbolsError)).toBeFalsy();
+        }
+      },
+    );
+  });
 });

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -183,6 +183,9 @@ describe('WzListEditor', () => {
     });
 
     it('should render the component', () => {
+      expect(screen.getByText('testName')).toBeInTheDocument();
+      expect(screen.getByText('/lists/test')).toBeInTheDocument();
+
       cdblist.forEach(item => {
         expect(screen.getByText(item.key)).toBeInTheDocument();
         if (!(item.value === '')) {

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -44,6 +44,14 @@ describe('WzListEditor', () => {
       key: 'key3',
       value: '',
     },
+    {
+      key: '"a0:a0:a0:a0:a0:a0"',
+      value: '',
+    },
+    {
+      key: '"b1:b1:b1:b1:b1:b1"',
+      value: '"test:6"',
+    },
   ];
 
   it('should render the component', () => {

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.test.tsx
@@ -54,7 +54,46 @@ describe('WzListEditor', () => {
     },
   ];
 
-  it('should render the component', () => {
+  const cdblistErrors = [
+    {
+      key: '":key',
+      value: 'value',
+    },
+    {
+      key: 'key',
+      value: '":value',
+    },
+    {
+      key: 'key"key',
+      value: 'value',
+    },
+    {
+      key: 'key',
+      value: 'value"value',
+    },
+    {
+      key: 'key',
+      value: 'value"',
+    },
+    {
+      key: 'key',
+      value: '"value',
+    },
+    {
+      key: '"key"key"',
+      value: 'value',
+    },
+    {
+      key: 'key',
+      value: '"value"value"',
+    },
+    {
+      key: 'key:"key',
+      value: 'value',
+    },
+  ];
+
+  beforeEach(() => {
     const cdblistMap = cdblist.map(item => {
       return `${item.key}:${item.value}`;
     });
@@ -68,13 +107,34 @@ describe('WzListEditor', () => {
         <WzListEditor listContent={listContent} />
       </Provider>,
     );
+  });
 
+  it('should render the component', () => {
     cdblist.forEach(item => {
       expect(screen.getByText(item.key)).toBeInTheDocument();
       if (!item.value === '') {
         expect(screen.getByText(item.value)).toBeInTheDocument();
       }
       expect(screen.queryByText(`${item.key}:${item.value}`)).toBeFalsy();
+    });
+  });
+
+  it('shoudl render the message when try to add invalid key or value', () => {
+    const button = screen.getByText('Add new entry');
+
+    fireEvent.click(button);
+
+    const keyInput = screen.getByPlaceholderText('Key');
+    const valueInput = screen.getByPlaceholderText('Value');
+
+    cdblistErrors.forEach(item => {
+      fireEvent.change(keyInput, { target: { value: item.key } });
+      fireEvent.change(valueInput, { target: { value: item.value } });
+      expect(
+        screen.getByText(
+          'Must start and end with quotes or have no quotes at all',
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -502,7 +502,6 @@ class WzListEditor extends Component {
                     <EuiButtonEmpty
                       iconType='plusInCircle'
                       isDisabled={!addingKey}
-                      fill
                       onClick={() => this.addItem()}
                       disabled={hasInvalidState}
                     >

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -300,15 +300,15 @@ class WzListEditor extends Component {
           return;
         }
 
-        this.setState({
+        this.setState(prevState => ({
           isInvalid: [
-            ...this.state.isInvalid,
+            ...prevState.isInvalid,
             {
               field,
               message: this.messages.colonError,
             },
           ],
-        });
+        }));
         return;
       }
     }
@@ -332,10 +332,11 @@ class WzListEditor extends Component {
     const hasMiddleQuotes = value.slice(1, -1).includes('"');
     const startsWithQuote = value.startsWith('"');
     const endsWithQuote = value.endsWith('"');
+    const valueLength = value.length !== 1;
 
     const isValid =
       !hasMiddleQuotes &&
-      ((startsWithQuote && endsWithQuote) ||
+      ((startsWithQuote && endsWithQuote && valueLength) ||
         (!startsWithQuote && !endsWithQuote));
 
     if (!isValid) {
@@ -349,15 +350,15 @@ class WzListEditor extends Component {
         return;
       }
 
-      this.setState({
+      this.setState(prevState => ({
         isInvalid: [
-          ...this.state.isInvalid,
+          ...prevState.isInvalid,
           {
             field,
             message: this.messages.quotesError,
           },
         ],
-      });
+      }));
     } else {
       this.setState(prevState => ({
         isInvalid: prevState.isInvalid.filter(
@@ -693,6 +694,7 @@ class WzListEditor extends Component {
                     });
                   }}
                   color='primary'
+                  data-testid='editButton'
                 />
                 <WzButtonPermissions
                   buttonType='icon'
@@ -702,6 +704,7 @@ class WzListEditor extends Component {
                   tooltip={{ position: 'top', content: `Remove ${item.key}` }}
                   onClick={() => this.deleteItem(item.key)}
                   color='danger'
+                  data-testid='deleteButton'
                 />
               </Fragment>
             );

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -666,6 +666,7 @@ class WzListEditor extends Component {
                       this.setEditedValue();
                     }}
                     color='primary'
+                    data-testid='saveEditButton'
                   />
                 </EuiToolTip>
                 <EuiToolTip position='top' content={'Discard'}>
@@ -674,6 +675,7 @@ class WzListEditor extends Component {
                     iconType='cross'
                     onClick={() => this.setState({ editing: false })}
                     color='danger'
+                    data-testid='cancelEditButton'
                   />
                 </EuiToolTip>
               </Fragment>

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -515,9 +515,9 @@ class WzListEditor extends Component {
     placeholder: string;
   }) {
     const isInvalid = this.state.isInvalid.some(error => error.field === field);
-    const errorMessages = this.state.isInvalid.map(error => {
-      const keyMatches = error.field === field;
-      return keyMatches ? error.message : '';
+    const errorMessages: string[] = [];
+    this.state.isInvalid.forEach(error => {
+      error.field === field && errorMessages.push(error.message);
     });
 
     return (

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -179,7 +179,6 @@ class WzListEditor extends Component {
       await this.resourcesHandler.updateFile(name, raw, overwrite);
       if (!addingNew) {
         const file = { name: name, content: raw, path: path };
-        this.props.updateListContent(file);
         this.setState({ showWarningRestart: true });
         this.showToast(
           'success',
@@ -187,6 +186,7 @@ class WzListEditor extends Component {
           'CBD List successfully created',
           3000,
         );
+        this.props.updateListContent(file);
       } else {
         this.setState({ showWarningRestart: true });
         this.showToast('success', 'Success', 'CBD List updated', 3000);
@@ -208,7 +208,7 @@ class WzListEditor extends Component {
     this.setState({ isSaving: false });
   }
 
-  showToast = (color, title, text, time) => {
+  showToast = (color: string, title: string, text: string, time: number) => {
     getToasts().add({
       color: color,
       title: title,

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -50,7 +50,7 @@ type FieldTypes = 'key' | 'value' | 'edit';
 type FieldStateTypes = 'addingKey' | 'addingValue' | 'editingValue';
 
 class WzListEditor extends Component {
-  messages = {
+  private readonly messages = {
     quotesError: 'Must start and end with quotes or have no quotes at all',
     colonError: 'Must start and end with quotes when using colon',
   };
@@ -311,17 +311,15 @@ class WzListEditor extends Component {
         });
         return;
       }
-
-      this.setState(prevState => ({
-        isInvalid: prevState.isInvalid.filter(
-          error =>
-            !(
-              error.field === field &&
-              error.message === this.messages.colonError
-            ),
-        ),
-      }));
     }
+    this.setState(prevState => ({
+      isInvalid: prevState.isInvalid.filter(
+        error =>
+          !(
+            error.field === field && error.message === this.messages.colonError
+          ),
+      ),
+    }));
   };
 
   /**
@@ -378,6 +376,7 @@ class WzListEditor extends Component {
    */
   addItem() {
     const { addingKey, addingValue } = this.state;
+    const hasinvalidState = this.state.isInvalid.length > 0;
     if (!addingKey || Object.keys(this.items).includes(addingKey)) {
       this.showToast(
         'danger',
@@ -389,7 +388,7 @@ class WzListEditor extends Component {
       );
       return;
     }
-    if (this.state.isInvalid.length > 0) {
+    if (hasinvalidState) {
       this.showToast(
         'danger',
         'Error',
@@ -518,21 +517,21 @@ class WzListEditor extends Component {
     onChange: (e: any) => void;
     placeholder: string;
   }) {
-    const isValid = this.state.isInvalid.some(error => error.field === field);
+    const isInvalid = this.state.isInvalid.some(error => error.field === field);
     const errorMessages = this.state.isInvalid.map(error => {
       const keyMatches = error.field === field;
       return keyMatches ? error.message : '';
     });
 
     return (
-      <EuiFormRow fullWidth={true} isInvalid={isValid} error={errorMessages}>
+      <EuiFormRow fullWidth={true} isInvalid={isInvalid} error={errorMessages}>
         <EuiFieldText
           fullWidth={true}
           placeholder={placeholder}
           value={value}
           onChange={onChange}
           aria-label='Use aria labels when no actual label is in use'
-          isInvalid={isValid}
+          isInvalid={isInvalid}
         />
       </EuiFormRow>
     );

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -268,17 +268,26 @@ class WzListEditor extends Component {
   };
 
   /**
+   * Validate that if starts with a quote it ends with a quote and vice versa.
    * Validate that the value has 0 or 2 quotes.
    * @param {String} value
    */
   private validateQuotes(value: string, field: FieldTypes): boolean {
-    const quotes = value.split('"').length - 1;
-    const isValid = quotes === 0 || quotes === 2;
+    const hasMiddleQuotes = value.slice(1, -1).includes('"');
+    const startsWithQuote = value.startsWith('"');
+    const endsWithQuote = value.endsWith('"');
+
+    const isValid =
+      (startsWithQuote && endsWithQuote && !hasMiddleQuotes) ||
+      (!startsWithQuote && !endsWithQuote && !value.includes('"'));
     if (!isValid) {
       this.setState({
         isInvalid: [
           ...this.state.isInvalid,
-          { field, message: 'Must have 0 or 2 quotes' },
+          {
+            field,
+            message: 'Must start and end with quotes or have no quotes at all',
+          },
         ],
       });
     } else {
@@ -309,7 +318,7 @@ class WzListEditor extends Component {
       this.showToast(
         'danger',
         'Error',
-        'Key and value must have 0 or 2 quotes',
+        'Key and value must start and end with quotes or have no quotes at all',
         3000,
       );
       return;
@@ -489,6 +498,7 @@ class WzListEditor extends Component {
                       isDisabled={!addingKey}
                       fill
                       onClick={() => this.addItem()}
+                      disabled={this.state.isInvalid.length > 0}
                     >
                       Add
                     </EuiButtonEmpty>

--- a/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
+++ b/plugins/main/public/controllers/management/components/management/cdblists/views/list-editor.tsx
@@ -91,16 +91,27 @@ class WzListEditor extends Component {
    * Save in the state as object the items for an easy modification by key-value
    * @param {String} content
    */
-  contentToObject(content) {
-    const items = {};
+  contentToObject(content: string) {
+    const items: {
+      [key: string]: string;
+    } = {};
     const lines = content.split('\n');
+
     lines.forEach(line => {
-      const split = line.startsWith('"') ? line.split('":') : line.split(':');
-      // All keys with multiple colons (:) should end with a quotation mark (")
-      const key = split[0].startsWith('"') ? split[0] + '"' : split[0];
-      const value = split[1] || '';
-      if (key) items[key] = value; // Prevent add empty keys
+      // Regex splitting the first : and ignoring the ones inside quotes
+      const match = line.match(/^((?:[^:"]*|"[^"]*")*):(.*)$/);
+
+      if (match) {
+        const [, key, value] = match;
+        const trimmedKey = key.trim();
+        const trimmedValue = value.trim();
+
+        if (trimmedKey) {
+          items[trimmedKey] = trimmedValue;
+        }
+      }
     });
+
     return items;
   }
 


### PR DESCRIPTION
### Description

Fixes the rendering of the table as in some cases they were not rendering correctly.

For example: 
- “:key” was not rendering in the table.

And added validations in the inputs.

### Issues Resolved
- #7166

### Evidence

![image](https://github.com/user-attachments/assets/55f9ae69-493a-4d22-9576-c43204bba77d)

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/c4bed83f-dda2-4031-8c87-1cff398d046a">

### Test

1. Navigate to CDB list
2. Create CDB list with different keys
   - `key:`
   - `"key":key`
   - `"key:":"key:"`
   - `key1:"key:" `
3. The table should be rendered accordingly.
4. The keys and values in quotes must be at the beginning and at the end, not in the middle of the value.  

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
