### PR TITLE
Add --tag functionality

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -14,6 +14,7 @@ VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 STAGE=""
 REVISION="00"
+TAG=false
 CURRENT_VERSION=""
 CURRENT_MAJOR_MINOR=""
 NEW_MAJOR_MINOR=""
@@ -34,16 +35,23 @@ log() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo "Usage: $0 [--version VERSION --stage STAGE | --tag] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
+  echo "                      Required if --tag is not used"
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
+  echo "                      Required if --tag is not used"
+  echo "  --tag               Generate a tag"
+  echo "                      If --stage is not set, it will be stageless(e.g., v4.6.0)"
+  echo "                      Otherwise it will be with the provided stage (e.g., v4.6.0-alpha1)"
+  echo "                      If this is set, --version and --stage are not required."
   echo "  --help              Display this help message"
   echo ""
-  echo "Example:"
+  echo "Examples:"
   echo "  $0 --version 4.6.0 --stage alpha0"
-  echo "  $0 --version 4.6.0 --stage beta1"
+  echo "  $0 --tag --stage alpha1"
+  echo "  $0 --tag"
 }
 
 # Function to update JSON file using sed
@@ -138,20 +146,29 @@ update_imposter_config() {
     return
   fi
 
-  # Read the current version from specFile
-  local current_spec_version
-  current_spec_version=$(grep -oE 'specFile: https://raw.githubusercontent.com/wazuh/wazuh/[0-9]+\.[0-9]+\.[0-9]+' "$imposter_config_file" | sed -E 's/.*wazuh\/([0-9]+\.[0-9]+\.[0-9]+)$/\1/' | head -n1)
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
 
-  if [ "$current_spec_version" = "$new_version" ]; then
-    # If the version is already correct, do nothing and don't report
+# Extract current reference from URL
+  local current_spec_ref
+  current_spec_ref=$(grep -oE 'specFile: https://raw.githubusercontent.com/wazuh/wazuh/[^/]+/' "$imposter_config_file" | sed -E 's|.*/wazuh/([^/]+)/.*|\1|' | head -n1)
+
+  if [ "$current_spec_ref" = "$replacement" ]; then
     return
   fi
 
   log "Updating specFile URL in $imposter_config_file to version $new_version"
 
   # Use sed to replace the version string within the specFile URL
-  # This regex targets the version part (e.g., 4.13.0) in the specific URL structure
-  sed -i -E "s|(specFile: https://raw.githubusercontent.com/wazuh/wazuh/)[0-9]+\.[0-9]+\.[0-9]+(.*)|\1${new_version}\2|" "$imposter_config_file" && log "Successfully updated specFile URL in $imposter_config_file" || {
+ sed -i -E "s|(specFile: https://raw.githubusercontent.com/wazuh/wazuh/)[^/]+|\1${replacement}|" "$imposter_config_file" && \
+    log "Successfully updated specFile URL in $imposter_config_file" || {
     log "ERROR: Failed to update specFile URL in $imposter_config_file using sed."
     exit 1
   }
@@ -175,6 +192,10 @@ parse_arguments() {
       usage
       exit 0
       ;;
+      --tag)
+      TAG=true
+      shift
+  ;;
     *)
       log "ERROR: Unknown option: $1" # Log error instead of just echo
       usage
@@ -186,21 +207,24 @@ parse_arguments() {
 
 # Function to validate input parameters
 validate_input() {
-  if [ -z "$VERSION" ]; then
-    log "ERROR: Version parameter is required"
+   if [ -z "$VERSION" ] && [ "$TAG" != true ]; then
+    log "ERROR: --version is required unless --tag is set"
     usage
     exit 1
   fi
-  if [ -z "$STAGE" ]; then
-    log "ERROR: Stage parameter is required"
+
+  if [ -z "$STAGE" ] && [ "$TAG" != true ]; then
+    log "ERROR: --stage is required unless --tag is set"
     usage
     exit 1
   fi
-  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+
+  if [ -n "$VERSION" ] && ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
     exit 1
   fi
-  if ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
+
+  if [ -n "$STAGE" ] && ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
     log "ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)"
     exit 1
   fi
@@ -276,26 +300,29 @@ compare_versions_and_set_revision() {
         REVISION="00" # Reset revision on patch increase
       else
         # Versions are identical (Major, Minor, Patch are equal)
-        log "New version ($VERSION) is identical to current version ($CURRENT_VERSION). Incrementing revision."
-        local main_package_json="${REPO_PATH}/plugins/main/package.json" # Need path again
-        log "Attempting to extract current revision from $main_package_json using sed (Note: This is fragile)"
-        local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$main_package_json" | head -n 1)
-        # Check if sed successfully extracted a revision
-        if [ -z "$current_revision_val" ]; then
-          log "ERROR: Failed to extract 'revision' from $main_package_json using sed. Check file format or key presence."
-          exit 1 # Exit if sed fails
+        log "New version ($VERSION) is identical to current version ($CURRENT_VERSION)"
+        if [ -n "$STAGE" ]; then
+          log "Incrementing revision."
+          local main_package_json="${REPO_PATH}/plugins/main/package.json" # Need path again
+          log "Attempting to extract current revision from $main_package_json using sed (Note: This is fragile)"
+          local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$main_package_json" | head -n 1)
+          # Check if sed successfully extracted a revision
+          if [ -z "$current_revision_val" ]; then
+            log "ERROR: Failed to extract 'revision' from $main_package_json using sed. Check file format or key presence."
+            exit 1 # Exit if sed fails
+          fi
+          log "Successfully extracted revision using sed: $current_revision_val"
+          if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
+            log "ERROR: Could not read current revision from $main_package_json"
+            exit 1
+          fi
+          # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
+          local current_revision_int=$((10#$current_revision_val))
+          local new_revision_int=$((current_revision_int + 1))
+          # Format back to two digits with leading zero
+          REVISION=$(printf "%02d" "$new_revision_int")
+          log "Current revision: $current_revision_val. New revision set to: $REVISION"
         fi
-        log "Successfully extracted revision using sed: $current_revision_val"
-        if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
-          log "ERROR: Could not read current revision from $main_package_json"
-          exit 1
-        fi
-        # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
-        local current_revision_int=$((10#$current_revision_val))
-        local new_revision_int=$((current_revision_int + 1))
-        # Format back to two digits with leading zero
-        REVISION=$(printf "%02d" "$new_revision_int")
-        log "Current revision: $current_revision_val. New revision set to: $REVISION"
       fi
     fi
   fi
@@ -306,8 +333,12 @@ compare_versions_and_set_revision() {
 update_root_version_json() {
   if [ -f "$VERSION_FILE" ]; then
     log "Processing $VERSION_FILE"
-    update_json "$VERSION_FILE" "version" "$VERSION"
-    update_json "$VERSION_FILE" "stage" "$STAGE"
+    if [ -n "$VERSION" ]; then
+      update_json "$VERSION_FILE" "version" "$VERSION"
+    fi
+    if [ -n "$STAGE" ]; then
+      update_json "$VERSION_FILE" "stage" "$STAGE"
+    fi
   else
     log "WARNING: $VERSION_FILE not found. Skipping update."
   fi
@@ -377,13 +408,15 @@ update_changelog() {
 
   # Check if an entry for this version and OpenSearch version already exists
   if grep -qE "$changelog_header_regex" "$changelog_file"; then
-    log "Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only."
-    # Use sed to update only the revision number in the header
-    sed -i -E "s|(${changelog_header_regex})|## Wazuh v${VERSION} - OpenSearch Dashboards ${OPENSEARCH_VERSION} - Revision ${REVISION}|" "$changelog_file" &&
+    if [ -n "$STAGE" ]; then
+      log "Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only."
+      # Use sed to update only the revision number in the header
+      sed -i -E "s|(${changelog_header_regex})|## Wazuh v${VERSION} - OpenSearch Dashboards ${OPENSEARCH_VERSION} - Revision ${REVISION}|" "$changelog_file" &&
       log "CHANGELOG.md revision updated successfully." || {
       log "ERROR: Failed to update revision in $changelog_file"
       exit 1
-    }
+      }
+    fi
   else
     log "No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry."
     local new_entry
@@ -428,6 +461,9 @@ main() {
   # Perform pre-update checks
   pre_update_checks
 
+  if [ -z "$VERSION" ]; then
+    VERSION=$CURRENT_VERSION # If no version provided, use current version
+  fi
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
@@ -451,7 +487,7 @@ main() {
   update_changelog
 
   # Conditionally update endpoints.json
-  if [ "$CURRENT_MAJOR_MINOR" != "$NEW_MAJOR_MINOR" ]; then
+  if [  [ -n "$VERSION" ] && ["$CURRENT_MAJOR_MINOR" != "$NEW_MAJOR_MINOR"] ]; then
     log "Major.minor version changed ($CURRENT_MAJOR_MINOR -> $NEW_MAJOR_MINOR). Updating endpoints.json..."
     update_endpoints_json "$CURRENT_MAJOR_MINOR" "$NEW_MAJOR_MINOR"
   else


### PR DESCRIPTION
### Description

This PR adds support for a stageless bump with the repository bumper script. This option will be enabled with the `--tag` flag. The previous functionality of the script should still work if the new flag is not set.

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard/issues/694

### Evidence
<details><summary>Version parameter is required</summary>

```console
# ./repository_bumper.sh --stage alpha1
[2025-06-04 15:26:23] Starting repository bump process
[2025-06-04 15:26:23] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:26:23] ERROR: --version is required unless --tag is set
Usage: ./repository_bumper.sh [--version VERSION --stage STAGE | --tag] [--help]

Parameters:
  --version VERSION   Specify the version (e.g., 4.6.0)
                      Required if --tag is not used
  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)
                      Required if --tag is not used
  --tag               Generate a tag
                      If --stage is not set, it will be stageless(e.g., v4.6.0)
                      Otherwise it will be with the provided stage (e.g., v4.6.0-alpha1)
                      If this is set, --version and --stage are not required.
  --help              Display this help message

Examples:
  ./repository_bumper.sh --version 4.6.0 --stage alpha0
  ./repository_bumper.sh --tag --stage alpha1
  ./repository_bumper.sh --tag
```


</details> 

<details><summary>Stage parameter is required</summary>


```console
# ./repository_bumper.sh --version 4.13.1
[2025-06-04 15:28:07] Starting repository bump process
[2025-06-04 15:28:07] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:28:07] ERROR: --stage is required unless --tag is set
Usage: ./repository_bumper.sh [--version VERSION --stage STAGE | --tag] [--help]

Parameters:
  --version VERSION   Specify the version (e.g., 4.6.0)
                      Required if --tag is not used
  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)
                      Required if --tag is not used
  --tag               Generate a tag
                      If --stage is not set, it will be stageless(e.g., v4.6.0)
                      Otherwise it will be with the provided stage (e.g., v4.6.0-alpha1)
                      If this is set, --version and --stage are not required.
  --help              Display this help message

Examples:
  ./repository_bumper.sh --version 4.6.0 --stage alpha0
  ./repository_bumper.sh --tag --stage alpha1
  ./repository_bumper.sh --tag
```



</details> 

<details><summary>Version must be in the format x.y.z (e.g., 4.6.0)</summary>


```console
# ./repository_bumper.sh --version 4.13.1.2 --stage alpha1
[2025-06-04 15:28:23] Starting repository bump process
[2025-06-04 15:28:23] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:28:23] ERROR: Version must be in the format x.y.z (e.g., 4.6.0)
```



</details> 

<details><summary>Stage must be alphanumeric (e.g., alpha0, beta1, rc2)</summary>


```console
# ./repository_bumper.sh --version 4.13.1 --stage alpha
[2025-06-04 15:28:39] Starting repository bump process
[2025-06-04 15:28:39] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:28:39] ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)
```


</details> 

<details><summary>New major version (2) cannot be lower than current major version (4).</summary>


```console
# ./repository_bumper.sh --version 3.13.1 --stage alpha1
[2025-06-04 15:28:51] Starting repository bump process
[2025-06-04 15:28:51] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:28:51] Version: 3.13.1
[2025-06-04 15:28:51] Stage: alpha1
[2025-06-04 15:28:51] Attempting to extract current version from /home/user/wazuh-dashboard-plugins/VERSION.json using sed...
[2025-06-04 15:28:51] Successfully extracted version using sed: 4.13.0
[2025-06-04 15:28:51] Current version detected in VERSION.json: 4.13.0
[2025-06-04 15:28:51] Current major.minor: 4.13
[2025-06-04 15:28:51] New major.minor: 3.13
[2025-06-04 15:28:51] Default revision set to: 00
[2025-06-04 15:28:51] Comparing new version (3.13.1) with current version (4.13.0)...
[2025-06-04 15:28:51] ERROR: New major version (3) cannot be lower than current major version (4).

```


</details> 

<details><summary>New minor version (12) cannot be lower than current minor version (13) when major versions are the same.</summary>


```console
# ./repository_bumper.sh --version 4.11.1 --stage alpha1
[2025-06-04 15:29:02] Starting repository bump process
[2025-06-04 15:29:02] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:29:02] Version: 4.11.1
[2025-06-04 15:29:02] Stage: alpha1
[2025-06-04 15:29:02] Attempting to extract current version from /home/user/wazuh-dashboard-plugins/VERSION.json using sed...
[2025-06-04 15:29:02] Successfully extracted version using sed: 4.13.0
[2025-06-04 15:29:02] Current version detected in VERSION.json: 4.13.0
[2025-06-04 15:29:02] Current major.minor: 4.13
[2025-06-04 15:29:02] New major.minor: 4.11
[2025-06-04 15:29:02] Default revision set to: 00
[2025-06-04 15:29:02] Comparing new version (4.11.1) with current version (4.13.0)...
[2025-06-04 15:29:02] ERROR: New minor version (11) cannot be lower than current minor version (13) when major versions are the same.
```


</details> 

<details><summary>New patch version (0) cannot be lower than current patch version (1) when major and minor versions are the same.</summary>


```console
# ./repository_bumper.sh --version 4.13.0 --stage alpha1
[2025-06-04 15:29:36] Starting repository bump process
[2025-06-04 15:29:36] Repository path: /home/user/wazuh-dashboard-plugins
[2025-06-04 15:29:36] Version: 4.13.0
[2025-06-04 15:29:36] Stage: alpha1
[2025-06-04 15:29:36] Attempting to extract current version from /home/user/wazuh-dashboard-plugins/VERSION.json using sed...
[2025-06-04 15:29:36] Successfully extracted version using sed: 4.13.1
[2025-06-04 15:29:36] Current version detected in VERSION.json: 4.13.1
[2025-06-04 15:29:36] Current major.minor: 4.13
[2025-06-04 15:29:36] New major.minor: 4.13
[2025-06-04 15:29:36] Default revision set to: 00
[2025-06-04 15:29:36] Comparing new version (4.13.0) with current version (4.13.1)...
[2025-06-04 15:29:36] ERROR: New patch version (0) cannot be lower than current patch version (1) when major and minor versions are the same.
```


</details> 

<details><summary>The repository bumper script should log its actions to a log file named `repository_bumper_{date_time}.log`, where `date_time` is the timestamp when the script is executed. For example: `repository_bumper_2025-04-04_18-47-04-670.log` and the log file will be located in the same path as the script.</summary>





</details> 

<details><summary>When keeping the same version, only the revision should be modified. The repository bumper should report each file that is modified.</summary>


![image](https://github.com/user-attachments/assets/2293d308-11f8-4671-9a98-232079d1c859)
![image](https://github.com/user-attachments/assets/4420c441-bc3a-45e9-9257-be9694e187c9)
![image](https://github.com/user-attachments/assets/25d9093d-ec1f-4520-8232-baeabd7efbc8)
![image](https://github.com/user-attachments/assets/dfaac088-0b03-4a7f-9d76-d173fba660d7)
![image](https://github.com/user-attachments/assets/4c5c97dc-f384-4b20-94c5-cca8dd7609d3)
![image](https://github.com/user-attachments/assets/4b482295-24e7-4d61-8944-5dffdbd81865)
![image](https://github.com/user-attachments/assets/de422dc3-c40b-447e-bf09-1046d7eb0110)

</details> 

<details><summary>When you keep the version but change the Stage, only the revision should be modified in corresponding files and the Stage in VERSION.json.</summary>


![image](https://github.com/user-attachments/assets/d0dc167e-d4d3-49da-82ef-1e95dd17070a)
![image](https://github.com/user-attachments/assets/1758a321-6f36-4999-b797-3ab7eaff6f9e)
![image](https://github.com/user-attachments/assets/fb86373e-699c-47c1-805c-2af12cd82730)
![image](https://github.com/user-attachments/assets/cd6ea6ba-0600-434a-8570-26589d9cf44a)
![image](https://github.com/user-attachments/assets/208d7a6b-1c3b-4318-b1d3-1e3a76891c4d)
![image](https://github.com/user-attachments/assets/c0a52ec9-153c-4fcf-8239-cc0a48aea776)
![image](https://github.com/user-attachments/assets/15f1c525-0d53-424b-9297-a4260c5947a0)
![image](https://github.com/user-attachments/assets/7ee024d4-19d2-4738-a219-bee9e5ff47b5)


</details> 

<details><summary>When changing the version, specifically the patch version, only the corresponding files should be updated and the revision should be set to zero. And a new entry should be added to the CHANGELOG, with the new version and the revision set to zero.</summary>


![image](https://github.com/user-attachments/assets/f4f3e2da-1ef8-4bbc-9a8e-c3388327ca85)
![image](https://github.com/user-attachments/assets/cdf62396-5d9d-4e33-a335-45ccb796acbe)
![image](https://github.com/user-attachments/assets/b70fdf4b-7f44-4c8a-819b-f8632df63dab)
![image](https://github.com/user-attachments/assets/cf90967f-5e7a-4233-b317-a5de14666ace)
![image](https://github.com/user-attachments/assets/09f744a2-209b-4e3d-a5d1-1a497b1517af)
![image](https://github.com/user-attachments/assets/0bdd06b2-1d5e-4b7f-9d43-7fe85276f3e4)
![image](https://github.com/user-attachments/assets/fc06743e-c2af-4d4f-8acd-29a0c41accb8)
![image](https://github.com/user-attachments/assets/0a6d92fb-961b-49cb-8987-dd1cc8a3f8c3)
![image](https://github.com/user-attachments/assets/dbf8f306-9335-41c8-9355-aedf820627b9)




</details> 

<details><summary>When changing the version, especially the minor version, all corresponding files should be updated, including endpoints.json located at (plugins/main/common/api-info/endpoints.json), and the revision should be set to zero.</summary>

![image](https://github.com/user-attachments/assets/73a8bbb5-a20c-41f5-bd58-a362219fd296)
![image](https://github.com/user-attachments/assets/537eb54f-f9b9-4c5c-bf9c-b7cb2851f010)
![image](https://github.com/user-attachments/assets/f629f30e-3082-422a-ba5b-828f7bf62174)
![image](https://github.com/user-attachments/assets/899ebb5f-e34c-476e-b39c-57fbea3139fc)
![image](https://github.com/user-attachments/assets/208c6afa-7132-4d39-8e51-43e24b8e0144)
![image](https://github.com/user-attachments/assets/b5442acd-f46e-426f-932a-1f5a55896085)
![image](https://github.com/user-attachments/assets/131a5d44-332a-4edd-9417-c7baa483f696)
![image](https://github.com/user-attachments/assets/c9f9d533-0fc1-4d12-8f82-01ed2f549001)
![image](https://github.com/user-attachments/assets/d0948ae7-0607-4c70-a961-93fa0099ecde)



</details> 

<details>
<summary>When only `--tag` is set, only `docker/imposter/wazuh-config.yml` should be modified to reference a tag</summary>

```console
# ./repository_bumper.sh --tag
```

![image](https://github.com/user-attachments/assets/e5c53dbf-8bbe-4bbb-a78b-2a79cd3e703f)

</details>

<details>
<summary>When  `--tag` is set together with a `--stage`, all the required files should be updated and  `docker/imposter/wazuh-config.yml` should be modified to reference a tag</summary>

```console
# ./repository_bumper.sh --tag --stage alpha1
```

![image](https://github.com/user-attachments/assets/f715c72a-97c6-48d0-90f4-3311ecd489b8)


</details>


<details>
<summary>When  `--tag` is set together with a `--version`, all the required files should be updated and `docker/imposter/wazuh-config.yml` should be modified to reference a tag</summary>

```console
# ./repository_bumper.sh --tag --version 4.13.1 
```

![image](https://github.com/user-attachments/assets/b8749e20-4664-46a7-805b-c0561d34cb79)

</details>

<details>
<summary>When  `--tag` is set together with a `--version` and `--stage`, all the required files should be updated and  `docker/imposter/wazuh-config.yml` should be modified to reference a tag</summary>

```console
# ./repository_bumper.sh --tag --version 4.13.1 --stage alpha1
```

![image](https://github.com/user-attachments/assets/7b1112de-9dee-4dd9-9888-080d7f089362)

</details>

<details>
<summary>When  `--tag` is not set `docker/imposter/wazuh-config.yml` should NOT reference a tag, but a numbered branch</summary>

```console
# ./repository_bumper.sh --version 4.13.1 --stage alpha1
```

![image](https://github.com/user-attachments/assets/ef32bd81-d66a-438e-af90-93646ec36386)

</details>



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
