### PR TITLE
Update development environments to use combined version format <Opensearch version>-<Wazuh version>

### DIFF
--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -100,11 +100,11 @@ jobs:
           # Support plugins whose version is defined under pluginPlatform or Kibana properties
           platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ matrix.plugins.path }}/package.json);
           echo "Plugin platform version: $platform_version";
-          
+
           # Get Wazuh version and concatenate with platform version
           wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
           echo "Wazuh version: $wazuh_version";
-          
+
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
           combined_version="${platform_version}-${wazuh_version}";
           echo "Combined platform version: $combined_version";

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -100,6 +100,14 @@ jobs:
           # Support plugins whose version is defined under pluginPlatform or Kibana properties
           platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ matrix.plugins.path }}/package.json);
           echo "Plugin platform version: $platform_version";
+          
+          # Get Wazuh version and concatenate with platform version
+          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          echo "Wazuh version: $wazuh_version";
+          
+          # Concatenate versions in format: <Opensearch version>-<Wazuh version>
+          platform_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $platform_version";
 
           # Set the environment variable to the correct platform
           [ "$platform" = "kbn" ] && { docker_env_plugin_platform="KIBANA_VERSION"; };

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -106,8 +106,8 @@ jobs:
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
-          platform_version="${platform_version}-${wazuh_version}";
-          echo "Combined platform version: $platform_version";
+          combined_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $combined_version";
 
           # Set the environment variable to the correct platform
           [ "$platform" = "kbn" ] && { docker_env_plugin_platform="KIBANA_VERSION"; };
@@ -115,10 +115,10 @@ jobs:
 
           # Up the environment and run the command
           docker run -t --rm \
-            -e ${docker_env_plugin_platform}=${platform_version} \
+            -e ${docker_env_plugin_platform}=${combined_version} \
             -v `pwd`/${{ matrix.plugins.path }}:/home/node/kbn/plugins/${{ matrix.plugins.container_path }} \
             ${{ inputs.docker_run_extra_args }} \
-            quay.io/wazuh/${platform}-dev:${platform_version} \
+            quay.io/wazuh/${platform}-dev:${combined_version} \
             bash -c '
               yarn config set registry https://registry.yarnpkg.com;
               cd /home/node/kbn/plugins/${{ matrix.plugins.container_path }} && yarn && ${{ inputs.command }};

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -94,6 +94,14 @@ jobs:
           # Support plugins whose version is defined under pluginPlatform or Kibana properties
           platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ matrix.plugins.path }}/package.json);
           echo "Plugin platform version: $platform_version";
+          
+          # Get Wazuh version and concatenate with platform version
+          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          echo "Wazuh version: $wazuh_version";
+          
+          # Concatenate versions in format: <Opensearch version>-<Wazuh version>
+          platform_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $platform_version";
 
           # Set the environment variable to the correct platform
           [ "$platform" = "kbn" ] && { docker_env_plugin_platform="KIBANA_VERSION"; };

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -100,8 +100,8 @@ jobs:
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
-          platform_version="${platform_version}-${wazuh_version}";
-          echo "Combined platform version: $platform_version";
+          combined_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $combined_version";
 
           # Set the environment variable to the correct platform
           [ "$platform" = "kbn" ] && { docker_env_plugin_platform="KIBANA_VERSION"; };
@@ -109,10 +109,10 @@ jobs:
 
           # Up the environment and run the command
           docker run -t --rm \
-            -e ${docker_env_plugin_platform}=${platform_version} \
+            -e ${docker_env_plugin_platform}=${combined_version} \
             -v `pwd`/${{ matrix.plugins.path }}:/home/node/kbn/plugins/${{ matrix.plugins.container_path }} \
             ${{ inputs.docker_run_extra_args }} \
