### PR TITLE
Fix wazuh.cluster.name field in sample data of IT Hygiene, FIM and vulnerabilites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added hardware and system information to the agent overview [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
 - Added settings to manage the FIM and IT Hygiene inventories data [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
 - Added persistence for selected columns and page size in data grid settings [#7379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7379)
-- Added the ability to manage the sample data from FIM, IT Higiene and vulnerabilities inventories and new settings to define the index names prefixes. [#7373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7373)
+- Added the ability to manage the sample data from FIM, IT Higiene and vulnerabilities inventories and new settings to define the index names prefixes. [#7373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7373) [7449](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7449)
 
 ## Changed
 

--- a/plugins/main/server/lib/sample-data/dataset/shared-utils.js
+++ b/plugins/main/server/lib/sample-data/dataset/shared-utils.js
@@ -33,7 +33,10 @@ function generateRandomAgent() {
 function generateRandomWazuh(params) {
   return {
     cluster: {
-      name: params?.cluster?.name || `wazuh-cluster-${random.int(0, 10)}`,
+      name:
+        params?.cluster?.name ||
+        params?.manager?.name ||
+        `wazuh-cluster-${random.int(0, 10)}`,
       node: params?.cluster?.node || `wazuh-cluster-node-${random.int(0, 10)}`,
     },
     schema: { version: '1.7.0' },


### PR DESCRIPTION
### Description
This pull request fixes the `wazuh.cluster.name` field is not set with the expected value when the server is in manager mode.
 
### Issues Resolved
#7369

### Evidence

### Test

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
