### PR TITLE
Fix typo in flyout title for available updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed error message to prevent pass no strings to the wazuh logger [#7167](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7167)
 - Fixed the rendering of the `data.vunerability.reference` in the table and flyout [#7177](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7177)
 - Fixed incorrect or empty Wazuh API version displayed after upgrade [#440](https://github.com/wazuh/wazuh-dashboard/issues/440)
+- Fixed typo in flyout title for available updates [#7235](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7235)
 
 ### Removed
 

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -583,7 +583,7 @@ export const ApiTable = compose(withErrorBoundary)(
                   <EuiFlexItem grow={false}>
                     <WzButtonOpenFlyout
                       tooltip={{ content: 'View available updates' }}
-                      flyoutTitle={'Availabe updates'}
+                      flyoutTitle={'Available updates'}
                       flyoutBody={() => {
                         return <AvailableUpdatesFlyout api={api} />;
                       }}


### PR DESCRIPTION
### Description

There's a typo in the available updates flyout, it says "Availabe updates" when it should be "available updates".

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/7234

### Evidence

![image](https://github.com/user-attachments/assets/564c4281-2653-4ed3-b830-582c05ee50a9)

### Test

1. Navigate to Server API's
2. Click on an API entry with updates in the "eye" button
3. See the fixed

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