-            quay.io/wazuh/${platform}-dev:${platform_version} \
+            quay.io/wazuh/${platform}-dev:${combined_version} \
             bash -c '
               yarn config set registry https://registry.yarnpkg.com;
               cd /home/node/kbn/plugins/${{ matrix.plugins.container_path }} && yarn && ${{ inputs.command }};

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -94,11 +94,11 @@ jobs:
           # Support plugins whose version is defined under pluginPlatform or Kibana properties
           platform_version=$(jq -r '.pluginPlatform.version, .kibana.version | select(. != null)' ${{ matrix.plugins.path }}/package.json);
           echo "Plugin platform version: $platform_version";
-          
+
           # Get Wazuh version and concatenate with platform version
           wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
           echo "Wazuh version: $wazuh_version";
-          
+
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
           combined_version="${platform_version}-${wazuh_version}";
           echo "Combined platform version: $combined_version";

--- a/docker/osd-dev/dev.sh
+++ b/docker/osd-dev/dev.sh
@@ -86,6 +86,16 @@ if [ -z "$os_version" ] || [ -z "$osd_version" ]; then
       echo "[ERROR] Could not retrieve the OSD version from package.json."
       exit 1
     fi
+    
+    wazuh_version=$(jq -r '.version' $PACKAGE_PATH)
+    if [ -z "$wazuh_version" ]; then
+      echo "[ERROR] Could not retrieve the Wazuh version from package.json."
+      exit 1
+    fi
+    
+   
+    osd_version="${osd_version}-${wazuh_version}"
+    echo "[INFO] Using combined version: $osd_version"
   fi
 fi
 

--- a/docker/osd-dev/dev.sh
+++ b/docker/osd-dev/dev.sh
@@ -94,8 +94,8 @@ if [ -z "$os_version" ] || [ -z "$osd_version" ]; then
     fi
     
    
-    osd_version="${osd_version}-${wazuh_version}"
-    echo "[INFO] Using combined version: $osd_version"
+    combined_osd_version="${osd_version}-${wazuh_version}"
+    echo "[INFO] Using combined version: $combined_osd_version"
   fi
 fi
 
@@ -114,7 +114,7 @@ fi
 
 export PASSWORD=${PASSWORD:-admin}
 export OS_VERSION=$os_version
-export OSD_VERSION=$osd_version
+export OSD_VERSION=${combined_osd_version}
 export OSD_PORT=${PORT:-5601}
 export IMPOSTER_VERSION=3.44.1
 export SRC=$1


### PR DESCRIPTION
### Description
This PR implements automatic version concatenation for development environments and workflows to use Docker images with the combined version format `<Opensearch version>-<Wazuh version>` (e.g., `3.0.0-5.0.0`). This change ensures consistency across different development environments and allows for better version management when working with multiple OpenSearch and Wazuh versions simultaneously.

### Changes made:
- **Updated `docker/osd-dev/dev.sh`**: Added automatic version concatenation when no `-d` flag is provided
  - Retrieves OpenSearch version from `pluginPlatform.version` in package.json
  - Retrieves Wazuh version from `version` in package.json
  - Concatenates versions in format: `<Opensearch version>-<Wazuh version>`
  - Added proper logging to show the combined version being used

- **Modified GitHub Actions workflows**:
  - Updated `.github/workflows/dev-environment.yml`
  - Updated `.github/workflows/6_builderprecompiled_base-dev-environment.yml`
  - Both workflows now use the combined version format for Docker images from Quay.io

- **Improved version management**:
  - Simplified version retrieval by using `package.json` as the single source of truth
  - Added proper error handling for missing version information
  - Enhanced logging to show individual and combined versions

### Technical Details:
- When `-d` flag is not provided, the system automatically detects and combines versions
- Format: `quay.io/wazuh/osd-dev:3.0.0-5.0.0` instead of `quay.io/wazuh/osd-dev:3.0.0`
- Maintains backward compatibility - manual version specification still works with `-d` flag
- Works with both OpenSearch Dashboard (OSD) and Kibana (KBN) platforms

### Issues Resolved
- [#7577](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7577)

### Evidence
- [Test Manual Build](https://github.com/wazuh/wazuh-dashboard-plugins/actions/runs/16074384346)

### Test
- Check if package its adding the wazuh version when image its created
- Test if dev env works successfully with the correct resource

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).