### PR TITLE
Add back button to endpoints summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.12.2
+- Added back button to Deploy Agent page that redirects to Endpoints Summary [#7443](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7443)
 
 ## Wazuh v4.12.1 - OpenSearch Dashboards 2.19.1 - Revision 00
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
@@ -18,7 +18,10 @@ import { ErrorHandler } from '../../../../../react-services/error-management';
 import './register-agent.scss';
 import { Steps } from '../steps/steps';
 import { InputForm } from '../../../../common/form';
-import { getGroups, getMasterConfiguration } from '../../services/register-agent-services';
+import {
+  getGroups,
+  getMasterConfiguration,
+} from '../../services/register-agent-services';
 import { useForm } from '../../../../common/form/hooks';
 import { FormConfiguration } from '../../../../common/form/types';
 import { useSelector } from 'react-redux';
@@ -35,7 +38,12 @@ import { compose } from 'redux';
 import { endpointSummary } from '../../../../../utils/applications';
 import { getWazuhCorePlugin } from '../../../../../kibana-services';
 import { getErrorOrchestrator } from '../../../../../react-services/common-services';
-import { enableMenu, ip, nestedResolve, savedSearch } from '../../../../../services/resolves';
+import {
+  enableMenu,
+  ip,
+  nestedResolve,
+  savedSearch,
+} from '../../../../../services/resolves';
 import NavigationService from '../../../../../react-services/navigation-service';
 import { SECTIONS } from '../../../../../sections';
 
@@ -49,9 +57,13 @@ export const RegisterAgent = compose(
     },
     { text: 'Deploy new agent' },
   ]),
