### PR TITLE
Unzip command not found in package generation action

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -108,8 +108,9 @@ jobs:
               cd /home/node/kbn/plugins/${{ matrix.plugins.container_path }} && yarn && ${{ inputs.command }};
             '
 
-      - name: Get the plugin version
+      - name: Get the plugin version and and format reference name
         run: |
+          echo "githubReference=$(echo ${{ inputs.reference }} | sed 's/\//-/g')" >> $GITHUB_ENV
           echo "version=$(jq -r '.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
 
@@ -117,7 +118,7 @@ jobs:
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact_name }}_${{ matrix.plugins.container_path }}_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: ${{ inputs.artifact_name }}_${{ matrix.plugins.container_path }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           path: ${{ matrix.plugins.path }}/${{ inputs.artifact_path }}
           if-no-files-found: 'error'
           overwrite: true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -56,21 +56,21 @@ jobs:
       - name: Step 03 - Download the main plugin's artifact
         uses: actions/download-artifact@v4
         with:
-          name: wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 
       - name: Step 04 - Download the core plugin's artifact
         uses: actions/download-artifact@v4
         with:
-          name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 
       - name: Step 05 - Download the check-updates plugin's artifact
         uses: actions/download-artifact@v4
         with:
-          name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -45,8 +45,9 @@ jobs:
           ref: ${{ inputs.reference }}
           path: wazuh
 
-      - name: Step 02 - Get version and revision
+      - name: Step 02 - Set variables
         run: |
+          echo "githubReference=$(echo ${{ inputs.reference }} | sed 's/\//-/g')" >> $GITHUB_ENV
           echo "currentDir=$(pwd -P)" >> $GITHUB_ENV
           echo "version=$(jq -r '.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
@@ -56,21 +57,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 
       - name: Step 04 - Download the core plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 
       - name: Step 05 - Download the check-updates plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           overwrite: true
 
       - name: Step 06 - Build the Docker image

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -52,21 +52,21 @@ jobs:
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "versionPlatform=$(jq -r '.pluginPlatform.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
 
-      - name: Step 03 - Download the plugin's artifact
+      - name: Step 03 - Download the main plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           overwrite: true
 
-      - name: Step 04 - Download the plugin's artifact
+      - name: Step 04 - Download the core plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           overwrite: true
 
-      - name: Step 05 - Download the plugin's artifact
+      - name: Step 05 - Download the check-updates plugin's artifact
         uses: actions/download-artifact@v4
         with:
           name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -3,6 +3,6 @@ set -e
 plugins=$(ls /tmp)
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmpf/$plugin/$(ls /tmp/$plugin)
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/$plugin/$(ls /tmp/$plugin)
 done
 echo "All plugins installed successfully"

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -1,11 +1,6 @@
-# plugins=$(ls /tmp)
-# echo $plugins
-# for plugin in $plugins; do
-#   echo $plugin
-#   unzip /tmp/$plugin -d /tmp/unziped/
-# done
-plugins=$(ls /tmp/plugins)
+plugins=$(ls /tmp)
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/plugins/$plugin/$(ls /tmp/plugins/$plugin)
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/$plugin/$(ls /tmp/$plugin)
 done
+echo "All plugins installed successfully"

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -2,7 +2,7 @@ plugins=$(ls /tmp)
 echo $plugins
 for plugin in $plugins; do
   echo $plugin
-  unzip $plugin -d /unziped/
+  unzip /tmp/$plugin -d /tmp/unziped/
 done
 plugins=$(ls /tmp/unziped)
 for plugin in $plugins; do

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -1,6 +1,8 @@
+set -e
+
 plugins=$(ls /tmp)
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/$plugin/$(ls /tmp/$plugin)
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmpf/$plugin/$(ls /tmp/$plugin)
 done
 echo "All plugins installed successfully"

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -1,9 +1,9 @@
-plugins=$(ls /tmp)
-echo $plugins
-for plugin in $plugins; do
-  echo $plugin
-  unzip /tmp/$plugin -d /tmp/unziped/
-done
+# plugins=$(ls /tmp)
+# echo $plugins
+# for plugin in $plugins; do
+#   echo $plugin
+#   unzip /tmp/$plugin -d /tmp/unziped/
+# done
 plugins=$(ls /tmp/unziped)
 for plugin in $plugins; do
   echo $plugin

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -4,8 +4,8 @@
 #   echo $plugin
 #   unzip /tmp/$plugin -d /tmp/unziped/
 # done
-plugins=$(ls /tmp/unziped)
+plugins=$(ls /tmp/plugins)
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/unziped/$plugin
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/plugins/$plugin/$(ls /tmp/plugins/$plugin)
 done

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -1,10 +1,10 @@
- plugins=$(ls /tmp)
+plugins=$(ls /tmp)
 echo $plugins
 for plugin in $plugins; do
   echo $plugin
   unzip $plugin -d /unziped/
 done
- plugins=$(ls /tmp/unziped)
+plugins=$(ls /tmp/unziped)
 for plugin in $plugins; do
   echo $plugin
   /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/unziped/$plugin

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -11,6 +11,7 @@ ADD ./plugins /tmp/
 
 USER root
 RUN yum update -y  && yum install -y unzip
+RUN ls -la /tmp
 RUN for plugin in $(ls /tmp); do \
   echo $plugin; \
   unzip /tmp/$plugin -d /tmp/unziped/; \

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -15,7 +15,7 @@ ADD ./plugins /tmp/
 # RUN rm /tmp/${PACKAGE_NAME}
 # USER opensearch-dashboards
 #
-RUN apt-get update && apt-get install -y unzip
+RUN yum update -y  && yum install -y unzip
 COPY --chown=opensearch-dashboards ./install-plugins.sh /
 RUN chmod +x /install-plugins.sh
 RUN /install-plugins.sh

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -11,8 +11,7 @@ ADD ./plugins /tmp/
 
 USER root
 RUN yum update -y  && yum install -y unzip
-RUN sh -x \
-for plugin in $(ls /tmp); do \
+RUN for plugin in $(ls /tmp); do \
   echo $plugin; \
   unzip /tmp/$plugin -d /tmp/unziped/; \
 done
@@ -28,4 +27,3 @@ USER opensearch-dashboards
 COPY --chown=opensearch-dashboards ./install-plugins.sh /
 RUN chmod +x /install-plugins.sh
 RUN /install-plugins.sh
-

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -6,15 +6,16 @@ FROM opensearchproject/opensearch-dashboards:${OSD_VERSION}
 
 ARG PACKAGE_NAME
 
-ADD ./plugins /tmp/
+ADD ./plugins /tmp/plugins/
 # This is needed to run it local
 
+RUN mkdir /tmp/unziped
 USER root
 RUN yum update -y  && yum install -y unzip
 RUN ls -la /tmp
-RUN for plugin in $(ls /tmp); do \
+RUN for plugin in $(ls /tmp/plugins); do \
   echo $plugin; \
-  unzip /tmp/$plugin -d /tmp/unziped/; \
+  unzip /tmp/plugins/$plugin -d /tmp/unziped/; \
 done
 # RUN rm /tmp/${PACKAGE_NAME}
 # echo $plugins

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -15,6 +15,7 @@ ADD ./plugins /tmp/
 # RUN rm /tmp/${PACKAGE_NAME}
 # USER opensearch-dashboards
 #
+RUN apt-get update && apt-get install -y unzip
 COPY --chown=opensearch-dashboards ./install-plugins.sh /
 RUN chmod +x /install-plugins.sh
 RUN /install-plugins.sh

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -8,14 +8,13 @@ ARG PACKAGE_NAME
 
 ADD ./plugins /tmp/
 # This is needed to run it local
-#
-# USER root
-# RUN yum update -y  && yum install -y unzip
+
+USER root
+RUN yum update -y  && yum install -y unzip
 # RUN unzip /tmp/${PACKAGE_NAME} -d /tmp/
 # RUN rm /tmp/${PACKAGE_NAME}
-# USER opensearch-dashboards
-#
-RUN yum update -y  && yum install -y unzip
+USER opensearch-dashboards
+
 COPY --chown=opensearch-dashboards ./install-plugins.sh /
 RUN chmod +x /install-plugins.sh
 RUN /install-plugins.sh

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -6,28 +6,15 @@ FROM opensearchproject/opensearch-dashboards:${OSD_VERSION}
 
 ARG PACKAGE_NAME
 
-ADD ./plugins /tmp/plugins/
+ADD ./plugins /tmp/
 # This is needed to run it local
-
-# RUN mkdir /tmp/unziped
+#
 # USER root
-# RUN mkdir /tmp/test
-# RUN cp /tmp/plugins/* /tmp/test
 # RUN yum update -y  && yum install -y unzip
-# RUN ls -la /tmp/test
-# RUN for plugin in $(ls /tmp/test); do \
-#   echo $plugin; \
-#   unzip /tmp/test/$plugin -d /tmp/unziped/; \
-# done
+# RUN unzip /tmp/${PACKAGE_NAME} -d /tmp/
 # RUN rm /tmp/${PACKAGE_NAME}
-# echo $plugins
-# for plugin in $plugins; do
-#   echo $plugin
-#   unzip /tmp/$plugin -d /tmp/unziped/
-# done
-
-USER opensearch-dashboards
-
+# USER opensearch-dashboards
+#
 COPY --chown=opensearch-dashboards ./install-plugins.sh /
 RUN chmod +x /install-plugins.sh
 RUN /install-plugins.sh

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -9,16 +9,16 @@ ARG PACKAGE_NAME
 ADD ./plugins /tmp/plugins/
 # This is needed to run it local
 
-RUN mkdir /tmp/unziped
-USER root
-RUN mkdir /tmp/test
-RUN cp /tmp/plugins/* /tmp/test
-RUN yum update -y  && yum install -y unzip
-RUN ls -la /tmp/test
-RUN for plugin in $(ls /tmp/test); do \
-  echo $plugin; \
-  unzip /tmp/test/$plugin -d /tmp/unziped/; \
-done
+# RUN mkdir /tmp/unziped
+# USER root
+# RUN mkdir /tmp/test
+# RUN cp /tmp/plugins/* /tmp/test
+# RUN yum update -y  && yum install -y unzip
+# RUN ls -la /tmp/test
+# RUN for plugin in $(ls /tmp/test); do \
+#   echo $plugin; \
+#   unzip /tmp/test/$plugin -d /tmp/unziped/; \
+# done
 # RUN rm /tmp/${PACKAGE_NAME}
 # echo $plugins
 # for plugin in $plugins; do

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -11,8 +11,8 @@ ADD ./plugins /tmp/
 
 USER root
 RUN yum update -y  && yum install -y unzip
-RUN plugins=$(ls /tmp)
-RUN for plugin in $plugins; do \
+RUN sh -x \
+for plugin in $(ls /tmp); do \
   echo $plugin; \
   unzip /tmp/$plugin -d /tmp/unziped/; \
 done

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -11,11 +11,13 @@ ADD ./plugins /tmp/plugins/
 
 RUN mkdir /tmp/unziped
 USER root
+RUN mkdir /tmp/test
+RUN cp /tmp/plugins/* /tmp/test
 RUN yum update -y  && yum install -y unzip
-RUN ls -la /tmp/plugins
-RUN for plugin in $(ls /tmp/plugins); do \
+RUN ls -la /tmp/test
+RUN for plugin in $(ls /tmp/test); do \
   echo $plugin; \
-  unzip /tmp/plugins/$plugin -d /tmp/unziped/; \
+  unzip /tmp/test/$plugin -d /tmp/unziped/; \
 done
 # RUN rm /tmp/${PACKAGE_NAME}
 # echo $plugins

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -12,7 +12,7 @@ ADD ./plugins /tmp/plugins/
 RUN mkdir /tmp/unziped
 USER root
 RUN yum update -y  && yum install -y unzip
-RUN ls -la /tmp
+RUN ls -la /tmp/plugins
 RUN for plugin in $(ls /tmp/plugins); do \
   echo $plugin; \
   unzip /tmp/plugins/$plugin -d /tmp/unziped/; \

--- a/scripts/test-packages/osd-test-packages.Dockerfile
+++ b/scripts/test-packages/osd-test-packages.Dockerfile
@@ -11,8 +11,18 @@ ADD ./plugins /tmp/
 
 USER root
 RUN yum update -y  && yum install -y unzip
-# RUN unzip /tmp/${PACKAGE_NAME} -d /tmp/
+RUN plugins=$(ls /tmp)
+RUN for plugin in $plugins; do \
+  echo $plugin; \
+  unzip /tmp/$plugin -d /tmp/unziped/; \
+done
 # RUN rm /tmp/${PACKAGE_NAME}
+# echo $plugins
+# for plugin in $plugins; do
+#   echo $plugin
+#   unzip /tmp/$plugin -d /tmp/unziped/
+# done
+
 USER opensearch-dashboards
 
 COPY --chown=opensearch-dashboards ./install-plugins.sh /


### PR DESCRIPTION
### Description
This pull request adds the unzip package to the test plugins post workflow to fix the `unzip: command not found` error. It also adds support for dev branches that contain `/` in their name.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/430

### Evidence
https://github.com/wazuh/wazuh-dashboard-plugins/actions/runs/12055324147/job/33615734496

### Test
- Run the wazuh dashboard package build action and verify there's no error in the output.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
