### PR TITLE
Repair agent deployment url to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.10.2
 
+### Fixed
+
+- Fixed agent deployment url to documentation [#7251](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7251)
+
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed agent deployment url to documentation [#7251](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7251)
+- Fixed documentation URL related to the usage of authentication password in the agent deployment [#7251](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7251)
 
 ## Wazuh v4.10.1 - OpenSearch Dashboards 2.16.0 - Revision 01
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -155,12 +155,12 @@ export const Steps = ({
                 color='warning'
                 title={
                   <span>
-                    The password is required but wasn't defined. Please
-                    check our{' '}
+                    The password is required but wasn't defined. Please check
+                    our{' '}
                     <EuiLink
                       target='_blank'
                       href={webDocumentationLink(
-                        'user-manual/agent-enrollment/security-options/using-password-authentication.html',
+                        'user-manual/agent/agent-enrollment/security-options/using-password-authentication.html',
                       )}
                       rel='noopener noreferrer'
                     >


### PR DESCRIPTION
### Description

The link to the documentation in the agent password step configuration is not properly defined.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7247


### Test

#### Preconditions

Enable the password authentication option by adding the configuration highlighted below to the `<auth>` section of the Wazuh server configuration file `/var/ossec/etc/ossec.conf`:


```
<auth>
  <use_password>yes</use_password>
</auth>
```

- Navigate to Agents management > Summary
- Click on Deploy new agent
- The password step renders a documentation link

It must navigate to a correct documentation guide: 
- https://documentation.wazuh.com/4.10/user-manual/agent/agent-enrollment/security-options/using-password-authentication.html

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
