### PR TITLE
Fix Windows service name in Deploy new agent

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
@@ -163,7 +163,7 @@ describe('getWindowsInstallCommand', () => {
 
 describe('getWindowsStartCommand', () => {
   it('should return the correct start command', () => {
-    const expectedCommand = 'NET START WazuhSvc';
+    const expectedCommand = 'NET START Wazuh';
 
     const result = getWindowsStartCommand({});
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.tsx
@@ -119,7 +119,7 @@ export const getWindowsInstallCommand = (
 export const getWindowsStartCommand = (
   _props: tOSEntryProps<tOptionalParameters>,
 ) => {
-  return `NET START WazuhSvc`;
+  return `NET START Wazuh`;
 };
 
 /******** MacOS ********/


### PR DESCRIPTION
### Description
This PR fixes the name of Windows service in the `Deploy new agent` section 

### Issues Resolved
#7534 

### Evidence
![image](https://github.com/user-attachments/assets/34df5e2b-9e2d-4dbf-8399-4322341be5ef)

**Test that the command actually works**
![image](https://github.com/user-attachments/assets/77797554-3309-41bf-ad30-57ec3a7007db)

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
