### PR TITLE
Remove unused node_build field in the package manifest of main plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Move the ability to manage the visibility of fields in `Events` and `Vulnerability Detection` > `Inventory` tables from `Columns` button to a new `Available fields` button enhancing the performance of the view [#7226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7226)
 - Change the color of `Export formatted` button of data grid tables to match the color of the rest of table buttons [#7226](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7226)
 
+### Removed
+
+- Remove unused `node_build` field in package manifest of `wazuh` plugin [#7245](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7245)
+
 ## Wazuh v4.10.0 - OpenSearch Dashboards 2.16.0 - Revision 08
 
 ### Added

--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -11,7 +11,6 @@
     "wazuh",
     "ossec"
   ],
-  "node_build": "10.23.1",
   "author": "Wazuh, Inc",
   "license": "GPL-2.0",
   "resolutions": {


### PR DESCRIPTION
### Description

This pull request removes the unused `node_build` property in the package manifest of main plugin.

### Issues Resolved

#5351

### Check List

- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
