### PR TITLE
Updates changelog during repository bump

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -448,6 +448,7 @@ main() {
   update_root_version_json
   update_package_json_files
   update_osd_json_files
+  update_changelog
 
   # Conditionally update endpoints.json
   if [ "$CURRENT_MAJOR_MINOR" != "$NEW_MAJOR_MINOR" ]; then


### PR DESCRIPTION
### Description
Adds an automatic step to update the changelog file when the repository version is bumped. Ensures the changelog accurately reflects the latest version changes.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard-plugins/issues/7397

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/pull/7402

### Test

https://github.com/wazuh/wazuh-dashboard-plugins/pull/7402

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
