### PR TITLE
Global Queries - Fields refinement

### DIFF
--- a/plugins/main/public/components/overview/it-hygiene/networks/inventories/networks/managed-filters.ts
+++ b/plugins/main/public/components/overview/it-hygiene/networks/inventories/networks/managed-filters.ts
@@ -1,7 +1,7 @@
 export default [
   {
     type: 'multiSelect',
-    key: 'network.name',
+    key: 'interface.name',
     placeholder: 'Name',
   },
   {

--- a/plugins/main/public/components/overview/it-hygiene/networks/inventories/networks/table-columns.ts
+++ b/plugins/main/public/components/overview/it-hygiene/networks/inventories/networks/table-columns.ts
@@ -1,6 +1,6 @@
 export default [
   { id: 'agent.name' },
-  { id: 'network.name' },
+  { id: 'interface.name' },
   { id: 'agent.host.ip' },
   { id: 'network.netmask' },
   { id: 'network.protocol' },

--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-networks/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-networks/main.js
@@ -1,19 +1,20 @@
 const random = require('../../lib/random');
 const { generateRandomAgent, generateRandomWazuh } = require('../shared-utils');
 
-function generateRandomInterface() {
-  return `name${random.int(0, 9999)}`;
-}
-
 function generateRandomNetwork() {
   return {
     broadcast: random.ip(),
     dhcp: random.boolean(),
     ip: random.ip(),
     metric: random.int(1, 100),
-    name: generateRandomInterface(),
     netmask: random.ip(),
     protocol: random.choice(['TCP', 'UDP', 'ICMP']),
+  };
+}
+
+function generateRandomInterface() {
+  return {
+    name: `name${random.int(0, 9999)}`,
   };
 }
 
@@ -23,6 +24,7 @@ function generateDocument(params) {
     '@timestamp': random.date(),
     agent: generateRandomAgent(),
     network: generateRandomNetwork(),
+    interface: generateRandomInterface(),
     wazuh: generateRandomWazuh(params),
   };
 }

--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-networks/template.json
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-networks/template.json
@@ -6,7 +6,7 @@
       "index": {
         "number_of_replicas": "0",
         "number_of_shards": "1",
-        "query.default_field": ["network.ip", "network.name"],
+        "query.default_field": ["network.ip", "interface.name"],
         "refresh_interval": "5s"
       }
     },
@@ -44,6 +44,14 @@
             }
           }
         },
+        "interface": {
+          "properties": {
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "network": {
           "properties": {
             "broadcast": {
@@ -57,10 +65,6 @@
             },
             "metric": {
               "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "netmask": {
               "type": "ip"


### PR DESCRIPTION
### Description
In relation to the [latest test](https://github.com/wazuh/wazuh/issues/27894) of Global Queries, some improvements need to be done in the fields ingested. We need to reflect these changes Wazuh dashboard fields analyzed.

Indexer issue:
- https://github.com/wazuh/wazuh-indexer/issues/849

Tasks:
- Unifies naming by moving the 'name' field from the network object to the interface object across filters, table columns, data generation, and mappings. Improves data consistency and aligns structure with typical network-interface relationships.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7474

### Evidence

- The `network.name` in networks is to be replaced with `interface.name`.
![image](https://github.com/user-attachments/assets/23e1a13c-95cf-4647-bc54-d3087ddb4bdd)

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
