### PR TITLE
Change master branch references to main

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -12,7 +12,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -11,14 +11,14 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA)
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -12,7 +12,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA)
       command:
         required: true

--- a/plugins/main/public/directives/wz-logtest/components/logtest.tsx
+++ b/plugins/main/public/directives/wz-logtest/components/logtest.tsx
@@ -66,7 +66,7 @@ export const Logtest = compose(
   // Format the result of the Wazuh API response to an output similar one to the `wazuh-logtest` utility
   const formatResult = (result, alert, messages) => {
     // How to the `wazuh-logtest` utility logs the output:
-    // https://github.com/wazuh/wazuh/blob/master/framework/scripts/wazuh-logtest.py#L359-L397
+    // https://github.com/wazuh/wazuh/blob/v4.3.0/framework/scripts/wazuh-logtest.py#L359-L397
 
     const logging = [];
 

--- a/plugins/main/scripts/generate-api-data.js
+++ b/plugins/main/scripts/generate-api-data.js
@@ -146,14 +146,14 @@ ${Object.keys(outputs)
   function displayExamples() {
     // TODO: examples
     console.log(`
-- Get API data from URL spec file and save to files (API branch master). Run from project root path.
-node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/master/api/api/spec/spec.yaml --output file --output-directory common/api-info
+- Get API data from URL spec file and save to files (API branch main). Run from project root path.
+node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/main/api/api/spec/spec.yaml --output file --output-directory common/api-info
 
 - Get API data from URL spec file using the plugin version and save to files. Run from project root path.
 node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/$(node -e \"console.log(require('./package.json').version.split('.').splice(0,2).join('.'))\")/api/api/spec/spec.yaml --output file --output-directory common/api-info
 
-- Unused: Get API data from spec file and print to stdout (API branch master). Run from project root path.
-node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/master/api/api/spec/spec.yaml --output stdout
+- Unused: Get API data from spec file and print to stdout (API branch main). Run from project root path.
+node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/main/api/api/spec/spec.yaml --output stdout
 
 `);
   }


### PR DESCRIPTION
### Description

This pull request changes the `master` branch name references to `main`

### Issues Resolved

#7277

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
