### PR TITLE
Missing fields are added to `whodata` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.14.0
 - Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587)
 
+### Fixed
+
+- Fixed missing provider and queue_size fields in whodata configuration [#7596](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7596)
+
 ## Wazuh v4.13.1 - OpenSearch Dashboards 2.19.2 - Revision 00
 
 ### Added

--- a/docker/imposter/agents/configuration/syscheck-syscheck.json
+++ b/docker/imposter/agents/configuration/syscheck-syscheck.json
@@ -838,7 +838,9 @@
       "database": "disk",
       "whodata": {
         "restart_audit": "yes",
-        "startup_healthcheck": "yes"
+        "startup_healthcheck": "yes",
+        "queue_size": 16384,
+        "provider": "audit"
       },
       "nodiff": ["/etc/ssl/private.key"]
     }

--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-who-data.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-who-data.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 
 import { EuiBasicTable } from '@elastic/eui';
 
@@ -22,6 +22,8 @@ import helpLinks from './help-links';
 const mainSettings = [
   { field: 'restart_audit', label: 'Restart audit' },
   { field: 'startup_healthcheck', label: 'Startup healthcheck' },
+  { field: 'provider', label: 'Provider' },
+  { field: 'queue_size', label: 'Queue size' },
 ];
 
 const columns = [{ field: 'audit_key', name: 'Keys' }];
@@ -33,40 +35,33 @@ class WzConfigurationIntegrityMonitoringWhoData extends Component {
   render() {
     const { currentConfig } = this.props;
     return (
-      <Fragment>
-        {currentConfig &&
-          currentConfig['syscheck-syscheck'] &&
-          currentConfig['syscheck-syscheck'].syscheck &&
-          !currentConfig['syscheck-syscheck'].syscheck.whodata && (
-            <WzNoConfig error='not-present' help={helpLinks} />
-          )}
-        {currentConfig &&
-          currentConfig['syscheck-syscheck'] &&
-          currentConfig['syscheck-syscheck'].syscheck &&
-          currentConfig['syscheck-syscheck'].syscheck.whodata && (
-            <WzConfigurationSettingsHeader
-              title='Who-data audit keys'
-              description='Server will include in its FIM baseline those events being monitored by Audit using audit_key.'
-              help={helpLinks}
-            >
-              <WzConfigurationSettingsGroup
-                config={currentConfig['syscheck-syscheck'].syscheck.whodata}
-                items={mainSettings}
+      <>
+        {!currentConfig?.['syscheck-syscheck']?.syscheck?.whodata && (
+          <WzNoConfig error='not-present' help={helpLinks} />
+        )}
+        {currentConfig?.['syscheck-syscheck']?.syscheck?.whodata && (
+          <WzConfigurationSettingsHeader
+            title='Who-data audit keys'
+            description='Server will include in its FIM baseline those events being monitored by Audit using audit_key.'
+            help={helpLinks}
+          >
+            <WzConfigurationSettingsGroup
+              config={currentConfig['syscheck-syscheck'].syscheck.whodata}
+              items={mainSettings}
+            />
+            {currentConfig['syscheck-syscheck'].syscheck.whodata.audit_key && (
+              <EuiBasicTable
+                items={currentConfig[
+                  'syscheck-syscheck'
+                ].syscheck.whodata.audit_key.map(item => ({
+                  audit_key: item,
+                }))}
+                columns={columns}
               />
-              {currentConfig['syscheck-syscheck'].syscheck.whodata
-                .audit_key && (
-                <EuiBasicTable
-                  items={currentConfig[
-                    'syscheck-syscheck'
-                  ].syscheck.whodata.audit_key.map(item => ({
-                    audit_key: item,
-                  }))}
-                  columns={columns}
-                />
-              )}
-            </WzConfigurationSettingsHeader>
-          )}
-      </Fragment>
+            )}
+          </WzConfigurationSettingsHeader>
+        )}
+      </>
     );
   }
 }

--- a/plugins/main/server/lib/reporting/agent-configuration.ts
+++ b/plugins/main/server/lib/reporting/agent-configuration.ts
@@ -308,6 +308,8 @@ export const AgentConfiguration = {
               ignore: 'Ignored files and directories',
               restart_audit: 'Restart audit',
               startup_healthcheck: 'Startup healthcheck',
+              provider: 'Provider',
+              queue_size: 'Queue size',
             },
           ],
           opts: {


### PR DESCRIPTION
### Description

Fixed missing `provider` and `queue_size` fields in whodata configuration
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/800

### Evidence

<img width="1536" height="728" alt="image" src="https://github.com/user-attachments/assets/7eff2e37-62a2-4ca7-b6c8-8d706f427ba2" />

### Test

1. Go to Endpoints summary > some agent > Configuration
2. Click on Integrity monitoring > Who-data (Windows agents do not have Who-data tab)
3. The provider and queue_size field should appear.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