-  withUserAuthorizationPrompt([[{ action: 'agent:create', resource: '*:*:*' }]])
+  withUserAuthorizationPrompt([
+    [{ action: 'agent:create', resource: '*:*:*' }],
+  ]),
 )(() => {
-  const configuration = useSelector((state: { appConfig: { data: any } }) => state.appConfig.data);
+  const configuration = useSelector(
+    (state: { appConfig: { data: any } }) => state.appConfig.data,
+  );
   const [wazuhVersion, setWazuhVersion] = useState('');
   const [haveUdpProtocol, setHaveUdpProtocol] = useState<boolean | null>(false);
   const [loading, setLoading] = useState(false);
@@ -63,7 +75,7 @@ export const RegisterAgent = compose(
     operatingSystemSelection: {
       type: 'custom',
       initialValue: '',
-      component: (props) => {
+      component: props => {
         return <OsCard {...props} />;
       },
       options: {
@@ -73,7 +85,9 @@ export const RegisterAgent = compose(
     serverAddress: {
       type: 'text',
       initialValue: configuration['enrollment.dns'] || '',
-      validate: getWazuhCorePlugin().configuration._settings.get('enrollment.dns').validate,
+      validate:
+        getWazuhCorePlugin().configuration._settings.get('enrollment.dns')
+          .validate,
     },
     agentName: {
       type: 'text',
@@ -84,7 +98,7 @@ export const RegisterAgent = compose(
     agentGroups: {
       type: 'custom',
       initialValue: [],
-      component: (props) => {
+      component: props => {
         return <GroupInput {...props} />;
       },
       options: {
@@ -133,7 +147,9 @@ export const RegisterAgent = compose(
         const needsPassword = authConfig?.auth?.use_password === 'yes';
         if (needsPassword) {
           wazuhPassword =
-            configuration?.['enrollment.password'] || authConfig?.['authd.pass'] || '';
+            configuration?.['enrollment.password'] ||
+            authConfig?.['authd.pass'] ||
+            '';
         }
         const groups = await getGroups();
         setNeedsPassword(needsPassword);
@@ -163,7 +179,9 @@ export const RegisterAgent = compose(
     fetchData();
   }, []);
 
-  const osCard = <InputForm {...form.fields.operatingSystemSelection}></InputForm>;
+  const osCard = (
+    <InputForm {...form.fields.operatingSystemSelection}></InputForm>
+  );
 
   const goBackEndpointSummary = () => {
     NavigationService.getInstance().navigate(`/${SECTIONS.AGENTS_PREVIEW}`);
@@ -175,24 +193,27 @@ export const RegisterAgent = compose(
         <EuiPageBody>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiPanel className="register-agent-wizard-container">
+              <EuiPanel className='register-agent-wizard-container'>
                 <EuiFlexGroup>
                   <EuiFlexItem>
                     <EuiFlexGroup>
                       <EuiFlexItem grow={false} style={{ marginRight: 0 }}>
-                        <EuiToolTip position="right" content={`Back to Endpoints`}>
+                        <EuiToolTip
+                          position='right'
+                          content={`Back to Endpoints`}
+                        >
                           <EuiButtonIcon
-                            aria-label="Back"
+                            aria-label='Back'
                             style={{ marginTop: 4 }}
-                            color="primary"
-                            iconSize="l"
-                            iconType="arrowLeft"
+                            color='primary'
+                            iconSize='l'
+                            iconType='arrowLeft'
                             onClick={() => goBackEndpointSummary()}
                           />
                         </EuiToolTip>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiTitle size="s">
+                        <EuiTitle size='s'>
                           <h1>Deploy new agent</h1>
                         </EuiTitle>
                       </EuiFlexItem>
@@ -203,7 +224,7 @@ export const RegisterAgent = compose(
                 {loading ? (
                   <>
                     <EuiFlexItem>
-                      <EuiProgress size="xs" color="primary" />
+                      <EuiProgress size='xs' color='primary' />
                     </EuiFlexItem>
                     <EuiSpacer></EuiSpacer>
                   </>

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
@@ -8,6 +8,8 @@ import {
   EuiPageBody,
   EuiSpacer,
   EuiProgress,
+  EuiToolTip,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { WzRequest } from '../../../../../react-services/wz-request';
 import { UI_LOGGER_LEVELS } from '../../../../../../common/constants';
@@ -42,6 +44,8 @@ import {
   nestedResolve,
   savedSearch,
 } from '../../../../../services/resolves';
+import NavigationService from '../../../../../react-services/navigation-service';
+import { SECTIONS } from '../../../../../sections';
 
 export const RegisterAgent = compose(
   withErrorBoundary,
@@ -179,6 +183,10 @@ export const RegisterAgent = compose(
     <InputForm {...form.fields.operatingSystemSelection}></InputForm>
   );
 
+  const goBackEndpointSummary = () => {
+    NavigationService.getInstance().navigate(`/${SECTIONS.AGENTS_PREVIEW}`);
+  };
+
   return (
     <div>
       <EuiPage style={{ background: 'transparent' }}>
@@ -188,9 +196,25 @@ export const RegisterAgent = compose(
               <EuiPanel className='register-agent-wizard-container'>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    <EuiTitle size='s'>
-                      <h1>Deploy new agent</h1>
-                    </EuiTitle>
+                    <EuiFlexGroup>
+                      <EuiFlexItem grow={false} style={{ marginRight: 0 }}>
+                        <EuiToolTip position='right' content={`Back to Endpoints`}>
+                          <EuiButtonIcon
+                            aria-label='Back'
+                            style={{ marginTop: 4 }}
+                            color='primary'
+                            iconSize='l'
+                            iconType='arrowLeft'
+                            onClick={() => goBackEndpointSummary()}
+                          />
+                        </EuiToolTip>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiTitle size='s'>
+                          <h1>Deploy new agent</h1>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer />

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
@@ -18,10 +18,7 @@ import { ErrorHandler } from '../../../../../react-services/error-management';
 import './register-agent.scss';
 import { Steps } from '../steps/steps';
 import { InputForm } from '../../../../common/form';
-import {
-  getGroups,
-  getMasterConfiguration,
-} from '../../services/register-agent-services';
+import { getGroups, getMasterConfiguration } from '../../services/register-agent-services';
 import { useForm } from '../../../../common/form/hooks';
 import { FormConfiguration } from '../../../../common/form/types';
 import { useSelector } from 'react-redux';
@@ -38,12 +35,7 @@ import { compose } from 'redux';
 import { endpointSummary } from '../../../../../utils/applications';
 import { getWazuhCorePlugin } from '../../../../../kibana-services';
 import { getErrorOrchestrator } from '../../../../../react-services/common-services';
-import {
-  enableMenu,
-  ip,
-  nestedResolve,
-  savedSearch,
-} from '../../../../../services/resolves';
+import { enableMenu, ip, nestedResolve, savedSearch } from '../../../../../services/resolves';
 import NavigationService from '../../../../../react-services/navigation-service';
 import { SECTIONS } from '../../../../../sections';
 
@@ -57,13 +49,9 @@ export const RegisterAgent = compose(
     },
     { text: 'Deploy new agent' },
   ]),
-  withUserAuthorizationPrompt([
-    [{ action: 'agent:create', resource: '*:*:*' }],
-  ]),
+  withUserAuthorizationPrompt([[{ action: 'agent:create', resource: '*:*:*' }]])
 )(() => {
-  const configuration = useSelector(
-    (state: { appConfig: { data: any } }) => state.appConfig.data,
-  );
+  const configuration = useSelector((state: { appConfig: { data: any } }) => state.appConfig.data);
   const [wazuhVersion, setWazuhVersion] = useState('');
   const [haveUdpProtocol, setHaveUdpProtocol] = useState<boolean | null>(false);
   const [loading, setLoading] = useState(false);
@@ -75,7 +63,7 @@ export const RegisterAgent = compose(
     operatingSystemSelection: {
       type: 'custom',
       initialValue: '',
-      component: props => {
+      component: (props) => {
         return <OsCard {...props} />;
       },
       options: {
@@ -85,9 +73,7 @@ export const RegisterAgent = compose(
     serverAddress: {
       type: 'text',
       initialValue: configuration['enrollment.dns'] || '',
-      validate:
-        getWazuhCorePlugin().configuration._settings.get('enrollment.dns')
-          .validate,
+      validate: getWazuhCorePlugin().configuration._settings.get('enrollment.dns').validate,
     },
     agentName: {
       type: 'text',
@@ -98,7 +84,7 @@ export const RegisterAgent = compose(
     agentGroups: {
       type: 'custom',
       initialValue: [],
-      component: props => {
+      component: (props) => {
         return <GroupInput {...props} />;
       },
       options: {
@@ -147,9 +133,7 @@ export const RegisterAgent = compose(
         const needsPassword = authConfig?.auth?.use_password === 'yes';
         if (needsPassword) {
           wazuhPassword =
-            configuration?.['enrollment.password'] ||
-            authConfig?.['authd.pass'] ||
-            '';
+            configuration?.['enrollment.password'] || authConfig?.['authd.pass'] || '';
         }
         const groups = await getGroups();
         setNeedsPassword(needsPassword);
@@ -179,9 +163,7 @@ export const RegisterAgent = compose(
     fetchData();
   }, []);
 
-  const osCard = (
-    <InputForm {...form.fields.operatingSystemSelection}></InputForm>
-  );
+  const osCard = <InputForm {...form.fields.operatingSystemSelection}></InputForm>;
 
   const goBackEndpointSummary = () => {
     NavigationService.getInstance().navigate(`/${SECTIONS.AGENTS_PREVIEW}`);
@@ -193,24 +175,24 @@ export const RegisterAgent = compose(
         <EuiPageBody>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiPanel className='register-agent-wizard-container'>
+              <EuiPanel className="register-agent-wizard-container">
                 <EuiFlexGroup>
                   <EuiFlexItem>
                     <EuiFlexGroup>
                       <EuiFlexItem grow={false} style={{ marginRight: 0 }}>
-                        <EuiToolTip position='right' content={`Back to Endpoints`}>
+                        <EuiToolTip position="right" content={`Back to Endpoints`}>
                           <EuiButtonIcon
-                            aria-label='Back'
+                            aria-label="Back"
                             style={{ marginTop: 4 }}
-                            color='primary'
-                            iconSize='l'
-                            iconType='arrowLeft'
+                            color="primary"
+                            iconSize="l"
+                            iconType="arrowLeft"
                             onClick={() => goBackEndpointSummary()}
                           />
                         </EuiToolTip>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiTitle size='s'>
+                        <EuiTitle size="s">
                           <h1>Deploy new agent</h1>
                         </EuiTitle>
                       </EuiFlexItem>
@@ -221,7 +203,7 @@ export const RegisterAgent = compose(
                 {loading ? (
                   <>
                     <EuiFlexItem>
-                      <EuiProgress size='xs' color='primary' />
+                      <EuiProgress size="xs" color="primary" />
                     </EuiFlexItem>
                     <EuiSpacer></EuiSpacer>
                   </>


### PR DESCRIPTION
### Description

This PR implements a navigation button in the agent registration wizard (Deploy new agent) that allows users to return directly to the agent summary view (Endpoints Summary).

Changes:
- Added a button with an arrow icon to the top left of the agent log panel.
- The button always redirects the user to the agent summary view ( /agents-preview ).
- Implemented following the existing design pattern in other sections of the application.

Initially, the issue proposed adding a conditional button that would only appear when at least one agent was registered. However, after discussion with the team, it was decided that the button should always be present and consistently redirect to the agent summary view, regardless of browsing history or the number of registered agents. This provides a more predictable and consistent navigation experience for users.
 
### Issues Resolved
#7441

### Evidence

https://github.com/user-attachments/assets/259faca0-e8da-4ece-9892-56757d61f07d


### Test
- Navigate to /app/endpoints-summary#/agents-preview/deploy
- Click on Back button
- It must to redirect to /app/endpoints-summary#/agents-preview

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
