### PR TITLE
Fix actions artifact plugins name

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: ${{ inputs.artifact_name }}_${{ matrix.plugins.container_path }}_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           path: ${{ matrix.plugins.path }}/${{ inputs.artifact_path }}
           if-no-files-found: 'error'
           overwrite: true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -52,15 +52,29 @@ jobs:
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "versionPlatform=$(jq -r '.pluginPlatform.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
 
-      - name: Step 03 - Download the plugin's source code
+      - name: Step 03 - Download the plugin's artifact
         uses: actions/download-artifact@v4
         with:
-          name: wazuh-dashboard-plugins_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/wazuh-dashboard-plugins_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           overwrite: true
 
-      - name: Step 04 - Build the Docker image
+      - name: Step 04 - Download the plugin's artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          overwrite: true
+
+      - name: Step 05 - Download the plugin's artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          overwrite: true
+
+      - name: Step 06 - Build the Docker image
         run: |
           echo "current=${{ env.currentDir }}"
           cd ./wazuh/scripts/test-packages
-          docker build --build-arg OSD_VERSION=${{ env.versionPlatform }} --build-arg PACKAGE_NAME=wazuh-dashboard-plugins_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip -f osd-test-packages.Dockerfile ./
+          docker build --build-arg OSD_VERSION=${{ env.versionPlatform }} -f osd-test-packages.Dockerfile ./

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -2,5 +2,10 @@
 echo $plugins
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/$plugin
+  unzip $plugin -d /unziped/
+done
+ plugins=$(ls /tmp/unziped)
+for plugin in $plugins; do
+  echo $plugin
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/unziped/$plugin
 done

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -6,7 +6,7 @@ FROM opensearchproject/opensearch-dashboards:${OSD_VERSION}
 
 ARG PACKAGE_NAME
 
-ADD ./${PACKAGE_NAME} /tmp/
+ADD ./plugins /tmp/
 # This is needed to run it local
 #
 # USER root


### PR DESCRIPTION
### Description
This pull request fixes the GitHub actions artifacts plugins name so that each plugin has its own name. 
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/427


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
