### PR TITLE
Add agent-management to help links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.11.0
 
+### Fixed
+
+- Fixed documentation links related to agent management [#7299](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7299)
+
 ### Changed
 
 - Refined the layout of the agent details view [#7193](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.11.1
 
+### Fixed
+
+- Fixed documentation links related to agent management [#7299](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7299)
+
 ## Wazuh v4.11.0 - OpenSearch Dashboards 2.16.0 - Revision 01
 
 ### Added
 
 - Support for Wazuh 4.11.0
-
-### Fixed
-
-- Fixed documentation links related to agent management [#7299](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7299)
 
 ### Changed
 

--- a/plugins/main/common/services/web_documentation.test.ts
+++ b/plugins/main/common/services/web_documentation.test.ts
@@ -2,8 +2,8 @@ import { DOCUMENTATION_WEB_BASE_URL, PLUGIN_VERSION_SHORT } from '../constants';
 import { webDocumentationLink } from './web_documentation';
 
 test(`Generate a web documentation URL using to the plugin short version`, () => {
-  expect(webDocumentationLink('user-manual/agent-enrollment/index.html')).toBe(
-    `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent-enrollment/index.html`,
+  expect(webDocumentationLink('user-manual/agent/agent-enrollment/index.html')).toBe(
+    `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent/agent-enrollment/index.html`,
   );
 });
 
@@ -15,8 +15,8 @@ test(`Generate a web documentation URL to the base URL using to the plugin short
 
 test(`Generate a web documentation URL using a specific version`, () => {
   expect(
-    webDocumentationLink('user-manual/agent-enrollment/index.html', '4.6'),
+    webDocumentationLink('user-manual/agent/agent-enrollment/index.html', '4.6'),
   ).toBe(
-    `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent-enrollment/index.html`,
+    `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent/agent-enrollment/index.html`,
   );
 });

--- a/plugins/main/common/services/web_documentation.test.ts
+++ b/plugins/main/common/services/web_documentation.test.ts
@@ -2,7 +2,9 @@ import { DOCUMENTATION_WEB_BASE_URL, PLUGIN_VERSION_SHORT } from '../constants';
 import { webDocumentationLink } from './web_documentation';
 
 test(`Generate a web documentation URL using to the plugin short version`, () => {
-  expect(webDocumentationLink('user-manual/agent/agent-enrollment/index.html')).toBe(
+  expect(
+    webDocumentationLink('user-manual/agent/agent-enrollment/index.html'),
+  ).toBe(
     `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent/agent-enrollment/index.html`,
   );
 });
@@ -15,7 +17,10 @@ test(`Generate a web documentation URL to the base URL using to the plugin short
 
 test(`Generate a web documentation URL using a specific version`, () => {
   expect(
-    webDocumentationLink('user-manual/agent/agent-enrollment/index.html', '4.6'),
+    webDocumentationLink(
+      'user-manual/agent/agent-enrollment/index.html',
+      '4.6',
+    ),
   ).toBe(
     `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent/agent-enrollment/index.html`,
   );

--- a/plugins/main/public/components/agents/prompts/prompt-agent-never-connected.tsx
+++ b/plugins/main/public/components/agents/prompts/prompt-agent-never-connected.tsx
@@ -17,7 +17,7 @@ import { webDocumentationLink } from '../../../../common/services/web_documentat
 import { showExploreAgentModalGlobal } from '../../../redux/actions/appStateActions';
 
 const documentationLink = webDocumentationLink(
-  'user-manual/agents/agent-connection.html',
+  'user-manual/agent/agent-management/agent-connection.html#checking-connection-with-the-wazuh-manager',
 );
 
 export const PromptAgentNeverConnected = () => {

--- a/plugins/main/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
@@ -34,7 +34,9 @@ const columns = [
 const helpLinks = [
   {
     text: 'Agent labels',
-    href: webDocumentationLink('user-manual/agent/agent-management/labels.html'),
+    href: webDocumentationLink(
+      'user-manual/agent/agent-management/labels.html',
+    ),
   },
   {
     text: 'Labels reference',

--- a/plugins/main/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
@@ -34,7 +34,7 @@ const columns = [
 const helpLinks = [
   {
     text: 'Agent labels',
-    href: webDocumentationLink('user-manual/agents/labels.html'),
+    href: webDocumentationLink('user-manual/agent/agent-management/labels.html'),
   },
   {
     text: 'Labels reference',

--- a/plugins/main/public/controllers/management/components/management/configuration/client/client.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/client/client.js
@@ -28,7 +28,7 @@ import { webDocumentationLink } from '../../../../../../../common/services/web_d
 const helpLinks = [
   {
     text: 'Checking connection with manager',
-    href: webDocumentationLink('user-manual/agents/agent-connection.html'),
+    href: webDocumentationLink('user-manual/agent/agent-management/agent-connection.html#checking-connection-with-the-wazuh-manager'),
   },
   {
     text: 'Client reference',

--- a/plugins/main/public/controllers/management/components/management/configuration/client/client.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/client/client.js
@@ -28,7 +28,9 @@ import { webDocumentationLink } from '../../../../../../../common/services/web_d
 const helpLinks = [
   {
     text: 'Checking connection with manager',
-    href: webDocumentationLink('user-manual/agent/agent-management/agent-connection.html#checking-connection-with-the-wazuh-manager'),
+    href: webDocumentationLink(
+      'user-manual/agent/agent-management/agent-connection.html#checking-connection-with-the-wazuh-manager',
+    ),
   },
   {
     text: 'Client reference',

--- a/plugins/main/public/controllers/management/components/management/configuration/registration-service/registration-service.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/registration-service/registration-service.js
@@ -26,7 +26,7 @@ import { webDocumentationLink } from '../../../../../../../common/services/web_d
 const helpLinks = [
   {
     text: 'Agent enrollment',
-    href: webDocumentationLink('user-manual/agent-enrollment/index.html'),
+    href: webDocumentationLink('user-manual/agent/agent-enrollment/index.html'),
   },
   {
     text: 'Registration service reference',

--- a/plugins/wazuh-core/common/services/web_documentation.test.ts
+++ b/plugins/wazuh-core/common/services/web_documentation.test.ts
@@ -2,8 +2,8 @@ import { DOCUMENTATION_WEB_BASE_URL, PLUGIN_VERSION_SHORT } from '../constants';
 import { webDocumentationLink } from './web_documentation';
 
 test(`Generate a web documentation URL using to the plugin short version`, () => {
-  expect(webDocumentationLink('user-manual/agent-enrollment/index.html')).toBe(
-    `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent-enrollment/index.html`,
+  expect(webDocumentationLink('user-manual/agent/agent-enrollment/index.html')).toBe(
+    `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent/agent-enrollment/index.html`,
   );
 });
 
@@ -15,8 +15,8 @@ test(`Generate a web documentation URL to the base URL using to the plugin short
 
 test(`Generate a web documentation URL using a specific version`, () => {
   expect(
-    webDocumentationLink('user-manual/agent-enrollment/index.html', '4.6'),
+    webDocumentationLink('user-manual/agent/agent-enrollment/index.html', '4.6'),
   ).toBe(
-    `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent-enrollment/index.html`,
+    `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent/agent-enrollment/index.html`,
   );
 });

--- a/plugins/wazuh-core/common/services/web_documentation.test.ts
+++ b/plugins/wazuh-core/common/services/web_documentation.test.ts
@@ -2,7 +2,9 @@ import { DOCUMENTATION_WEB_BASE_URL, PLUGIN_VERSION_SHORT } from '../constants';
 import { webDocumentationLink } from './web_documentation';
 
 test(`Generate a web documentation URL using to the plugin short version`, () => {
-  expect(webDocumentationLink('user-manual/agent/agent-enrollment/index.html')).toBe(
+  expect(
+    webDocumentationLink('user-manual/agent/agent-enrollment/index.html'),
+  ).toBe(
     `${DOCUMENTATION_WEB_BASE_URL}/${PLUGIN_VERSION_SHORT}/user-manual/agent/agent-enrollment/index.html`,
   );
 });
@@ -15,7 +17,10 @@ test(`Generate a web documentation URL to the base URL using to the plugin short
 
 test(`Generate a web documentation URL using a specific version`, () => {
   expect(
-    webDocumentationLink('user-manual/agent/agent-enrollment/index.html', '4.6'),
+    webDocumentationLink(
+      'user-manual/agent/agent-enrollment/index.html',
+      '4.6',
+    ),
   ).toBe(
     `${DOCUMENTATION_WEB_BASE_URL}/4.6/user-manual/agent/agent-enrollment/index.html`,
   );


### PR DESCRIPTION
### Description

This pull request fixes the agent check connection link and the agent labels link.

### Issues Resolved

#7298 


### Test


#### Agents management -> Summary
- Add a new agent using the Server management dev tools
- Go to Agents management -> Summary
- Select the never connected agent
- Check the help link works as expected (Keep in mind 4.11 documentation is still not productive, so change the version number to 4.10)

#### Server Management -> Settings -> Alerts
- Go to Server Management -> Settings -> Alerts
- Click on the Labels tab
- Verify the help links work


#### Server Management -> Settings -> Registration service
- Go to Server Management -> Settings -> Registration service
- Click on the Labels tab
- Verify the help links work

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
