### PR TITLE
Remove revision number from about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed agent view not showing the latest agent state [#7336](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7336)
 - Fixed saved queries not displaying in the search bar [#7377](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7377)
 
+### Removed
+
+- Removed revision number from about page [#7390](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7390)
+
 ## Wazuh v4.11.2 - OpenSearch Dashboards 2.16.0 - Revision 02
 
 ### Added

--- a/plugins/main/public/components/settings/about/__snapshots__/appInfo.test.tsx.snap
+++ b/plugins/main/public/components/settings/about/__snapshots__/appInfo.test.tsx.snap
@@ -27,19 +27,6 @@ exports[`SettingsAboutAppInfo component should render version, revision, install
               </b>
             </div>
           </div>
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiText euiText--medium"
-            >
-              App revision:
-               
-              <b>
-                01
-              </b>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/plugins/main/public/components/settings/about/appInfo.test.tsx
+++ b/plugins/main/public/components/settings/about/appInfo.test.tsx
@@ -13,7 +13,6 @@ describe('SettingsAboutAppInfo component', () => {
       <SettingsAboutAppInfo
         appInfo={{
           'app-version': '4.8.0',
-          revision: '01',
         }}
       />,
     );
@@ -22,7 +21,5 @@ describe('SettingsAboutAppInfo component', () => {
 
     expect(getByText('App version:')).toBeInTheDocument();
     expect(getByText('4.8.0')).toBeInTheDocument();
-    expect(getByText('App revision:')).toBeInTheDocument();
-    expect(getByText('01')).toBeInTheDocument();
   });
 });

--- a/plugins/main/public/components/settings/about/appInfo.tsx
+++ b/plugins/main/public/components/settings/about/appInfo.tsx
@@ -1,11 +1,9 @@
 import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import React from 'react';
+import { AppInfo } from '../types';
 
 interface SettingsAboutAppInfoProps {
-  appInfo?: {
-    'app-version': string;
-    revision: string;
-  };
+  appInfo?: AppInfo;
 }
 
 export const SettingsAboutAppInfo = ({
@@ -22,12 +20,6 @@ export const SettingsAboutAppInfo = ({
           <EuiText>
             App version:{' '}
             <b>{appInfo?.['app-version'] ? appInfo['app-version'] : ''}</b>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText>
-            App revision:{' '}
-            <b>{appInfo?.['revision'] ? appInfo['revision'] : ''}</b>
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/plugins/main/public/components/settings/about/index.tsx
+++ b/plugins/main/public/components/settings/about/index.tsx
@@ -3,12 +3,10 @@ import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
 import { SettingsAboutAppInfo } from './appInfo';
 import { SettingsAboutGeneralInfo } from './generalInfo';
 import { PLUGIN_APP_NAME } from '../../../../common/constants';
+import { AppInfo } from '../types';
 
 interface SettingsAboutProps {
-  appInfo?: {
-    'app-version': string;
-    revision: string;
-  };
+  appInfo?: AppInfo;
 }
 
 export const SettingsAbout = (props: SettingsAboutProps) => {

--- a/plugins/main/public/components/settings/settings.tsx
+++ b/plugins/main/public/components/settings/settings.tsx
@@ -45,6 +45,7 @@ import {
 import { Route, Switch } from '../router-search';
 import { useRouterSearch } from '../common/hooks';
 import NavigationService from '../../react-services/navigation-service';
+import { AppInfo } from './types';
 
 const configurationTabID = 'configuration';
 
@@ -81,7 +82,7 @@ class SettingsComponent extends React.Component {
   apiIsDown;
   googleGroupsSVG;
   currentDefault;
-  appInfo;
+  appInfo: AppInfo | undefined;
 
   constructor(props) {
     super(props);
@@ -295,7 +296,6 @@ class SettingsComponent extends React.Component {
       const response = data.data.data;
       this.appInfo = {
         'app-version': response['app-version'],
-        revision: response['revision'],
       };
 
       this.setState({ load: false });

--- a/plugins/main/public/components/settings/types.ts
+++ b/plugins/main/public/components/settings/types.ts
@@ -1,0 +1,3 @@
+export interface AppInfo {
+  'app-version': string;
+}


### PR DESCRIPTION
### Description

Remove the revision number from the About page, and adapt the type as the revision is removed.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/602

### Evidence

<img width="535" alt="image" src="https://github.com/user-attachments/assets/7097ead9-5105-4b4f-bc6d-ad7b4de9285c" />

### Test

1. Navigate to About page
2. Check that the revision number does not appear

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
