### PR TITLE
Remove creation of certs folder from documentation

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -154,11 +154,9 @@ NODE_NAME=<DASHBOARD_NODE_NAME>
 ```
 
 ```console
-sudo mkdir /etc/wazuh-dashboard/certs
 sudo tar -xf ./wazuh-certificates.tar -C /etc/wazuh-dashboard/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./root-ca.pem
 sudo mv -n /etc/wazuh-dashboard/certs/$NODE_NAME.pem /etc/wazuh-dashboard/certs/dashboard.pem
 sudo mv -n /etc/wazuh-dashboard/certs/$NODE_NAME-key.pem /etc/wazuh-dashboard/certs/dashboard-key.pem
-sudo chmod 500 /etc/wazuh-dashboard/certs
 sudo chmod 400 /etc/wazuh-dashboard/certs/*
 sudo chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/certs
 ```


### PR DESCRIPTION
### Description

This pull request removes the creation of the certs folder from the documentation because it has to be already created by Wazuh dashboard installation.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/7344


### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
