### PR TITLE
Fix several documentation links - remove 4.12.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed TOP-5-SO filter management in Endpoints > Summary [#7278](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7278)
 - Fixed CSV export not filtering by timerange [#7304](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7304)
 - Fixed agent view not showing the latest agent state [#7336](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7336)
-- Fixed several broken Wazuh documentation links [#7354](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7354)
 
 ## Wazuh v4.11.1 - OpenSearch Dashboards 2.16.0 - Revision 02
 


### PR DESCRIPTION
### Description

This pull request removes the changelog entry for [this fix](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7354) because a new PR has been merged for Wazuh 4.11.2. Therefore, the pull request made for 4.12.0 is no longer relevant.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/7328

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
