### PR TITLE
Fix some problems related to IT Hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.13.0
-- Added `It Hygiene` application [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
+- Added `It Hygiene` application [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368) [#7461](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7461)
 - Added hardware and system information to the agent overview [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
 - Added settings to manage the FIM and IT Hygiene inventories data [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
 - Added persistence for selected columns and page size in data grid settings [#7379](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7379)

--- a/plugins/main/public/components/common/hocs/with-index-pattern.tsx
+++ b/plugins/main/public/components/common/hocs/with-index-pattern.tsx
@@ -242,6 +242,12 @@ const fieldMappers = {
   // integer, remove thousands and decimals separator thorugh the params.pattern
   integer: ({ type }) =>
     type === 'number' ? { id: 'number', params: { pattern: '0' } } : undefined,
+  percent: ({ type }) => {
+    console.log({ type });
+    return type === 'number'
+      ? { id: 'percent', params: { pattern: '0,0.[00]%' } }
+      : undefined;
+  },
 };
 
 export function mapFieldsFormat(expectedFields: {
@@ -250,6 +256,7 @@ export function mapFieldsFormat(expectedFields: {
   return {
     mapSavedObjectAttributesCreation: ({ fields }) => {
       const fieldsToMap = Object.keys(expectedFields);
+      console.log({ fieldsToMap });
       const mappedFields = fields
         ?.filter(({ name }) => fieldsToMap.includes(name))
         .map(field => {

--- a/plugins/main/public/components/common/hocs/with-index-pattern.tsx
+++ b/plugins/main/public/components/common/hocs/with-index-pattern.tsx
@@ -243,7 +243,6 @@ const fieldMappers = {
   integer: ({ type }) =>
     type === 'number' ? { id: 'number', params: { pattern: '0' } } : undefined,
   percent: ({ type }) => {
-    console.log({ type });
     return type === 'number'
       ? { id: 'percent', params: { pattern: '0,0.[00]%' } }
       : undefined;
@@ -256,7 +255,6 @@ export function mapFieldsFormat(expectedFields: {
   return {
     mapSavedObjectAttributesCreation: ({ fields }) => {
       const fieldsToMap = Object.keys(expectedFields);
-      console.log({ fieldsToMap });
       const mappedFields = fields
         ?.filter(({ name }) => fieldsToMap.includes(name))
         .map(field => {

--- a/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
@@ -51,7 +51,7 @@ export const withSystemInventoryDataSource =
         'destination.port': 'integer',
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
-        'host.memory.used': 'percent',
+        'host.memory.used': 'bytes',
         'host.network.egress.bytes': 'bytes',
         'host.network.ingress.bytes': 'bytes',
         'package.size': 'bytes',
@@ -146,7 +146,7 @@ export const withSystemInventoryHardwareDataSource =
       mapFieldsFormat({
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
-        'host.memory.used': 'percent',
+        'host.memory.used': 'bytes',
       }),
     ),
     ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),

--- a/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
@@ -51,7 +51,6 @@ export const withSystemInventoryDataSource =
         'destination.port': 'integer',
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
-        'host.memory.used': 'bytes',
         'host.network.egress.bytes': 'bytes',
         'host.network.ingress.bytes': 'bytes',
         'package.size': 'bytes',
@@ -146,7 +145,6 @@ export const withSystemInventoryHardwareDataSource =
       mapFieldsFormat({
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
-        'host.memory.used': 'bytes',
       }),
     ),
     ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),

--- a/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
@@ -51,6 +51,7 @@ export const withSystemInventoryDataSource =
         'destination.port': 'integer',
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
+        'host.memory.used': 'percent',
         'host.network.egress.bytes': 'bytes',
         'host.network.ingress.bytes': 'bytes',
         'package.size': 'bytes',
@@ -145,6 +146,7 @@ export const withSystemInventoryHardwareDataSource =
       mapFieldsFormat({
         'host.memory.free': 'bytes',
         'host.memory.total': 'bytes',
+        'host.memory.used': 'percent',
       }),
     ),
     ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),

--- a/plugins/main/public/components/overview/it-hygiene/common/saved-vis/generators.ts
+++ b/plugins/main/public/components/overview/it-hygiene/common/saved-vis/generators.ts
@@ -358,3 +358,125 @@ export const getVisStateMetricFilterBy = (
     },
   };
 };
+
+export const getVisStateHistrogramBy = (
+  indexPatternId: string,
+  field: string,
+  title: string,
+  visIDPrefix: string,
+  interval: string = 'd',
+) => {
+  return {
+    id: `${visIDPrefix}-${field}`,
+    title: title,
+    type: 'area',
+    params: {
+      type: 'area',
+      grid: {
+        categoryLines: false,
+      },
+      categoryAxes: [
+        {
+          id: 'CategoryAxis-1',
+          type: 'category',
+          position: 'bottom',
+          show: true,
+          style: {},
+          scale: {
+            type: 'linear',
+          },
+          labels: {
+            show: true,
+            filter: true,
+            truncate: 100,
+          },
+          title: {},
+        },
+      ],
+      valueAxes: [
+        {
+          id: 'ValueAxis-1',
+          name: 'LeftAxis-1',
+          type: 'value',
+          position: 'left',
+          show: true,
+          style: {},
+          scale: {
+            type: 'linear',
+            mode: 'normal',
+          },
+          labels: {
+            show: true,
+            rotate: 0,
+            filter: false,
+            truncate: 100,
+          },
+          title: {
+            text: 'Count',
+          },
+        },
+      ],
+      seriesParams: [
+        {
+          show: true,
+          type: 'area',
+          mode: 'stacked',
+          data: {
+            label: 'Count',
+            id: '1',
+          },
+          drawLinesBetweenPoints: true,
+          lineWidth: 2,
+          showCircles: true,
+          interpolate: 'linear',
+          valueAxis: 'ValueAxis-1',
+        },
+      ],
+      addTooltip: true,
+      addLegend: true,
+      legendPosition: 'right',
+      times: [],
+      addTimeMarker: false,
+      thresholdLine: {
+        show: false,
+        value: 10,
+        width: 1,
+        style: 'full',
+        color: '#E7664C',
+      },
+      labels: {},
+    },
+    data: {
+      searchSource: createSearchSource(indexPatternId),
+      references: createIndexPatternReferences(indexPatternId),
+      aggs: [
+        {
+          id: '1',
+          enabled: true,
+          type: 'count',
+          params: {},
+          schema: 'metric',
+        },
+        {
+          id: '2',
+          enabled: true,
+          type: 'date_histogram',
+          params: {
+            field: field,
+            timeRange: {
+              from: 'now-24h',
+              to: 'now',
+            },
+            useNormalizedOpenSearchInterval: true,
+            scaleMetricValues: false,
+            interval: interval,
+            drop_partials: false,
+            min_doc_count: 1,
+            extended_bounds: {},
+          },
+          schema: 'segment',
+        },
+      ],
+    },
+  };
+};

--- a/plugins/main/public/components/overview/it-hygiene/dashboards/dashboard-kpi.ts
+++ b/plugins/main/public/components/overview/it-hygiene/dashboards/dashboard-kpi.ts
@@ -1,7 +1,7 @@
 import { DashboardPanelState } from '../../../../../../../../src/plugins/dashboard/public/application';
 import { EmbeddableInput } from '../../../../../../../../src/plugins/embeddable/public';
 import {
-  getVisStateDonutByField,
+  getVisStateHistrogramBy,
   getVisStateHorizontalBarByField,
 } from '../common/saved-vis/generators';
 
@@ -253,11 +253,12 @@ export const getDashboardKPIs = (
       type: 'visualization',
       explicitInput: {
         id: 's2',
-        savedVis: getVisStateDonutByField(
+        savedVis: getVisStateHistrogramBy(
           indexPatternId,
-          'process.state',
-          'Process state',
-          'it-hygiene-stat',
+          'process.start',
+          'Processes initiation',
+          'it-hygiene-processes',
+          'h',
         ),
       },
     },

--- a/plugins/main/public/components/overview/it-hygiene/networks/inventories/interfaces/dashboard.ts
+++ b/plugins/main/public/components/overview/it-hygiene/networks/inventories/interfaces/dashboard.ts
@@ -52,14 +52,24 @@ const getVisStateGlobalPacketLossMetric = (
               {\
                 \"script\": {\
                   \"source\": \" \
-                    double d=(doc['host.network.ingress.drops'].size() != 0 ? doc['host.network.ingress.drops'].value : 0) \
-                      + (doc['host.network.egress.drops'].size() != 0 ? doc['host.network.egress.drops'].value : 0); \
-                    double p=(doc['host.network.ingress.packets'].size() != 0 ? doc['host.network.ingress.packets'].value : 0) \
-                      + (doc['host.network.egress.packets'].size() != 0 ? doc['host.network.egress.packets'].value : 0); \
-                    return p == 0 ? 0 : (d/p);\", \
+                    float in_drops=(doc['host.network.ingress.drops'].size() != 0 ? doc['host.network.ingress.drops'].value : 0); \
+                    float in_errors=(doc['host.network.ingress.errors'].size() != 0 ? doc['host.network.ingress.errors'].value : 0); \
+                    float in_packets=(doc['host.network.ingress.packets'].size() != 0 ? doc['host.network.ingress.packets'].value : 0); \
+                    float out_drops=(doc['host.network.egress.drops'].size() != 0 ? doc['host.network.egress.drops'].value : 0); \
+                    float out_errors=(doc['host.network.egress.errors'].size() != 0 ? doc['host.network.egress.errors'].value : 0); \
+                    float out_packets=(doc['host.network.egress.packets'].size() != 0 ? doc['host.network.egress.packets'].value : 0); \
+                    float d=(in_drops + out_drops); \
+                    float p=(in_drops + in_errors + in_packets + out_drops + out_errors + out_packets); \
+                    return p == 0 ? 0 : Math.round((d/p)*100*100);\", \
                   \"lang\": \"painless\" \
                 }\
-              }",
+              }" /*
+                The total packets is the sum of: packets, drops and erros.
+                The result is multiplied by:
+                - 100 to convert the value (d/p) to percent (%)
+                WORKAROUND: multiply 100 to equilibrate the division by 100 done when the `isPercentMode` is true
+              */,
+
             customLabel: 'Global packet loss rate',
           },
           schema: 'metric',

--- a/plugins/main/public/components/overview/it-hygiene/packages/inventories/packages/managed-filters.ts
+++ b/plugins/main/public/components/overview/it-hygiene/packages/inventories/packages/managed-filters.ts
@@ -14,9 +14,4 @@ export default [
     key: 'package.version',
     placeholder: 'Version',
   },
-  {
-    type: 'multiSelect',
-    key: 'package.architecture',
-    placeholder: 'Architecture',
-  },
 ];

--- a/plugins/main/public/components/overview/it-hygiene/packages/inventories/packages/table-columns.ts
+++ b/plugins/main/public/components/overview/it-hygiene/packages/inventories/packages/table-columns.ts
@@ -3,6 +3,5 @@ export default [
   { id: 'package.vendor' },
   { id: 'package.name' },
   { id: 'package.version' },
-  { id: 'package.architecture' },
   { id: 'package.description' },
 ];

--- a/plugins/main/public/components/overview/it-hygiene/processes/inventories/processes/dashboard.ts
+++ b/plugins/main/public/components/overview/it-hygiene/processes/inventories/processes/dashboard.ts
@@ -4,7 +4,10 @@ import {
   createIndexPatternReferences,
   createSearchSource,
 } from '../../../common/saved-vis/create-saved-vis-data';
-import { getVisStateHorizontalBarByField } from '../../../common/saved-vis/generators';
+import {
+  getVisStateHistrogramBy,
+  getVisStateHorizontalBarByField,
+} from '../../../common/saved-vis/generators';
 import { SavedVis } from '../../../common/types';
 
 type ProcessState =
@@ -84,15 +87,15 @@ export const getOverviewProcessesProcessesTab = (indexPatternId: string) => {
       indexPatternId,
       'process.name',
       'Top 5 processes',
-      'it-hygiene-packages',
+      'it-hygiene-processes',
       'Processes',
     ),
-    getVisStateHorizontalBarByField(
+    getVisStateHistrogramBy(
       indexPatternId,
-      'process.state',
-      'States',
-      'it-hygiene-packages',
-      'States',
+      'process.start',
+      'Processes initiation',
+      'it-hygiene-processes',
+      'h',
     ),
   ]);
 };

--- a/plugins/main/public/components/overview/it-hygiene/system/inventories/hardware/inventory.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/system/inventories/hardware/inventory.tsx
@@ -19,6 +19,7 @@ export const ITHygieneSystemInventoryHardware =
         }
         tableDefaultColumns={tableColumns}
         managedFilters={managedFilters}
+        managedFiltersProps={{ style: { flexGrow: 0.25, minWidth: '300px' } }}
         getDashboardPanels={getOverviewSystemHardwareTab}
         tableId='it-hygiene-inventory-hardware'
         indexPattern={props.indexPattern}

--- a/plugins/main/public/components/overview/it-hygiene/system/inventories/hardware/managed-filters.ts
+++ b/plugins/main/public/components/overview/it-hygiene/system/inventories/hardware/managed-filters.ts
@@ -4,9 +4,4 @@ export default [
     key: 'host.cpu.name',
     placeholder: 'CPU name',
   },
-  {
-    type: 'multiSelect',
-    key: 'agent.host.architecture',
-    placeholder: 'Architecture',
-  },
 ];


### PR DESCRIPTION
### Description
This pull request 

# Changes
- Remove Arhitecture selector from System > Hardware
- Remove `package.architecture` as default column in Packages > Packages
- Replace States viualization ain IT Hygiene > Dashboard and Processes > Processses
- Fix visualization of Global packets loss rate

### Issues Resolved
#7450

### Evidence
![image](https://github.com/user-attachments/assets/f142b596-f166-4601-90e4-c6e1dee45812)
![image](https://github.com/user-attachments/assets/b803d80c-0252-4e3d-89e7-e86a2d8ccd10)
![image](https://github.com/user-attachments/assets/381f8f86-4a81-427b-915f-d4cf78ab97e2)
![image](https://github.com/user-attachments/assets/a13ecc63-4d68-4e52-8563-847169f1e6a3)
![image](https://github.com/user-attachments/assets/91781c5d-3f90-4425-9462-fbd62b7faf21)

### Test

# wdp-pr-7461

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Ensure there is no Arhitecture selector in System > Hardware | :black_circle: | :black_circle: | :black_circle: |
| Ensure the package.architecture field is not set as default column in of the table in Packages > Packages | :black_circle: | :black_circle: | :black_circle: |
| Ensure the visualization of Global packets loss rate represents the expected value and has no too much decimals | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Ensure there is no Arhitecture selector in System > Hardware


</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Ensure the package.architecture field is not set as default column in of the table in Packages > Packages</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Ensure the visualization of Global packets loss rate represents the expected value and has no too much decimals</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
