### PR TITLE
Fix custom branding documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed several broken Wazuh documentation links [#7370](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7370)
+- Fixed several broken Wazuh documentation links [#7370](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7370) [#7371](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7371)
 
 ## Wazuh v4.11.1 - OpenSearch Dashboards 2.16.0 - Revision 02
 

--- a/plugins/wazuh-core/common/constants.ts
+++ b/plugins/wazuh-core/common/constants.ts
@@ -572,7 +572,7 @@ export const PLUGIN_SETTINGS_CATEGORIES: {
     title: 'Custom branding',
     description:
       'If you want to use custom branding elements such as logos, you can do so by editing the settings below.',
-    documentationLink: 'user-manual/wazuh-dashboard/white-labeling.html',
+    documentationLink: 'user-manual/wazuh-dashboard/custom-branding.html',
     renderOrder: SettingCategory.CUSTOMIZATION,
   },
   [SettingCategory.API_CONNECTION]: {


### PR DESCRIPTION
### Description

This pull request fixes the custom branding documentation link located in the App settings section. The documentation link for 4.11.x is:
https://documentation.wazuh.com/4.11/user-manual/wazuh-dashboard/custom-branding.html

### Issues Resolved

#7328 

### Evidence

![image](https://github.com/user-attachments/assets/48c3fe0b-30f9-4e24-9463-8c11e82d48c9)


### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
