### PR TITLE
Fix format issue in CSV reports

### DIFF
--- a/plugins/main/package.json
+++ b/plugins/main/package.json
@@ -58,7 +58,7 @@
     "install": "^0.13.0",
     "js2xmlparser": "^5.0.0",
     "jsdom": "^16.6.0",
-    "json2csv": "^4.1.2",
+    "json-2-csv": "^3.20.0",
     "jwt-decode": "^3.1.2",
     "loglevel": "^1.7.1",
     "markdown-it-link-attributes": "^4.0.1",

--- a/plugins/main/public/components/common/data-grid/data-grid-service.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.ts
@@ -162,11 +162,11 @@ export const exportSearchToCSV = async (
 
   const options = {
     emptyFieldValue: '',
+    keys: resultsFields.map(field => ({ field: field, title: field })), // This prevents dots from being escaped and also sorts the fields appropriately
   };
 
   let csv = await converter.json2csvAsync(data, options);
 
-  // create a csv file using blob
   const blobData = new Blob([csv], {
     type: 'text/csv',
   });

--- a/plugins/main/public/components/common/data-grid/data-grid-service.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.ts
@@ -11,6 +11,7 @@ export const MAX_ENTRIES_PER_QUERY = 10000;
 import { tDataGridColumn } from './use-data-grid';
 import { cellFilterActions } from './cell-filter-actions';
 import { onFilterCellActions } from './filter-cell-actions';
+import converter from 'json-2-csv';
 
 type ParseData<T> =
   | {
@@ -159,29 +160,14 @@ export const exportSearchToCSV = async (
 
   if (!data || data.length === 0) return;
 
-  const parsedData = data
-    .map(row => {
-      const parsedRow = resultsFields?.map(field => {
-        const value = row[field];
-        if (value === undefined || value === null) {
-          return '';
-        }
-        if (typeof value === 'object') {
-          return JSON.stringify(value);
-        }
-        // Escape double quotes and handle line breaks to prevent column misalignment
-        return `"${value
-          .toString()
-          .replaceAll(/"/g, '""')
-          .replaceAll(/\r\n/g, '\\r\\n')
-          .replaceAll(/\n/g, '\\n')}"`;
-      });
-      return parsedRow?.join(',');
-    })
-    .join('\n');
+  const options = {
+    emptyFieldValue: '',
+  };
+
+  let csv = await converter.json2csvAsync(data, options);
 
   // create a csv file using blob
-  const blobData = new Blob([`${resultsFields?.join(',')}\n${parsedData}`], {
+  const blobData = new Blob([csv], {
     type: 'text/csv',
   });
 

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -878,15 +878,12 @@ export class WazuhApiCtrl {
         fields = fields.map(item => ({ value: item, default: '-' }));
         const options = {
           emptyFieldValue: '',
+          keys: fields.map(field => ({
+            field: field.value,
+            title: KeyEquivalence[field.value] || field.value,
+          })),
         };
         let csv = await converter.json2csvAsync(itemsArray, options);
-
-        for (const field of fields) {
-          const { value } = field;
-          if (csv.includes(value)) {
-            csv = csv.replace(value, KeyEquivalence[value] || value);
-          }
-        }
 
         return response.ok({
           headers: { 'Content-Type': 'text/csv' },

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -12,7 +12,7 @@
 
 // Require some libraries
 import { ErrorResponse } from '../lib/error-response';
-import { Parser } from 'json2csv';
+import converter from 'json-2-csv';
 import { KeyEquivalence } from '../../common/csv-key-equivalence';
 import { ApiErrorEquivalence } from '../lib/api-errors-equivalence';
 import apiRequestList from '../../common/api-info/endpoints';
@@ -876,10 +876,11 @@ export class WazuhApiCtrl {
           itemsArray = output.data.data.affected_items[0].items;
         }
         fields = fields.map(item => ({ value: item, default: '-' }));
+        const options = {
+          emptyFieldValue: '',
+        };
+        let csv = await converter.json2csvAsync(itemsArray, options);
 
-        const json2csvParser = new Parser({ fields });
-
-        let csv = json2csvParser.parse(itemsArray);
         for (const field of fields) {
           const { value } = field;
           if (csv.includes(value)) {

--- a/plugins/main/yarn.lock
+++ b/plugins/main/yarn.lock
@@ -1145,11 +1145,6 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.15.1:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -1333,6 +1328,11 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
+deeks@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/deeks/-/deeks-2.6.1.tgz#ee852ab76d5b4ca4bcfda34ba55660c40b92f505"
+  integrity sha512-PZrpz5xLo2JPZa3L+kqMMMdZU5pRwMysTM1xd6pLhNtgQw4Iq3wbF2QWaQTVh+HRq9Yg4rcjDIJ+scfGLxmsjQ==
+
 deep-equal@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -1437,6 +1437,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doc-path@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/doc-path/-/doc-path-3.1.0.tgz#4e1b5ba445d02e6b8f5bc122e8af43e659463d14"
+  integrity sha512-Pv2hLQbUM8du5681lTWIYk0OtVBmNhMAeZNGeFhMMJBIR89Nw4XesBwee1Xtlfk83n71tn0Y6VsJOn4d3qIiTw==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -2878,6 +2883,14 @@ jsdom@^16.6.0:
     ws "^7.4.6"
     xml-name-validator "^3.0.0"
 
+json-2-csv@^3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-3.20.0.tgz#8d9a7ad8a296016dbeb43eb76c03e66ac26d9136"
+  integrity sha512-IbqUB+yaycVNB/q2fiY5kyRjy5kRiEXqvNvGlxM5L0Bfi0RdvklVHc4t9MfeYF1GsZVpZWDBs9LdWmSjsQ8jvg==
+  dependencies:
+    deeks "2.6.1"
+    doc-path "3.1.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -2887,15 +2900,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
-json2csv@^4.1.2:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.5.4.tgz#2b59c2869a137ec48cd2e243e0180466155f773f"
-  integrity sha512-YxBhY4Lmn8IvVZ36nqg5omxneLy9JlorkqW1j/EDCeqvmi+CQ4uM+wsvXlcIqvGDewIPXMC/O/oF8DX9EH5aoA==
-  dependencies:
-    commander "^2.15.1"
-    jsonparse "^1.3.1"
-    lodash.get "^4.4.2"
 
 json5@^1.0.2:
   version "1.0.2"
@@ -2908,11 +2912,6 @@ json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonparse@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -2985,11 +2984,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.isequal@^4.5.0:
   version "4.5.0"

--- a/plugins/wazuh-core/package.json
+++ b/plugins/wazuh-core/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "axios": "^1.1.3",
-    "json2csv": "^4.1.2",
     "jwt-decode": "^3.1.2",
     "md5": "^2.3.0",
     "node-cron": "^3.0.2"

--- a/plugins/wazuh-core/yarn.lock
+++ b/plugins/wazuh-core/yarn.lock
@@ -524,11 +524,6 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.15.1:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -1570,15 +1565,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json2csv@^4.1.2:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.5.4.tgz#2b59c2869a137ec48cd2e243e0180466155f773f"
-  integrity sha512-YxBhY4Lmn8IvVZ36nqg5omxneLy9JlorkqW1j/EDCeqvmi+CQ4uM+wsvXlcIqvGDewIPXMC/O/oF8DX9EH5aoA==
-  dependencies:
-    commander "^2.15.1"
-    jsonparse "^1.3.1"
-    lodash.get "^4.4.2"
-
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -1590,11 +1576,6 @@ json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonparse@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -1661,11 +1642,6 @@ lodash.curry@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
   integrity sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
### Description
This PR fixes a problem with CSV format when a field contains `,` by adding the `json-2-csv` library to handle that. 
It also changes `json2csv`, formerly used in `wazuh-api` controller with `json-2-csv`, and removes a library that was not used in `wazuh-core`.

The reason to use a different library is to be consistent with the libraries used in Opensearch Reporting plugin.

### Issues Resolved
#7548

### Evidence
**Before**
![image](https://github.com/user-attachments/assets/9e71ef78-4ace-4ae4-be38-88922c9e067e)

**After**
![image](https://github.com/user-attachments/assets/1b66fd8b-cfcb-41ff-ba06-9b76a5c5b540)

### Test
- Navigate to `Threat hunting > Events`, add columns that may contain several objects (i.e. Mitre columns)
- Genearte a CSV report and verify that it contains all the selected columns, in the correct order and the format is correct
- Verify that the API csv reports are correct. Those are: 
  - Decoders
  - Rules
  - Endpoints list
  - Cluster nodes
  - SCA checks
  - CDB Lists

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
