### PR TITLE
Change localhost to 127.0.0.1

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -114,7 +114,7 @@ Example:
 
 ```yaml
 server.host: 0.0.0.0
-opensearch.hosts: https://localhost:9200
+opensearch.hosts: https://127.0.0.1:9200
 ```
 
 ### Deploying certificates


### PR DESCRIPTION
### Description

This pull request changes in the installation documentation localhost:9200 to 127.0.0.1:9200 in the indexer connection to match the default opensearch_dashboard.yml configuration file.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/7344

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
