### PR TITLE
Break while loop in case of exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed CSV export not filtering by timerange [#7304](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7304)
 - Fixed agent view not showing the latest agent state [#7336](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7336)
 - Fixed saved queries not displaying in the search bar [#7377](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7377)
+- Fixed monitoring cronjob infinite retries in case of a request exception [#7401](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7401)
 
 ### Removed
 

--- a/plugins/main/server/start/monitoring/index.ts
+++ b/plugins/main/server/start/monitoring/index.ts
@@ -479,7 +479,7 @@ async function fetchAllAgentsFromApiHost(context, apiHost) {
           - Reduce (if possible) the quantity of data to index by document
 
         Requirements:
-          - Research about the neccesary data to index.
+          - Research about the necessary data to index.
 
         How to do:
           - Wazuh API request:
@@ -502,6 +502,7 @@ async function fetchAllAgentsFromApiHost(context, apiHost) {
             payload.offset
           }/${payload.limit}: ${error.message || error}`,
         );
+        throw error;
       }
     }
     return agents;


### PR DESCRIPTION
### Description

This pull request fixes an infinite while loop when the monitoring agents fetching throws an exception.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7394

### Test

- Force an exception inside the monitoring cronjob while loop
- Check it logs the error in the console and breaks the loop

```console
server    log   [13:54:11.399] [info][listening] Server running at https://0.0.0.0:5601
server    log   [13:54:11.457] [info][server][OpenSearchDashboards][http] http server running at https://0.0.0.0:5601
server    log   [13:54:33.837] [error][monitoring][plugins][wazuh] ApiID: manager, Error request with offset/limit 500/500: test
server    log   [13:55:29.084] [error][monitoring][plugins][wazuh] ApiID: manager. Error: test
server    log   [13:55:29.406] [error][monitoring][plugins][wazuh] test
```


### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
