### PR TITLE
Update pinned agent state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed logging UI logs due to logger undefined property [#7267](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7267)
 - Fixed TOP-5-SO filter management in Endpoints > Summary [#7278](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7278)
 - Fixed CSV export not filtering by timerange [#7304](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7304)
+- Fixed agent view not showing the latest agent state [#7336](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7336)
 
 ## Wazuh v4.11.1 - OpenSearch Dashboards 2.16.0 - Revision 00
 

--- a/plugins/main/public/components/common/hocs/withAgentSync.tsx
+++ b/plugins/main/public/components/common/hocs/withAgentSync.tsx
@@ -12,15 +12,16 @@
 
 import React, { useState, useEffect } from 'react';
 import { PinnedAgentManager } from '../../wz-agent-selector/wz-agent-selector-service';
-import { withGuardAsync } from './withGuard';
 
 export const withAgentSync = WrappedComponent => props => {
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const pinnedAgentManager = new PinnedAgentManager();
-    pinnedAgentManager.syncPinnedAgentSources().finally(() => {
-      setLoading(false);
-    });
+    pinnedAgentManager
+      .syncPinnedAgentSources({ forceUpdate: true })
+      .finally(() => {
+        setLoading(false);
+      });
   }, []);
   return loading ? null : <WrappedComponent {...props}></WrappedComponent>;
 };

--- a/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
+++ b/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
@@ -5,6 +5,14 @@ import { DATA_SOURCE_FILTER_CONTROLLED_PINNED_AGENT } from '../../../common/cons
 import { WzRequest } from '../../react-services';
 import NavigationService from '../../react-services/navigation-service';
 
+/**
+ * Options for the syncPinnedAgentSources method
+ * @param forceUpdate - Force the update of the pinned agent with a Wazuh API request
+ */
+type TsyncPinnedAgentSourcesOptions = {
+  forceUpdate?: boolean;
+};
+
 export class PinnedAgentManager {
   public static NO_AGENT_DATA = {};
   public static AGENT_ID_VIEW_KEY = 'agent';
@@ -71,7 +79,7 @@ export class PinnedAgentManager {
     return !!this.store.getState().appStateReducers?.currentAgentData?.id;
   }
 
-  async syncPinnedAgentSources() {
+  async syncPinnedAgentSources(options?: TsyncPinnedAgentSourcesOptions) {
     const locationHref = window.location.href;
     const keyToMatch: string = locationHref.includes(this.AGENT_VIEW_URL)
       ? PinnedAgentManager.AGENT_ID_VIEW_KEY
@@ -90,7 +98,8 @@ export class PinnedAgentManager {
         !pinnedAgentByUrl === pinnedAgentByStore ||
         (pinnedAgentByUrl &&
           pinnedAgentByStore &&
-          agentIdValueUrl !== this.getPinnedAgent().id);
+          agentIdValueUrl !== this.getPinnedAgent().id) ||
+        options?.forceUpdate;
       if (mustBeSynchronized) {
         try {
           if (isValidAgentId) {

--- a/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
+++ b/plugins/main/public/components/wz-agent-selector/wz-agent-selector-service.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import store from '../../redux/store';
 import { updateCurrentAgentData } from '../../redux/actions/appStateActions';
 import { DATA_SOURCE_FILTER_CONTROLLED_PINNED_AGENT } from '../../../common/constants';
@@ -22,7 +23,7 @@ export class PinnedAgentManager {
 
   private equalToPinnedAgent(agentData: any): boolean {
     const pinnedAgent = this.getPinnedAgent();
-    return pinnedAgent?.id === agentData?.id;
+    return _.isEqual(pinnedAgent, agentData);
   }
 
   private checkValidAgentId(agentId: string | null): boolean {


### PR DESCRIPTION
### Description

This pull request updates the pinned agent state whenever the agent view initially loads. This ensures that if the agent changes its connection status then the related components show the latest change.

> [!NOTE]
> The agent data only updates the redux state when the agent view loads and then keeps using the redux state to avoid 
spamming requests to the Wazuh API.


### Issues Resolved

#7329 

### Evidence

![image](https://github.com/user-attachments/assets/74f4b382-3d55-4cb7-a4a6-75dfb4113731)


### Test

- Register 2 agents in a Wazuh manager
- Go to Endpoint summary
- Select agent 001 when it's active to enter the agent view
- Verify the agent is displayed as active
- Shut down the agent
- Go to Endpoint summary again
- Wait until the agent is displayed as disconnected
- Click on the previously selected agent to enter the agent view
- Check the agent state is disconnected

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
