### PR TITLE
Fix rule details flyout to show all compliances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed a problem in Vulnerabilities > Dashboard and Inventory when there are no indices matching with the index pattern [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
-- Fixed a bug in Rule details flyout > It didn't map all the compliances [#7501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7501)
+- Fixed a bug in Rule details flyout, where it didn't map all the compliances [#7501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7501)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed a problem in Vulnerabilities > Dashboard and Inventory when there are no indices matching with the index pattern [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368)
+- Fixed a bug in Rule details flyout > It didn't map all the compliances [#7501](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7501)
 
 ### Removed
 

--- a/docker/imposter/rules/rules.js
+++ b/docker/imposter/rules/rules.js
@@ -1,0 +1,74 @@
+if (context.request.queryParams.rule_ids !== undefined) {
+  if (context.request.queryParams.rule_ids === '505') {
+    var resp = {
+      data: {
+        affected_items: [
+          {
+            filename: '0015-ossec_rules.xml',
+            relative_dirname: 'ruleset/rules',
+            id: 505,
+            level: 3,
+            status: 'enabled',
+            details: {
+              if_sid: '500',
+              match: {
+                pattern: 'Agent removed',
+              },
+            },
+            pci_dss: ['10.6.1', '10.2.6'],
+            gpg13: ['10.1'],
+            gdpr: ['IV_35.7.d'],
+            hipaa: ['164.312.b'],
+            nist_800_53: ['AU.6', 'AU.14', 'AU.5'],
+            tsc: ['CC7.2', 'CC7.3', 'CC6.8'],
+            mitre: ['T1562.001'],
+            groups: ['ossec'],
+            description: 'Wazuh agent removed.',
+          },
+        ],
+        total_affected_items: 1,
+        total_failed_items: 0,
+        failed_items: [],
+      },
+      message: 'All selected rules were returned',
+      error: 0,
+    };
+  } else {
+    var resp = {
+      data: {
+        affected_items: [
+          {
+            filename: '0020-syslog_rules.xml',
+            relative_dirname: 'ruleset/rules',
+            id: 1001,
+            level: 2,
+            status: 'enabled',
+            details: {
+              match: {
+                pattern: "^Couldn't open /etc/securetty",
+              },
+            },
+            pci_dss: ['0.2.4'],
+            gpg13: ['4.1'],
+            gdpr: ['IV_35.7.d'],
+            hipaa: ['164.312.b'],
+            nist_800_53: ['AU.14', 'AC.7'],
+            tsc: ['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3'],
+            mitre: [],
+            groups: ['syslog', 'errors'],
+            description: 'File missing. Root access unrestricted.',
+          },
+        ],
+        total_affected_items: 1,
+        total_failed_items: 0,
+        failed_items: [],
+      },
+      message: 'All selected rules were returned',
+      error: 0,
+    };
+  }
+
+  respond().withStatusCode(200).withData(JSON.stringify(resp));
+} else {
+  respond().withStatusCode(200).withFile('rules/rules.json');
+}

--- a/docker/imposter/rules/rules.json
+++ b/docker/imposter/rules/rules.json
@@ -1,0 +1,54 @@
+{
+  "data": {
+    "affected_items": [
+      {
+        "filename": "0015-ossec_rules.xml",
+        "relative_dirname": "ruleset/rules",
+        "id": 505,
+        "level": 3,
+        "status": "enabled",
+        "details": {
+          "if_sid": "500",
+          "match": {
+            "pattern": "Agent removed"
+          }
+        },
+        "pci_dss": ["10.6.1", "10.2.6"],
+        "gpg13": ["10.1"],
+        "gdpr": ["IV_35.7.d"],
+        "hipaa": ["164.312.b"],
+        "nist_800_53": ["AU.6", "AU.14", "AU.5"],
+        "tsc": ["CC7.2", "CC7.3", "CC6.8"],
+        "mitre": ["T1562.001"],
+        "groups": ["ossec"],
+        "description": "Wazuh agent removed."
+      },
+      {
+        "filename": "0020-syslog_rules.xml",
+        "relative_dirname": "ruleset/rules",
+        "id": 1001,
+        "level": 2,
+        "status": "enabled",
+        "details": {
+          "match": {
+            "pattern": "^Couldn't open /etc/securetty"
+          }
+        },
+        "pci_dss": ["0.2.4"],
+        "gpg13": ["4.1"],
+        "gdpr": ["IV_35.7.d"],
+        "hipaa": ["164.312.b"],
+        "nist_800_53": ["AU.14", "AC.7"],
+        "tsc": ["CC6.1", "CC6.8", "CC7.2", "CC7.3"],
+        "mitre": [],
+        "groups": ["syslog", "errors"],
+        "description": "File missing. Root access unrestricted."
+      }
+    ],
+    "total_affected_items": 2,
+    "total_failed_items": 0,
+    "failed_items": []
+  },
+  "message": "All selected rules were returned",
+  "error": 0
+}

--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -592,7 +592,7 @@ resources:
     path: /rules
     response:
       statusCode: 200
-      staticFile: rules/rules.json
+      scriptFile: rules/rules.js
 
   # Get groups
   - method: GET

--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -590,6 +590,9 @@ resources:
   # List rules
   - method: GET
     path: /rules
+    response:
+      statusCode: 200
+      staticFile: rules/rules.json
 
   # Get groups
   - method: GET

--- a/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
+++ b/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
@@ -582,6 +582,7 @@ export default withRouterSearch(
             mitreIds,
             mitreTactics: uniqueTactics,
             mitreTechniques: mitreName,
+            mitreLoading: false,
           });
         }
       } catch (error) {

--- a/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
+++ b/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
@@ -42,11 +42,11 @@ export default withRouterSearch(
     constructor(props) {
       super(props);
       this.complianceEquivalences = {
-        pci: 'PCI DSS',
+        pci_dss: 'PCI DSS',
         gdpr: 'GDPR',
         gpg13: 'GPG 13',
         hipaa: 'HIPAA',
-        'nist-800-53': 'NIST-800-53',
+        nist_800_53: 'NIST-800-53',
         tsc: 'TSC',
         mitreTactics: 'MITRE Tactics',
         mitreTechniques: 'MITRE Techniques',
@@ -245,8 +245,8 @@ export default withRouterSearch(
         'gdpr',
         'gpg13',
         'hipaa',
-        'nist-800-53',
-        'pci',
+        'nist_800_53',
+        'pci_dss',
         'tsc',
         'mitre',
       ];

--- a/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
+++ b/plugins/main/public/controllers/management/components/management/ruleset/views/rule-info.tsx
@@ -201,7 +201,7 @@ export default withRouterSearch(
 
         const compliance = this.buildCompliance(currentRule);
         if (compliance?.mitre?.length && currentRuleId !== mitreRuleId) {
-          mitreState = this.addMitreInformation(
+          mitreState = await this.addMitreInformation(
             compliance.mitre,
             currentRuleId,
           );


### PR DESCRIPTION
### Description
This PR fixes a bug on which the Rule details flyout doesn't show all the compliances. It also adds a new rule in the `/rules` imposter response, which contains all possible compliances (data extracted from a real manager).
 
### Issues Resolved
#7497

### Evidence
**Before**
![image](https://github.com/user-attachments/assets/c5b35159-9dc0-4b3a-b90f-05ea311359f5)

**After**
![image](https://github.com/user-attachments/assets/41518b4b-d608-4574-849a-3405b451cc48)

### Test
- Navigate to Rules
- Click on a Rule
- Validate that it shows all the compliances

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
