### PR TITLE
Shown Wazuh API version is wrong or empty after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the check updates UI was displayed despite it could be configured as disabled [#7156](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7156)
 - Fixed filter by value in document details in safari [#7151](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7151)
 - Fixed error message to prevent pass no strings to the wazuh logger [#7167](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7167)
-- Fixed the rendering of the `data.vunerability.reference` in the table and flyout [#7177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7177)\
+- Fixed the rendering of the `data.vunerability.reference` in the table and flyout [#7177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7177)
 - Fixed incorrect or empty Wazuh API version displayed after upgrade [#440](https://github.com/wazuh/wazuh-dashboard/issues/440)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the check updates UI was displayed despite it could be configured as disabled [#7156](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7156)
 - Fixed filter by value in document details in safari [#7151](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7151)
 - Fixed error message to prevent pass no strings to the wazuh logger [#7167](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7167)
-- Fixed the rendering of the `data.vunerability.reference` in the table and flyout [#7177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7177)
+- Fixed the rendering of the `data.vunerability.reference` in the table and flyout [#7177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7177)\
+- Fixed incorrect or empty Wazuh API version displayed after upgrade [#440](https://github.com/wazuh/wazuh-dashboard/issues/440)
 
 ### Removed
 

--- a/plugins/wazuh-check-updates/server/plugin-services.ts
+++ b/plugins/wazuh-check-updates/server/plugin-services.ts
@@ -1,6 +1,7 @@
 import {
   CoreStart,
   ISavedObjectsRepository,
+  Logger,
 } from 'opensearch-dashboards/server';
 import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_utils/common';
 import { WazuhCorePluginStart } from '../../wazuh-core/server';
@@ -11,4 +12,4 @@ export const [getCore, setCore] = createGetterSetter<CoreStart>('Core');
 export const [getWazuhCore, setWazuhCore] =
   createGetterSetter<WazuhCorePluginStart>('WazuhCore');
 export const [getWazuhCheckUpdatesServices, setWazuhCheckUpdatesServices] =
-  createGetterSetter<any>('WazuhCheckUpdatesServices');
+  createGetterSetter<{ logger: Logger }>('WazuhCheckUpdatesServices');

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -255,6 +255,42 @@ describe('getUpdates function', () => {
       ],
     });
   });
+  it('should return available updates from api when the second request fail', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
+    mockRequest
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            api_version: version,
+          },
+        },
+      }))
+      .mockImplementationOnce(() => {
+        throw new Error('Error');
+      });
+
+    const updates = await getUpdates(true);
+
+    expect(updates).toEqual({
+      last_check_date: expect.any(Date),
+      apis_available_updates: [
+        {
+          api_id: API_ID,
+          current_version: `v${version}`,
+          status: API_UPDATES_STATUS.ERROR,
+          error: {
+            detail: 'Error',
+            title: 'Error',
+          },
+        },
+      ],
+    });
+  });
   it('should return error from api when both requests fail', async () => {
     mockRequest
       .mockImplementationOnce(() => {

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -93,7 +93,7 @@ describe('getUpdates function', () => {
     expect(updates).toEqual(savedObject);
   });
 
-  it('should return available updates from api', async () => {
+  it('should return available updates from api when both requests succeed', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -204,7 +204,7 @@ describe('getUpdates function', () => {
       ],
     });
   });
-  it('should return updates when api version undefined first request and second request fails', async () => {
+  it('should return updates when api version undefined on first request and second request fails', async () => {
     const semver = {
       major: 4,
       minor: 3,

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -1,10 +1,11 @@
-import { getSavedObject } from '../saved-object/get-saved-object';
-import { setSavedObject } from '../saved-object/set-saved-object';
+import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
+import { API_UPDATES_STATUS } from '../../../common/types';
 import {
   getWazuhCheckUpdatesServices,
   getWazuhCore,
 } from '../../plugin-services';
-import { API_UPDATES_STATUS } from '../../../common/types';
+import { getSavedObject } from '../saved-object/get-saved-object';
+import { setSavedObject } from '../saved-object/set-saved-object';
 import { getUpdates } from './get-updates';
 import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -12,6 +12,7 @@ const mockedGetSavedObject = getSavedObject as jest.Mock;
 jest.mock('../saved-object/get-saved-object');
 
 const mockedSetSavedObject = setSavedObject as jest.Mock;
+mockedSetSavedObject.mockImplementation(() => ({}));
 jest.mock('../saved-object/set-saved-object');
 
 const mockedGetWazuhCore = getWazuhCore as jest.Mock;
@@ -92,7 +93,18 @@ describe('getUpdates function', () => {
   });
 
   test('should return available updates from api', async () => {
-    mockedSetSavedObject.mockImplementation(() => ({}));
+    const last_available_patch = {
+      description:
+        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+      published_date: '2022-05-18T10:12:43Z',
+      semver: {
+        major: 4,
+        minor: 3,
+        patch: 8,
+      },
+      tag: 'v4.3.8',
+      title: 'Wazuh v4.3.8',
+    };
     mockedGetWazuhCore.mockImplementationOnce(() => {
       return {
         api: {
@@ -115,18 +127,7 @@ describe('getUpdates function', () => {
                       update_check: undefined,
                       last_available_major: undefined,
                       last_available_minor: undefined,
-                      last_available_patch: {
-                        description:
-                          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-                        published_date: '2022-05-18T10:12:43Z',
-                        semver: {
-                          major: 4,
-                          minor: 3,
-                          patch: 8,
-                        },
-                        tag: 'v4.3.8',
-                        title: 'Wazuh v4.3.8',
-                      },
+                      last_available_patch,
                       last_check_date: undefined,
                     },
                   },
@@ -152,18 +153,7 @@ describe('getUpdates function', () => {
           update_check: undefined,
           last_available_major: undefined,
           last_available_minor: undefined,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
+          last_available_patch,
           last_check_date: undefined,
         },
       ],

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -8,6 +8,8 @@ import { getSavedObject } from '../saved-object/get-saved-object';
 import { setSavedObject } from '../saved-object/set-saved-object';
 import { getUpdates } from './get-updates';
 
+const API_ID = 'api id';
+
 const mockGetSavedObject = getSavedObject as jest.Mock;
 jest.mock('../saved-object/get-saved-object');
 
@@ -18,7 +20,7 @@ jest.mock('../saved-object/set-saved-object');
 const mockGetWazuhCore = getWazuhCore as jest.Mock;
 const mockRequest = jest.fn();
 const mockManageHosts = {
-  get: jest.fn(() => [{ id: 'api id' }]),
+  get: jest.fn(() => [{ id: API_ID }]),
 };
 const mockGetHostsEntries = jest.fn(() => []);
 mockGetWazuhCore.mockImplementationOnce(() => {
@@ -55,25 +57,27 @@ describe('getUpdates function', () => {
   });
 
   test('should return available updates from saved object', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
     const last_available_patch = {
       description:
         '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
       published_date: '2022-05-18T10:12:43Z',
-      semver: {
-        major: 4,
-        minor: 3,
-        patch: 8,
-      },
-      tag: 'v4.3.8',
-      title: 'Wazuh v4.3.8',
+      semver,
+      tag: `v${version}`,
+      title: `Wazuh v${version}`,
     };
     const last_check_date = '2023-09-30T14:00:00.000Z';
     const savedObject = {
       last_check_date,
       apis_available_updates: [
         {
-          api_id: 'api id',
-          current_version: 'v4.3.1',
+          api_id: API_ID,
+          current_version: `v${version}`,
           status: API_UPDATES_STATUS.UP_TO_DATE,
           last_available_patch,
         },
@@ -90,23 +94,25 @@ describe('getUpdates function', () => {
   });
 
   test('should return available updates from api', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
     const last_available_patch = {
       description:
         '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
       published_date: '2022-05-18T10:12:43Z',
-      semver: {
-        major: 4,
-        minor: 3,
-        patch: 8,
-      },
-      tag: 'v4.3.8',
-      title: 'Wazuh v4.3.8',
+      semver,
+      tag: `v${version}`,
+      title: `Wazuh v${version}`,
     };
     mockRequest
       .mockImplementationOnce(() => ({
         data: {
           data: {
-            api_version: '4.3.1',
+            api_version: version,
           },
         },
       }))
@@ -114,7 +120,7 @@ describe('getUpdates function', () => {
         data: {
           data: {
             uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
-            current_version: 'v4.3.1',
+            current_version: `v${version}`,
             update_check: undefined,
             last_available_major: undefined,
             last_available_minor: undefined,
@@ -130,8 +136,8 @@ describe('getUpdates function', () => {
       last_check_date: expect.any(Date),
       apis_available_updates: [
         {
-          api_id: 'api id',
-          current_version: 'v4.3.1',
+          api_id: API_ID,
+          current_version: `v${version}`,
           status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
           update_check: undefined,
           last_available_major: undefined,

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -255,4 +255,44 @@ describe('getUpdates function', () => {
       ],
     });
   });
+  it('should return error from api when both requests fail', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
+    const last_available_patch = {
+      description:
+        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+      published_date: '2022-05-18T10:12:43Z',
+      semver,
+      tag: `v${version}`,
+      title: `Wazuh v${version}`,
+    };
+    mockRequest
+      .mockImplementationOnce(() => {
+        throw new Error('Error');
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('Error');
+      });
+
+    const updates = await getUpdates(true);
+
+    expect(updates).toEqual({
+      last_check_date: expect.any(Date),
+      apis_available_updates: [
+        {
+          api_id: API_ID,
+          current_version: undefined,
+          status: API_UPDATES_STATUS.ERROR,
+          error: {
+            detail: 'Error',
+            title: 'Error',
+          },
+        },
+      ],
+    });
+  });
 });

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -23,7 +23,7 @@ const mockManageHosts = {
   get: jest.fn(() => [{ id: API_ID }]),
 };
 const mockGetHostsEntries = jest.fn(() => []);
-mockGetWazuhCore.mockImplementationOnce(() => {
+mockGetWazuhCore.mockImplementation(() => {
   return {
     api: {
       client: {
@@ -116,6 +116,113 @@ describe('getUpdates function', () => {
           },
         },
       }))
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+            current_version: `v${version}`,
+            update_check: undefined,
+            last_available_major: undefined,
+            last_available_minor: undefined,
+            last_available_patch,
+            last_check_date: undefined,
+          },
+        },
+      }));
+
+    const updates = await getUpdates(true);
+
+    expect(updates).toEqual({
+      last_check_date: expect.any(Date),
+      apis_available_updates: [
+        {
+          api_id: API_ID,
+          current_version: `v${version}`,
+          status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
+          update_check: undefined,
+          last_available_major: undefined,
+          last_available_minor: undefined,
+          last_available_patch,
+          last_check_date: undefined,
+        },
+      ],
+    });
+  });
+
+  it('should return available updates from api when in the first request, api_version is undefined', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
+    const last_available_patch = {
+      description:
+        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+      published_date: '2022-05-18T10:12:43Z',
+      semver,
+      tag: `v${version}`,
+      title: `Wazuh v${version}`,
+    };
+    mockRequest
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            api_version: undefined,
+          },
+        },
+      }))
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+            current_version: `v${version}`,
+            update_check: undefined,
+            last_available_major: undefined,
+            last_available_minor: undefined,
+            last_available_patch,
+            last_check_date: undefined,
+          },
+        },
+      }));
+
+    const updates = await getUpdates(true);
+
+    expect(updates).toEqual({
+      last_check_date: expect.any(Date),
+      apis_available_updates: [
+        {
+          api_id: API_ID,
+          current_version: `v${version}`,
+          status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
+          update_check: undefined,
+          last_available_major: undefined,
+          last_available_minor: undefined,
+          last_available_patch,
+          last_check_date: undefined,
+        },
+      ],
+    });
+  });
+  it('should return available updates from api when the first request fail', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
+    const last_available_patch = {
+      description:
+        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+      published_date: '2022-05-18T10:12:43Z',
+      semver,
+      tag: `v${version}`,
+      title: `Wazuh v${version}`,
+    };
+    mockRequest
+      .mockImplementationOnce(() => {
+        throw new Error('Error');
+      })
       .mockImplementationOnce(() => ({
         data: {
           data: {

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -149,7 +149,7 @@ describe('getUpdates function', () => {
     });
   });
 
-  it('should return available updates from api when in the first request, api_version is undefined', async () => {
+  it('should return updates when api version undefined on first request', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -204,7 +204,7 @@ describe('getUpdates function', () => {
       ],
     });
   });
-  it('should return available updates from api when in the first request, api_version is undefined and the second request fail', async () => {
+  it('should return updates when api version undefined first request and second request fails', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -240,7 +240,7 @@ describe('getUpdates function', () => {
       ],
     });
   });
-  it('should return available updates from api when the first request fail', async () => {
+  it('should return updates when first request fails', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -291,7 +291,7 @@ describe('getUpdates function', () => {
       ],
     });
   });
-  it('should return available updates from api when the second request fail', async () => {
+  it('should return updates when second request fails', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -327,7 +327,7 @@ describe('getUpdates function', () => {
       ],
     });
   });
-  it('should return error from api when both requests fail', async () => {
+  it('should return error when both requests fail', async () => {
     mockRequest
       .mockImplementationOnce(() => {
         throw new Error('Error');

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -7,16 +7,36 @@ import {
 import { getSavedObject } from '../saved-object/get-saved-object';
 import { setSavedObject } from '../saved-object/set-saved-object';
 import { getUpdates } from './get-updates';
-import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 
-const mockedGetSavedObject = getSavedObject as jest.Mock;
+const mockGetSavedObject = getSavedObject as jest.Mock;
 jest.mock('../saved-object/get-saved-object');
 
-const mockedSetSavedObject = setSavedObject as jest.Mock;
-mockedSetSavedObject.mockImplementation(() => ({}));
+const mockSetSavedObject = setSavedObject as jest.Mock;
+mockSetSavedObject.mockImplementation(() => ({}));
 jest.mock('../saved-object/set-saved-object');
 
-const mockedGetWazuhCore = getWazuhCore as jest.Mock;
+const mockGetWazuhCore = getWazuhCore as jest.Mock;
+const mockRequest = jest.fn();
+const mockManageHosts = {
+  get: jest.fn(() => [{ id: 'api id' }]),
+};
+const mockGetHostsEntries = jest.fn(() => []);
+mockGetWazuhCore.mockImplementationOnce(() => {
+  return {
+    api: {
+      client: {
+        asInternalUser: {
+          request: mockRequest,
+        },
+      },
+    },
+    manageHosts: mockManageHosts,
+    serverAPIHostEntries: {
+      getHostsEntries: mockGetHostsEntries,
+    },
+  };
+});
+
 const mockedGetWazuhCheckUpdatesServices =
   getWazuhCheckUpdatesServices as jest.Mock;
 mockedGetWazuhCheckUpdatesServices.mockImplementation(() => ({
@@ -35,62 +55,38 @@ describe('getUpdates function', () => {
   });
 
   test('should return available updates from saved object', async () => {
-    mockedGetSavedObject.mockImplementation(() => ({
-      last_check_date: '2023-09-30T14:00:00.000Z',
+    const last_available_patch = {
+      description:
+        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+      published_date: '2022-05-18T10:12:43Z',
+      semver: {
+        major: 4,
+        minor: 3,
+        patch: 8,
+      },
+      tag: 'v4.3.8',
+      title: 'Wazuh v4.3.8',
+    };
+    const last_check_date = '2023-09-30T14:00:00.000Z';
+    const savedObject = {
+      last_check_date,
       apis_available_updates: [
         {
           api_id: 'api id',
           current_version: 'v4.3.1',
           status: API_UPDATES_STATUS.UP_TO_DATE,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
+          last_available_patch,
         },
       ],
-    }));
-
-    mockedGetWazuhCore.mockImplementation(() => ({
-      serverAPIHostEntries: {
-        getHostsEntries: jest.fn(() => []),
-      },
-    }));
+    };
+    mockGetSavedObject.mockImplementation(() => savedObject);
 
     const updates = await getUpdates();
 
     expect(getSavedObject).toHaveBeenCalledTimes(1);
     expect(getSavedObject).toHaveBeenCalledWith(SAVED_OBJECT_UPDATES);
 
-    expect(updates).toEqual({
-      last_check_date: '2023-09-30T14:00:00.000Z',
-      apis_available_updates: [
-        {
-          api_id: 'api id',
-          current_version: 'v4.3.1',
-          status: API_UPDATES_STATUS.UP_TO_DATE,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
-        },
-      ],
-    });
+    expect(updates).toEqual(savedObject);
   });
 
   test('should return available updates from api', async () => {
@@ -106,41 +102,27 @@ describe('getUpdates function', () => {
       tag: 'v4.3.8',
       title: 'Wazuh v4.3.8',
     };
-    mockedGetWazuhCore.mockImplementationOnce(() => {
-      return {
-        api: {
-          client: {
-            asInternalUser: {
-              request: jest
-                .fn()
-                .mockImplementationOnce(() => ({
-                  data: {
-                    data: {
-                      api_version: '4.3.1',
-                    },
-                  },
-                }))
-                .mockImplementationOnce(() => ({
-                  data: {
-                    data: {
-                      uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
-                      current_version: 'v4.3.1',
-                      update_check: undefined,
-                      last_available_major: undefined,
-                      last_available_minor: undefined,
-                      last_available_patch,
-                      last_check_date: undefined,
-                    },
-                  },
-                })),
-            },
+    mockRequest
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            api_version: '4.3.1',
           },
         },
-        manageHosts: {
-          get: jest.fn(() => [{ id: 'api id' }]),
+      }))
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+            current_version: 'v4.3.1',
+            update_check: undefined,
+            last_available_major: undefined,
+            last_available_minor: undefined,
+            last_available_patch,
+            last_check_date: undefined,
+          },
         },
-      };
-    });
+      }));
 
     const updates = await getUpdates(true);
 

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -256,20 +256,6 @@ describe('getUpdates function', () => {
     });
   });
   it('should return error from api when both requests fail', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
-    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
-    const last_available_patch = {
-      description:
-        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-      published_date: '2022-05-18T10:12:43Z',
-      semver,
-      tag: `v${version}`,
-      title: `Wazuh v${version}`,
-    };
     mockRequest
       .mockImplementationOnce(() => {
         throw new Error('Error');

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -204,6 +204,42 @@ describe('getUpdates function', () => {
       ],
     });
   });
+  it('should return available updates from api when in the first request, api_version is undefined and the second request fail', async () => {
+    const semver = {
+      major: 4,
+      minor: 3,
+      patch: 1,
+    };
+    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
+    mockRequest
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            api_version: undefined,
+          },
+        },
+      }))
+      .mockImplementationOnce(() => {
+        throw new Error('Error');
+      });
+
+    const updates = await getUpdates(true);
+
+    expect(updates).toEqual({
+      last_check_date: expect.any(Date),
+      apis_available_updates: [
+        {
+          api_id: API_ID,
+          current_version: undefined,
+          status: API_UPDATES_STATUS.ERROR,
+          error: {
+            detail: 'Error',
+            title: 'Error',
+          },
+        },
+      ],
+    });
+  });
   it('should return available updates from api when the first request fail', async () => {
     const semver = {
       major: 4,

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -56,7 +56,7 @@ describe('getUpdates function', () => {
     jest.clearAllMocks();
   });
 
-  test('should return available updates from saved object', async () => {
+  it('should return available updates from saved object', async () => {
     const semver = {
       major: 4,
       minor: 3,
@@ -93,7 +93,7 @@ describe('getUpdates function', () => {
     expect(updates).toEqual(savedObject);
   });
 
-  test('should return available updates from api', async () => {
+  it('should return available updates from api', async () => {
     const semver = {
       major: 4,
       minor: 3,

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -74,7 +74,9 @@ export const getUpdates = async (
             {},
             options,
           );
-          currentVersion = `v${api_version}`;
+          if (api_version !== undefined) {
+            currentVersion = `v${api_version}`;
+          }
         } catch {
           logger.debug('[ERROR]: Cannot get the API version');
         }
@@ -142,8 +144,8 @@ export const getUpdates = async (
       error instanceof Error
         ? error.message
         : typeof error === 'string'
-          ? error
-          : 'Error trying to get available updates';
+        ? error
+        : 'Error trying to get available updates';
 
     logger.error(message);
     return Promise.reject(error);

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -9,7 +9,7 @@ import {
   getWazuhCheckUpdatesServices,
   getWazuhCore,
 } from '../../plugin-services';
-import { IAPIHost } from "../../../../wazuh-core/server/services";
+import { IAPIHost } from '../../../../wazuh-core/server/services';
 
 export const getUpdates = async (
   queryApi = false,
@@ -26,9 +26,30 @@ export const getUpdates = async (
       return availableUpdates;
     }
 
+    const getStatus = ({
+      update_check,
+      last_available_major,
+      last_available_minor,
+      last_available_patch,
+    }: ResponseApiAvailableUpdates) => {
+      if (update_check === false) {
+        return API_UPDATES_STATUS.DISABLED;
+      }
+
+      if (
+        last_available_major?.tag ||
+        last_available_minor?.tag ||
+        last_available_patch?.tag
+      ) {
+        return API_UPDATES_STATUS.AVAILABLE_UPDATES;
+      }
+
+      return API_UPDATES_STATUS.UP_TO_DATE;
+    };
+
     const { manageHosts, api: wazuhApiClient } = getWazuhCore();
 
-    const hosts = await manageHosts.get() as IAPIHost[];
+    const hosts = (await manageHosts.get()) as IAPIHost[];
 
     const apisAvailableUpdates = await Promise.all(
       hosts?.map(async api => {
@@ -39,6 +60,25 @@ export const getUpdates = async (
           apiHostID: api.id,
           forceRefresh: true,
         };
+        let currentVersion: string | undefined = undefined;
+        let availableUpdates: ResponseApiAvailableUpdates = {};
+
+        try {
+          const {
+            data: {
+              data: { api_version },
+            },
+          } = await wazuhApiClient.client.asInternalUser.request(
+            'GET',
+            '/',
+            {},
+            options,
+          );
+          currentVersion = `v${api_version}`;
+        } catch {
+          logger.debug('[ERROR]: Cannot get the API version');
+        }
+
         try {
           const response = await wazuhApiClient.client.asInternalUser.request(
             method,
@@ -47,42 +87,30 @@ export const getUpdates = async (
             options,
           );
 
-          const update = response.data.data as ResponseApiAvailableUpdates;
+          availableUpdates = response.data.data as ResponseApiAvailableUpdates;
 
           const {
-            current_version,
             update_check,
             last_available_major,
             last_available_minor,
             last_available_patch,
             last_check_date,
-          } = update;
+          } = availableUpdates;
 
-          const getStatus = () => {
-            if (update_check === false) {
-              return API_UPDATES_STATUS.DISABLED;
-            }
-
-            if (
-              last_available_major?.tag ||
-              last_available_minor?.tag ||
-              last_available_patch?.tag
-            ) {
-              return API_UPDATES_STATUS.AVAILABLE_UPDATES;
-            }
-
-            return API_UPDATES_STATUS.UP_TO_DATE;
-          };
+          // If for some reason, the previous request fails
+          if (currentVersion === undefined) {
+            currentVersion = availableUpdates.current_version;
+          }
 
           return {
-            current_version,
+            current_version: currentVersion,
             update_check,
             last_available_major,
             last_available_minor,
             last_available_patch,
             last_check_date: last_check_date || undefined,
             api_id: api.id,
-            status: getStatus(),
+            status: getStatus(availableUpdates),
           };
         } catch (error: any) {
           logger.debug('[ERROR]: Cannot get the API status');
@@ -94,6 +122,7 @@ export const getUpdates = async (
           return {
             api_id: api.id,
             status: API_UPDATES_STATUS.ERROR,
+            current_version: currentVersion,
             error: errorResponse,
           };
         }

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -15,6 +15,8 @@ export const getUpdates = async (
   queryApi = false,
   forceQuery = false,
 ): Promise<AvailableUpdates> => {
+  const { logger } = getWazuhCheckUpdatesServices();
+
   try {
     if (!queryApi) {
       const availableUpdates = (await getSavedObject(
@@ -83,6 +85,7 @@ export const getUpdates = async (
             status: getStatus(),
           };
         } catch (error: any) {
+          logger.debug('[ERROR]: Cannot get the API status');
           const errorResponse = {
             title: error.response?.data?.title,
             detail: error.response?.data?.detail ?? error.message,
@@ -112,8 +115,6 @@ export const getUpdates = async (
         : typeof error === 'string'
           ? error
           : 'Error trying to get available updates';
-
-    const { logger } = getWazuhCheckUpdatesServices();
 
     logger.error(message);
     return Promise.reject(error);

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -81,16 +81,16 @@ export const getUpdates = async (
             api_id: api.id,
             status: getStatus(),
           };
-        } catch (e: any) {
-          const error = {
-            title: e.response?.data?.title,
-            detail: e.response?.data?.detail ?? e.message,
+        } catch (error: any) {
+          const errorResponse = {
+            title: error.response?.data?.title,
+            detail: error.response?.data?.detail ?? error.message,
           };
 
           return {
             api_id: api.id,
             status: API_UPDATES_STATUS.ERROR,
-            error,
+            error: errorResponse,
           };
         }
       }),
@@ -109,8 +109,8 @@ export const getUpdates = async (
       error instanceof Error
         ? error.message
         : typeof error === 'string'
-        ? error
-        : 'Error trying to get available updates';
+          ? error
+          : 'Error trying to get available updates';
 
     const { logger } = getWazuhCheckUpdatesServices();
 

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -9,6 +9,7 @@ import {
   getWazuhCheckUpdatesServices,
   getWazuhCore,
 } from '../../plugin-services';
+import { IAPIHost } from "../../../../wazuh-core/server/services";
 
 export const getUpdates = async (
   queryApi = false,
@@ -25,7 +26,7 @@ export const getUpdates = async (
 
     const { manageHosts, api: wazuhApiClient } = getWazuhCore();
 
-    const hosts: { id: string }[] = await manageHosts.get();
+    const hosts = await manageHosts.get() as IAPIHost[];
 
     const apisAvailableUpdates = await Promise.all(
       hosts?.map(async api => {

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -117,7 +117,7 @@ export const getUpdates = async (
         } catch (error: any) {
           logger.debug('[ERROR]: Cannot get the API status');
           const errorResponse = {
-            title: error.response?.data?.title,
+            title: error.response?.data?.title ?? error.message,
             detail: error.response?.data?.detail ?? error.message,
           };
 

--- a/plugins/wazuh-core/server/services/manage-hosts.ts
+++ b/plugins/wazuh-core/server/services/manage-hosts.ts
@@ -15,7 +15,7 @@ import { ServerAPIClient } from './server-api-client';
 import { API_USER_STATUS_RUN_AS } from '../../common/api-user-status-run-as';
 import { HTTP_STATUS_CODES } from '../../common/constants';
 
-interface IAPIHost {
+export interface IAPIHost {
   id: string;
   url: string;
   username: string;


### PR DESCRIPTION
### Description

During https://github.com/wazuh/wazuh/issues/27183, it was found that Wazuh API version shown is not the current one after upgrading from v4.9.2 to v4.10.0-rc1

![image](https://github.com/user-attachments/assets/22f31553-ed97-4a19-b81d-6962a5fa00bc)

After cleaning the cache, the error is worse

![image](https://github.com/user-attachments/assets/217a5f75-54cd-4868-a69a-1b0ec24dea86)

**Expected behavior**

Wazuh API is v4.10.0

![image](https://github.com/user-attachments/assets/54d2ba0e-2c8d-4dfe-a3d3-10c065a13a18)

### Issues Resolved

Closes https://github.com/wazuh/wazuh-dashboard/issues/440

### Evidence

![image](https://github.com/user-attachments/assets/0822bafa-df38-4dd7-a0db-e0f219ce00ad)

![image](https://github.com/user-attachments/assets/613dc286-1fe5-4711-97b1-b0dafc1c0c52)

![image](https://github.com/user-attachments/assets/6164fc74-0925-438f-b596-0b623e5a5cda)

![image](https://github.com/user-attachments/assets/1476173a-36e1-429c-9cca-aaf3592e4e02)


### Test

1. Navigate to `Dashboard management` » `Server APIs`
2. Open DevTools
3. Go to `Application` » `Session storage`
4. Delete key `checkUpdates`
  ![image](https://github.com/user-attachments/assets/a2b98f41-90f0-4bb5-be98-6f269d362472)
5. Reload the page
6. Please verify the status of the `Version` column under two scenarios: when everything is correct and when an issue arises.

> [!NOTE]
> Remove `checkUpdates` for each reloaded page.

#### Unit tests

![image](https://github.com/user-attachments/assets/5a72b57c-a368-4fe0-8aa2-8036327d40ac)

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
