### PR TITLE
Fix to the double scroll bar

### DIFF
--- a/plugins/main/public/styles/layout.scss
+++ b/plugins/main/public/styles/layout.scss
@@ -361,19 +361,3 @@
   outline: none !important;
   outline-color: transparent !important;
 }
-
-.globalQueryBar:not(:empty) {
-  padding: 8px !important;
-}
-
-.dscWrapper {
-  .table > thead > tr > th,
-  .table > tbody > tr > th,
-  .table > tfoot > tr > th,
-  .table > thead > tr > td,
-  .table > tbody > tr > td,
-  .table > tfoot > tr > td {
-    font-size: 12px !important;
-    font-kerning: normal !important;
-  }
-}


### PR DESCRIPTION
### Description

Fix to the double scroll bar in Discover when accessing from a Wazuh plugin.

CSS classes that were modifying opensearch styles are removed.

The change of the padding was made for an html template of the discover, instead of creating a new class we modified a class of the discover. 

https://github.com/wazuh/wazuh-dashboard-plugins/commit/9a72b1db9d671eb935acbd6d2f630c9b14e7834c

It also deletes another class that is overwriting those proposed by opensearch, since it is added in an issue that was to adapt to support the dark mode.

https://github.com/wazuh/wazuh-dashboard-plugins/pull/1430

### Issues Resolved

- #7388 

### Evidence



### Test



### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
