### PR TITLE
Add full width to document detail fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed adding the same filter twice doesn't show it in the search bar [#7185](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7185)
-- Fixed rendering of rows in CDB list table when it starts with quotes. [#7171](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7171)
+- Fixed rendering of rows in CDB list table when it starts with quotes [#7171](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7171)
+- Fixed width of long fields in the document detail flyout [#7206](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7206)
 
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 00
 

--- a/plugins/main/public/components/common/doc-viewer/doc-viewer.tsx
+++ b/plugins/main/public/components/common/doc-viewer/doc-viewer.tsx
@@ -229,7 +229,11 @@ const DocViewer = (props: tDocViewerProps) => {
                            */
                           // eslint-disable-next-line react/no-danger
                           dangerouslySetInnerHTML={{ __html: value as string }}
-                          style={{ overflowY: 'auto', wordBreak: 'break-all' }}
+                          style={{
+                            overflowY: 'auto',
+                            wordBreak: 'break-all',
+                            width: '100%',
+                          }}
                         />
                       )}
                     </td>

--- a/plugins/main/server/lib/generate-alerts/sample-data/authentication.js
+++ b/plugins/main/server/lib/generate-alerts/sample-data/authentication.js
@@ -104,7 +104,8 @@ module.exports.windowsInvalidLoginPassword = {
       channel: 'Security',
       keywords: '0x8010000000000000',
       level: '0',
-      message: '',
+      message:
+        '"Network connection detected:\r\nRuleName: technique_id=T1218,technique_name=Signed Binary Proxy Execution\r\nUtcTime: 2024-12-17 18:19:07.118\r\nProcessGuid: {1d283861-07bb-6753-7500-000000001102}\r\nProcessId: 3800\r\nImage: C:\\Windows\\System32\\svchost.exe\r\nUser: NT AUTHORITY\\NETWORK SERVICE\r\nProtocol: tcp\r\nInitiated: false\r\nSourceIsIpv6: false\r\nSourceIp: 45.131.195.204\r\nSourceHostname: -\r\nSourcePort: 49057\r\nSourcePortName: -\r\nDestinationIsIpv6: false\r\nDestinationIp: 10.0.1.38\r\nDestinationHostname: us-west-1.compute.internal\r\nDestinationPort: 3389\r\nDestinationPortName: ms-server"',
       opcode: '0',
       providerGuid: '{54849625-5478-4994-a5ba-3e3b0328c30d}',
       providerName: 'Microsoft-Windows-Security-Auditing',


### PR DESCRIPTION
### Description

This pull request adds content to the sample data field `data.win.system.message` and applies a style so it uses the 100% of the space available.

### Issues Resolved

#7204 

### Evidence

![image](https://github.com/user-attachments/assets/116c3f46-ad28-47f3-a3d7-427f4c56ebaf)

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
