### PR TITLE
Fixed adding the same filter twice doesn't show it in the search bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Added ending quotes to CDB Lists keys [#7159](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7159)
+- Fixed adding the same filter twice doesn't show it in the search bar [#7185] (https://github.com/wazuh/wazuh-dashboard-plugins/pull/7185)
 
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Added ending quotes to CDB Lists keys [#7159](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7159)
-- Fixed adding the same filter twice doesn't show it in the search bar [#7185] (https://github.com/wazuh/wazuh-dashboard-plugins/pull/7185)
+- Fixed adding the same filter twice doesn't show it in the search bar [#7185](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7185)
 - Fixed rendering of rows in CDB list table when it starts with quotes. [#7171](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7171)
 
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 00

--- a/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
+++ b/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
   <SearchBar
     defaultMode="wql"
     input=""
-    inputTimeMark={1733140489774}
+    inputTimeMark={1733150110123}
     modes={
       Array [
         Object {

--- a/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
+++ b/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
   <SearchBar
     defaultMode="wql"
     input=""
+    inputTimeMark={1733140489774}
     modes={
       Array [
         Object {

--- a/plugins/main/public/components/common/tables/table-with-search-bar.test.tsx
+++ b/plugins/main/public/components/common/tables/table-with-search-bar.test.tsx
@@ -89,6 +89,12 @@ const tableProps = {
   },
 };
 
+beforeAll(() => {
+  global.Date.now = jest.fn(() =>
+    new Date('2024-12-02T14:35:10.123').getTime(),
+  );
+});
+
 describe('Table With Search Bar component', () => {
   it('renders correctly to match the snapshot', () => {
     const wrapper = mount(<TableWithSearchBar {...tableProps} />);

--- a/plugins/main/public/components/common/tables/table-with-search-bar.tsx
+++ b/plugins/main/public/components/common/tables/table-with-search-bar.tsx
@@ -111,6 +111,8 @@ export function TableWithSearchBar<T>({
   const [items, setItems] = useState([]);
   const [totalItems, setTotalItems] = useState(0);
   const [filters, setFilters] = useState(rest.filters || {});
+  // Added a timestamp to track when the same filter is added multiple times
+  // after being manually removed.
   const [filtersTimeMark, setFiltersTimeMark] = useState<number>(Date.now());
   const [pagination, setPagination] = useState({
     pageIndex: 0,
@@ -180,7 +182,7 @@ export function TableWithSearchBar<T>({
         try {
           setLoading(true);
 
-          //Reset the table selection in case is enabled
+          // Reset the table selection in case is enabled
           tableRef.current.setSelection([]);
 
           const { items, totalItems } = await onSearch(

--- a/plugins/main/public/components/common/tables/table-with-search-bar.tsx
+++ b/plugins/main/public/components/common/tables/table-with-search-bar.tsx
@@ -111,6 +111,7 @@ export function TableWithSearchBar<T>({
   const [items, setItems] = useState([]);
   const [totalItems, setTotalItems] = useState(0);
   const [filters, setFilters] = useState(rest.filters || {});
+  const [filtersTimeMark, setFiltersTimeMark] = useState<number>(Date.now());
   const [pagination, setPagination] = useState({
     pageIndex: 0,
     pageSize: tablePageSizeOptions[0],
@@ -228,6 +229,10 @@ export function TableWithSearchBar<T>({
     isMounted.current = true;
   }, []);
 
+  useEffect(() => {
+    setFiltersTimeMark(Date.now());
+  }, [rest.filters]);
+
   const tablePagination = {
     ...pagination,
     totalItemCount: totalItems,
@@ -251,6 +256,7 @@ export function TableWithSearchBar<T>({
           },
         ]}
         input={rest?.filters?.q || ''}
+        inputTimeMark={filtersTimeMark}
         onSearch={({ apiQuery }) => {
           // Set the query, reset the page index and update the refresh
           setFilters(apiQuery);

--- a/plugins/main/public/components/search-bar/index.tsx
+++ b/plugins/main/public/components/search-bar/index.tsx
@@ -24,6 +24,7 @@ export interface SearchBarProps {
   onSearch: (params: any) => void;
   buttonsRender?: () => React.ReactNode;
   input?: string;
+  inputTimeMark?: number;
 }
 
 export const SearchBar = ({
@@ -102,7 +103,7 @@ export const SearchBar = ({
           },
         ),
       );
-  }, [rest.input]);
+  }, [rest.inputTimeMark]);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
### Description

A timestamp has been added to handle when the same filter is added twice.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7124

### Evidence

https://github.com/user-attachments/assets/b42cedaf-6cc3-4f66-ba4d-a8db2158c62d

### Test

Check that adding a filter through the details flyout, deleting into the search-bar, and adding the same filter again, renders in the input of the search-bar.

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
