### PR TITLE
Change "Vulnerabilities by year of publication" visualization label - vulnerabilities dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.12.1
 
+### Fixed
+
+- Fixed X-axis label in "Vulnerabilities by year of publication" visualization [#7422](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7422)
+
 ## Wazuh v4.12.0 - OpenSearch Dashboards 2.19.1 - Revision 03
 
 ### Added

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
@@ -403,6 +403,7 @@ const getVisStateAccumulationMostDetectedVulnerabilities = (
             drop_partials: false,
             min_doc_count: 1,
             extended_bounds: {},
+            customLabel: 'Year published',
           },
           schema: 'segment',
         },


### PR DESCRIPTION
### Description

This change improves the readability of the "Vulnerabilities by year of publication" chart in the vulnerability dashboard by changing the X-axis label from "vulnerability.published_at per year" to "Year published."

### Issues Resolved

[#7422](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7422)

### Evidence

<img width="597" alt="Screenshot 2025-05-08 at 3 48 48 PM" src="https://github.com/user-attachments/assets/a5e5bf66-0452-4edf-910a-4fd837828dc6" />
<img width="1792" alt="Screenshot 2025-05-08 at 3 48 57 PM" src="https://github.com/user-attachments/assets/cfe20bbd-1ff4-4a89-a620-ffa6689651e0" />


### Test

To test this PR, follow these steps:

1. To view the visualization with test data, you can use the vulnerabilities events injection script:
```bash
cd scripts/vulnerabilities-events-injector
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
python3 dataInjectScript.py
 ```
2. Follow the script instructions to inject test data into your Wazuh-Indexer/Opensearch instance.
3. Navigate to the vulnerabilities dashboard and verify that the X-axis label in the "Vulnerabilities by year of publication" visualization now shows "Year published" instead of "vulnerability.published_at per year".
4. Alternatively, you can verify the change directly in the code by reviewing the file:
```bash
 plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard_panels.ts
 ```

And confirm that the customLabel parameter is set to "Year published" in the X-axis configuration.

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
