### PR TITLE
Restrict access to partial configuration information to read-only users

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
@@ -142,10 +142,7 @@ export const RegisterAgent = compose(
         let wazuhPassword = '';
         const needsPassword = authConfig?.auth?.use_password === 'yes';
         if (needsPassword) {
-          wazuhPassword =
-            configuration?.['enrollment.password'] ||
-            authConfig?.['authd.pass'] ||
-            '';
+          wazuhPassword = authConfig?.['authd.pass'] || '';
         }
         const groups = await getGroups();
         setNeedsPassword(needsPassword);

--- a/plugins/main/server/routes/wazuh-utils/wazuh-utils.test.ts
+++ b/plugins/main/server/routes/wazuh-utils/wazuh-utils.test.ts
@@ -413,10 +413,6 @@ describe.skip('[endpoint] PUT /utils/configuration', () => {
     ${'enrollment.dns'}                            | ${''}                                                            | ${200}             | ${null}
     ${'enrollment.dns'}                            | ${'test space'}                                                  | ${400}             | ${'[request body.enrollment.dns]: No whitespaces allowed.'}
     ${'enrollment.dns'}                            | ${true}                                                          | ${400}             | ${'[request body.enrollment.dns]: expected value of type [string] but got [boolean]'}
-    ${'enrollment.password'}                       | ${'test'}                                                        | ${200}             | ${null}
-    ${'enrollment.password'}                       | ${''}                                                            | ${400}             | ${'[request body.enrollment.password]: Value can not be empty.'}
-    ${'enrollment.password'}                       | ${'test space'}                                                  | ${200}             | ${null}
-    ${'enrollment.password'}                       | ${true}                                                          | ${400}             | ${'[request body.enrollment.password]: expected value of type [string] but got [boolean]'}
     ${'fim.pattern'}                               | ${'test'}                                                        | ${200}             | ${null}
     ${'fim.pattern'}                               | ${'test*'}                                                       | ${200}             | ${null}
     ${'fim.pattern'}                               | ${''}                                                            | ${400}             | ${'[request body.pattern]: Value can not be empty.'}

--- a/plugins/wazuh-core/common/constants.ts
+++ b/plugins/wazuh-core/common/constants.ts
@@ -1673,27 +1673,6 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
       SettingsValidator.serverAddressHostnameFQDNIPv4IPv6,
     ),
   },
-  'enrollment.password': {
-    title: 'Enrollment password',
-    description:
-      'Specifies the password used to authenticate during the agent enrollment.',
-    store: {
-      file: {
-        configurableManaged: true,
-      },
-    },
-    category: SettingCategory.GENERAL,
-    type: EpluginSettingType.text,
-    defaultValue: '',
-    isConfigurableFromSettings: false,
-    validateUIForm: function (value) {
-      return this.validate(value);
-    },
-    validate: SettingsValidator.compose(
-      SettingsValidator.isString,
-      SettingsValidator.isNotEmptyString,
-    ),
-  },
   'fim.pattern': {
     title: 'Index pattern',
     description: 'Default index pattern to use for file integrity monitoring.',

--- a/plugins/wazuh-core/common/plugin-settings.test.ts
+++ b/plugins/wazuh-core/common/plugin-settings.test.ts
@@ -138,9 +138,6 @@ describe('[settings] Input validation', () => {
     ${'enrollment.dns'}                            | ${'2001:0db8:85a3:0000:0000:8a2e:0370:7334:KL12'}                      | ${'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6'}
     ${'enrollment.dns'}                            | ${'example.'}                                                          | ${'It should be a valid hostname, FQDN, IPv4 or uncompressed IPv6'}
     ${'enrollment.dns'}                            | ${'127.0.0.1'}                                                         | ${undefined}
-    ${'enrollment.password'}                       | ${'test'}                                                              | ${undefined}
-    ${'enrollment.password'}                       | ${''}                                                                  | ${'Value can not be empty.'}
-    ${'enrollment.password'}                       | ${'test space'}                                                        | ${undefined}
     ${'fim.pattern'}                               | ${'test'}                                                              | ${undefined}
     ${'fim.pattern'}                               | ${'test*'}                                                             | ${undefined}
     ${'fim.pattern'}                               | ${''}                                                                  | ${'Value can not be empty.'}


### PR DESCRIPTION
### Description
In certain configurations, authenticated users with read-only API roles may retrieve agent enrollment credentials through the `/utils/configuration` endpoint. These credentials can be used to register new agents within the same Wazuh tenant without requiring elevated permissions through the UI.

Users with authenticated access and the appropriate RBAC profile may access the configuration API. This endpoint returns a JSON payload that includes the `enrollment.password` and `enrollment.dns` fields used to register agents.

Despite lacking `agent:create` permissions via the user interface, these credentials may be used manually to register additional agents via command-line or automation scripts.

Example of retrieved information by a read-only user:
<details> 
```json
{
    "statusCode": 200,
    "error": 0,
    "data": {
        "alerts.sample.prefix": "wazuh-alerts-4.x-",
        "checks.api": true,
        "checks.fields": true,
        "checks.maxBuckets": true,
        "checks.metaFields": true,
        "checks.pattern": true,
        "checks.setup": true,
        "checks.template": true,
        "checks.timeFilter": true,
        "configuration.ui_api_editable": true,
        "cron.prefix": "wazuh",
        "cron.statistics.apis": [],
        "cron.statistics.index.creation": "w",
        "cron.statistics.index.name": "statistics",
        "cron.statistics.index.replicas": 0,
        "cron.statistics.index.shards": 1,
        "cron.statistics.interval": "0 */5 * * * *",
        "cron.statistics.status": true,
        "customization.enabled": true,
        "customization.logo.app": "",
        "customization.logo.healthcheck": "",
        "customization.logo.reports": "",
        "customization.reports.footer": "",
        "customization.reports.header": "",
        "enrollment.dns": "192.168.1.142",
        "enrollment.password": "",
        "hideManagerAlerts": false,
        "ip.ignore": [],
        "ip.selector": true,
        "wazuh.updates.disabled": false,
        "pattern": "wazuh-alerts-*",
        "timeout": 20000,
        "reports.csv.maxRows": 10000,
        "wazuh.monitoring.creation": "w",
        "wazuh.monitoring.enabled": true,
        "wazuh.monitoring.frequency": 900,
        "wazuh.monitoring.pattern": "wazuh-monitoring-*",
        "wazuh.monitoring.replicas": 0,
        "wazuh.monitoring.shards": 1,
        "vulnerabilities.pattern": "wazuh-states-vulnerabilities-*"
    }
}
```
</details>

- Stops referencing or validating the enrollment password configuration by eliminating related code, tests, and constants. Simplifies agent registration flow to rely solely on the existing authentication method.
 
### Issues Resolved
[List any issues this PR will resolve]

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
