### PR TITLE
Restrict GitHub workflows permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     name: Build app package (auto)
     uses: ./.github/workflows/dev-environment.yml
+    permissions:
+      actions: read
+      contents: read
     with:
       reference: ${{ github.ref_name }}
       command: 'yarn build'

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -43,6 +43,8 @@ jobs:
   # Deploy the plugin in a development environment and run a command
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
+    permissions:
+      pull-requests: write
     name: Deploy and run command
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Build app package
     uses: ./.github/workflows/dev-environment.yml
+    permissions: {}
     with:
       reference: ${{ inputs.reference }}
       command: 'yarn build'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,8 @@
 # Jest is a third-party software https://jestjs.io/
 
 name: Run unit test
-
+permissions:
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Description
This pull request restricts GitHub workflow permissions to a minimum. 
 

### Test
- Verify al tests pass
- Verify the package building process works as expected

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
