### PR TITLE
Update GitHub actions to use Ubuntu 24.04

### DIFF
--- a/.github/actions/comment-test-coverage/README.md
+++ b/.github/actions/comment-test-coverage/README.md
@@ -13,7 +13,7 @@ name: test-pull-request
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -44,7 +44,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   linter:
     name: Ensure the code format on the changed files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
       - name: Checkout code

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -35,7 +35,7 @@ jobs:
   test-packages:
     needs: build
     name: Test packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Step 01 - Download the plugin's source code

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   prettier:
     name: Ensure the code format on the changed files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
       - name: Checkout code

--- a/.github/workflows/wazuh-build-push-docker-action.yml
+++ b/.github/workflows/wazuh-build-push-docker-action.yml
@@ -53,7 +53,7 @@ jobs:
   job-build-manager-image:
     if: ${{ github.event.inputs.build-manager-image == 'true' }}
     name: Run build and push manager image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download wazuh-kibana-app
         uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
   job-build-agent-image:
     if: ${{ github.event.inputs.build-agent-image == 'true' }}
     name: Run build and push agent image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download wazuh-kibana-app
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
   job-build-cypress-image:
     if: ${{ github.event.inputs.build-cypress-image == 'true' }}
     name: Run build and push cypress image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download wazuh-kibana-app
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

This pull request updates our GitHub actions to use Ubuntu 24.04 image instead of latest. This is to prevent unexpected changes in the version of the image.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/535

### Test

Check the actions don't throw any errors.

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
