### PR TITLE
Upgrade `cross-spawn` and `dompurify`

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility_request.md
+++ b/.github/ISSUE_TEMPLATE/compatibility_request.md
@@ -4,19 +4,20 @@ about: Suggest supporting a new platform version (Elastic, OpenSearch)
 title: 'Compatibility with [Elastic | OpenSearch] (version)'
 labels: compatibility
 assignees: ''
-
 ---
 
 ## Description
+
 We need to ensure the UI compatibility with the next version of Elastic vX.X | OpenSearch vX.X.
 This update is still being discussed, but we need to be aware of potential issues.
 
 For that, we need to:
 
-- [ ] Review opensearch and opensearch-dashboard latest stable changelog. 
+- [ ] Review opensearch and opensearch-dashboard latest stable changelog.
 - [ ] Identify improvements and potential impact on the UI.
+- [ ] Check if any dependencies were upgraded and upgrade it in our plugins.
 - [ ] Develop a testing environment to verify our components would work under this new build.
 
-
 ## Issues
--  _List here the detected issues_
+
+- _List here the detected issues_

--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -15,7 +15,8 @@
   "license": "GPL-2.0",
   "resolutions": {
     "**/es5-ext": "^0.10.63",
-    "**/follow-redirects": "^1.15.6"
+    "**/follow-redirects": "^1.15.6",
+    "cross-spawn": "^7.0.5"
   },
   "repository": {
     "type": "git",
@@ -49,7 +50,7 @@
   },
   "dependencies": {
     "axios": "^1.7.4",
-    "dompurify": "^3.1.3",
+    "dompurify": "3.2.4",
     "install": "^0.13.0",
     "js2xmlparser": "^5.0.0",
     "jsdom": "^16.6.0",

--- a/plugins/main/yarn.lock
+++ b/plugins/main/yarn.lock
@@ -553,6 +553,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/tz-offset@*":
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@types/tz-offset/-/tz-offset-0.0.0.tgz#d58f1cebd794148d245420f8f0660305d320e565"
@@ -1212,10 +1217,10 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "^2.6.12"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -1454,10 +1459,12 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dompurify@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.4.tgz#42121304b2b3a6bae22f80131ff8a8f3f3c56be2"
-  integrity sha512-2gnshi6OshmuKil8rMZuQCGiUF3cUxHY3NGDzUAdUx/NPEe5DVnO8BDoAQouvgwnx0R/+a6jUn36Z0FSdq8vww==
+dompurify@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 duplexer2@~0.1.4:
   version "0.1.4"

--- a/plugins/wazuh-check-updates/package.json
+++ b/plugins/wazuh-check-updates/package.json
@@ -8,7 +8,8 @@
   "description": "Wazuh Check Updates",
   "private": true,
   "resolutions": {
-    "**/follow-redirects": "^1.15.6"
+    "**/follow-redirects": "^1.15.6",
+    "cross-spawn": "^7.0.5"
   },
   "scripts": {
     "build": "yarn plugin-helpers build --opensearch-dashboards-version=$OPENSEARCH_DASHBOARDS_VERSION",

--- a/plugins/wazuh-check-updates/yarn.lock
+++ b/plugins/wazuh-check-updates/yarn.lock
@@ -546,10 +546,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cross-spawn@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@^7.0.2, cross-spawn@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"

--- a/plugins/wazuh-core/package.json
+++ b/plugins/wazuh-core/package.json
@@ -8,7 +8,8 @@
   "description": "Wazuh Core",
   "private": true,
   "resolutions": {
-    "**/follow-redirects": "^1.15.6"
+    "**/follow-redirects": "^1.15.6",
+    "cross-spawn": "^7.0.5"
   },
   "scripts": {
     "build": "yarn plugin-helpers build --opensearch-dashboards-version=$OPENSEARCH_DASHBOARDS_VERSION",

--- a/plugins/wazuh-core/yarn.lock
+++ b/plugins/wazuh-core/yarn.lock
@@ -546,10 +546,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cross-spawn@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@^7.0.2, cross-spawn@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
### Description

This PR upgrades the `cross-spawn` and `dompurify` dependencies to match the versions in Opensearch Dashboards.

### Issues Resolved

#7428 

### Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
