### PR TITLE
Change the agent startup command in macOS

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
@@ -222,6 +222,8 @@ describe('getMacOsInstallCommand', () => {
 describe('getMacosStartCommand', () => {
   it('returns the correct start command for macOS', () => {
     const startCommand = getMacosStartCommand({});
-    expect(startCommand).toEqual('sudo /Library/Ossec/bin/wazuh-control start');
+    expect(startCommand).toEqual(
+      'sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist',
+    );
   });
 });

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
@@ -172,5 +172,5 @@ export const getMacOsInstallCommand = (
 export const getMacosStartCommand = (
   _props: tOSEntryProps<tOptionalParameters>,
 ) => {
-  return `sudo /Library/Ossec/bin/wazuh-control start`;
+  return 'sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist';
 };


### PR DESCRIPTION
### Description

The agent start command is changed so that it is synchronized with the documentation and does not give errors when uninstalling the agent.

### Issues Resolved

- #7429 

### Evidence

<img width="532" alt="image" src="https://github.com/user-attachments/assets/3d3a529c-b227-4100-9272-ab66e0453332" />

### Test

1. Installing a macOS agent 
2. Follow the uninstallation guide of the agent https://documentation.wazuh.com/current/installation-guide/uninstalling-wazuh/agent.html#uninstalling-macos-agent
3. The agent must be deleted

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
