### PR TITLE
Fix missing sample data warning in File Integrity Monitoring > Inventory

### DIFF
--- a/plugins/main/public/components/common/dashboards/inventory.tsx
+++ b/plugins/main/public/components/common/dashboards/inventory.tsx
@@ -199,6 +199,7 @@ export const InventoryDashboardTable = ({
   tableId,
   indexPattern,
   additionalDocumentDetailsTabs,
+  categoriesSampleData,
 }: InventoryDashboardTableProps) => {
   const {
     dataSource,
@@ -246,6 +247,7 @@ export const InventoryDashboardTable = ({
       indexPattern={indexPattern}
       classNameDashboardWrapper={classNameDashboardWrapper}
       additionalDocumentDetailsTabs={additionalDocumentDetailsTabs}
+      categoriesSampleData={categoriesSampleData}
     />
   );
 };


### PR DESCRIPTION
### Description
This PR fixes a bug where the sample data warning was not shown in the Inventory tab of File Integrity monitoring.
 
### Issues Resolved
#7522 

### Evidence
![image](https://github.com/user-attachments/assets/69c1f498-38be-422b-8b10-a74678d49814)
![image](https://github.com/user-attachments/assets/6e2b16cc-d198-456b-ab40-94863d2cb5fb)
![image](https://github.com/user-attachments/assets/15890ab8-a585-4aad-953f-bc28a9458e39)

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
