### PR TITLE
Added start command option to dev.sh script

### DIFF
--- a/docker/osd-dev/dev.sh
+++ b/docker/osd-dev/dev.sh
@@ -156,11 +156,14 @@ up)
  down)
    docker compose --profile $profile -f dev.yml down -v --remove-orphans
    ;;
+ start)
+   docker compose --profile $profile -f dev.yml -p ${COMPOSE_PROJECT_NAME} start
+   ;;
  stop)
    docker compose --profile $profile -f dev.yml -p ${COMPOSE_PROJECT_NAME} stop
    ;;
  *)
-   echo "[ERROR] Action must be up | down | stop: "
+   echo "[ERROR] Action must be up | down | stop | start: "
    echo
    usage
    ;;


### PR DESCRIPTION
### Description

Add a `start` command option to mimic the functionality of `docker compose start`

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7238

### Evidence

```
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ ./dev.sh /home/usuario/wazuh-dashboard-plugins/plugins up
[INFO] OS Version not received via flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[INFO] OSD Version not received via a flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[+] Running 14/14
 ✔ Network os-dev-2.18.0              Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_os_logs"       Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_os_data"       Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_wm_certs"      Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_osd_cache"     Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_wd_certs"      Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_idp_certs"     Created                                                                                                                                                            0.0s 
 ✔ Volume "os-dev-2180_wi_certs"      Created                                                                                                                                                            0.0s 
 ✔ Container os-dev-2180-generator-1  Started                                                                                                                                                            1.8s 
 ✔ Container os-dev-2180-os1-1        Healthy                                                                                                                                                           12.5s 
 ✔ Container os-dev-2180-imposter-1   Started                                                                                                                                                            2.5s 
 ✔ Container os-dev-2180-exporter-1   Started                                                                                                                                                            2.7s 
 ✔ Container os-dev-2180-osd-1        Started                                                                                                                                                           12.5s 
 ✔ Container os-dev-2180-filebeat-1   Started                                                                                                                                                           12.0s 
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ docker ps
CONTAINER ID   IMAGE                                                       COMMAND                   CREATED              STATUS                        PORTS                                                                NAMES
bd253a81cde9   quay.io/wazuh/osd-dev:2.18.0                                "/usr/local/bin/entr…"    About a minute ago   Up About a minute             0.0.0.0:5601->5601/tcp                                               os-dev-2180-osd-1
23da14d3e712   elastic/filebeat:7.10.2                                     "/bin/bash -c '\n  mk…"   About a minute ago   Up About a minute                                                                                  os-dev-2180-filebeat-1
e4662bcab1f2   opensearchproject/opensearch:2.18.0                         "./opensearch-docker…"    About a minute ago   Up About a minute (healthy)   0.0.0.0:9200->9200/tcp, 9600/tcp, 0.0.0.0:9300->9300/tcp, 9650/tcp   os-dev-2180-os1-1
0ad5f140f902   cfssl/cfssl                                                 "/bin/bash -c '\n  ex…"   About a minute ago   Up About a minute (healthy)   8888/tcp                                                             os-dev-2180-generator-1
af56719b50ec   quay.io/prometheuscommunity/elasticsearch-exporter:latest   "/bin/elasticsearch_…"    About a minute ago   Up About a minute             7979/tcp                                                             os-dev-2180-exporter-1
9021b762974a   outofcoffee/imposter:3.44.1                                 "java -classpath /op…"    About a minute ago   Up About a minute             8080/tcp, 8443/tcp                                                   os-dev-2180-imposter-1
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ ./dev.sh /home/usuario/wazuh-dashboard-plugins/plugins stop
[INFO] OS Version not received via flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[INFO] OSD Version not received via flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[+] Stopping 6/6
 ✔ Container os-dev-2180-generator-1  Stopped                                                                                                                                                           30.0s 
 ✔ Container os-dev-2180-filebeat-1   Stopped                                                                                                                                                           33.5s 
 ✔ Container os-dev-2180-imposter-1   Stopped                                                                                                                                                           31.7s 
 ✔ Container os-dev-2180-exporter-1   Stopped                                                                                                                                                           26.0s 
 ✔ Container os-dev-2180-osd-1        Stopped                                                                                                                                                           39.5s 
 ✔ Container os-dev-2180-os1-1        Stopped                                                                                                                                                           17.8s 
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ ./dev.sh /home/usuario/wazuh-dashboard-plugins/plugins start
[INFO] OS Version not received via flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[INFO] OSD Version not received via flag, getting the version from ../../plugins/wazuh-core/package.json. Using: 2.18.0
[+] Running 6/6
 ✔ Container os-dev-2180-imposter-1   Started                                                                                                                                                            1.3s 
 ✔ Container os-dev-2180-os1-1        Healthy                                                                                                                                                           11.1s 
 ✔ Container os-dev-2180-generator-1  Started                                                                                                                                                            0.5s 
 ✔ Container os-dev-2180-exporter-1   Started                                                                                                                                                            1.3s 
 ✔ Container os-dev-2180-osd-1        Started                                                                                                                                                            1.2s 
 ✔ Container os-dev-2180-filebeat-1   Started                                                                                                                                                            1.4s 
~/wazuh-dashboard-plugins/docker/osd-dev(master)$ docker ps
CONTAINER ID   IMAGE                                                       COMMAND                   CREATED         STATUS                    PORTS                                                                NAMES
bd253a81cde9   quay.io/wazuh/osd-dev:2.18.0                                "/usr/local/bin/entr…"    3 minutes ago   Up 3 seconds              0.0.0.0:5601->5601/tcp                                               os-dev-2180-osd-1
23da14d3e712   elastic/filebeat:7.10.2                                     "/bin/bash -c '\n  mk…"   3 minutes ago   Up 3 seconds                                                                                   os-dev-2180-filebeat-1
e4662bcab1f2   opensearchproject/opensearch:2.18.0                         "./opensearch-docker…"    3 minutes ago   Up 14 seconds (healthy)   0.0.0.0:9200->9200/tcp, 9600/tcp, 0.0.0.0:9300->9300/tcp, 9650/tcp   os-dev-2180-os1-1
0ad5f140f902   cfssl/cfssl                                                 "/bin/bash -c '\n  ex…"   3 minutes ago   Up 15 seconds (healthy)   8888/tcp                                                             os-dev-2180-generator-1
af56719b50ec   quay.io/prometheuscommunity/elasticsearch-exporter:latest   "/bin/elasticsearch_…"    3 minutes ago   Up 14 seconds             7979/tcp                                                             os-dev-2180-exporter-1
9021b762974a   outofcoffee/imposter:3.44.1                                 "java -classpath /op…"    3 minutes ago   Up 14 seconds             8080/tcp, 8443/tcp                                                   os-dev-2180-imposter-1

```
### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable


| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Run up, stop, and start commands and check that all container works correctly. | :black_circle: | :black_circle: | :black_circle: |


### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
