### PR TITLE
Saved queries not displayed in the search bar

### DIFF
--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -535,3 +535,10 @@ export enum FilterStateStore {
   APP_STATE = 'appState',
   GLOBAL_STATE = 'globalState',
 }
+
+export const SUPPORTED_LANGUAGES = {
+  KUERY: 'kuery',
+  LUCENE: 'lucene',
+} as const;
+
+export const SUPPORTED_LANGUAGES_ARRAY = Object.values(SUPPORTED_LANGUAGES);

--- a/plugins/main/public/plugin.ts
+++ b/plugins/main/public/plugin.ts
@@ -47,6 +47,7 @@ import { Applications, Categories } from './utils/applications';
 import { euiPaletteColorBlind } from '@elastic/eui';
 import NavigationService from './react-services/navigation-service';
 import { createHashHistory } from 'history';
+import { SUPPORTED_LANGUAGES_ARRAY } from '../common/constants';
 
 export class WazuhPlugin
   implements
@@ -115,6 +116,19 @@ export class WazuhPlugin
 
       _.merge(this._mapping, _.zipObject(keysToMap, colorPalette));
     };
+
+    /* ---------------------------------------------------------------------- */
+    /*           Register the supported languages for the query bar           */
+    /* ---------------------------------------------------------------------- */
+    const appIds: string[] = Applications.map(app => app.id);
+    const languageService = plugins.data.query.queryString.languageService;
+    SUPPORTED_LANGUAGES_ARRAY.forEach(language => {
+      const languageInstance = languageService.getLanguage(language);
+      languageService.registerLanguage({
+        ...languageInstance,
+        supportedAppNames: [...languageInstance.supportedAppNames, ...appIds],
+      });
+    });
 
     // Register the applications
     Applications.forEach(app => {


### PR DESCRIPTION
### Description

Since the upgrade to OpenSearch 2.19.1 we found out that the default behavior of the saved queries has changed. Now it only shows the saved queries allowed in the `supportedAppNames` property in the query languages registered.

References:

https://github.com/wazuh/wazuh-dashboard/blob/4.13.0/src/plugins/data/public/query/query_string/language_service/lib/dql_language.ts#L34

https://github.com/wazuh/wazuh-dashboard/blob/4.13.0/src/plugins/data/public/query/saved_query/saved_query_service.ts#L136-L148

To fix it, we could re-register the query languages, including our applications ID in the `setup` method `plugin.ts` file of the plugin.

For example:
```javascript
const dataPlugin = plugins.data;
    dataPlugin.query.queryString.languageService.registerLanguage({
      ...dataPlugin.query.queryString.languageService.getLanguage('kuery'),
      supportedAppNames: [
        'discover',
        'dashboards',
        'visualize',
        'data-explorer',
        'vis-builder',
        '*',
        'threat-hunting',
      ],
    });

```

#### Additional information
This was discovered in the following comment:
- https://github.com/wazuh/wazuh/issues/27903#issuecomment-2753637986

### Issues Resolved

[Saved queries not displayed in the search bar · Issue #7374 · wazuh/wazuh-dashboard-plugins](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7374)

### Evidence

https://github.com/user-attachments/assets/f100f926-6c3f-4cf7-9ad5-bf01b5635354

### Test

Test the same steps that are shown in the evidence.

You should ensure that the saved query is shown in each application.

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
