### PR TITLE
Change fields in FIM indices and split the Registry data into 2 index patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Split the FIM registry inventory into 2 index patterns and change some fields in the FIM files and registries sample data[#7604](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7604)
+- Split the FIM registry inventory into 2 index patterns and change some fields in the FIM files and registries sample data [#7604](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7604)
 
 ## Wazuh v4.14.0 - OpenSearch Dashboards 2.19.2 - Revision 00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 5.0.0
 
+### Changed
+
+- Split the FIM registry inventory into 2 index patterns and change some fields in the FIM files and registries sample data[#7604](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7604)
+
 ## Wazuh v4.14.0 - OpenSearch Dashboards 2.19.2 - Revision 00
 
 ### Added

--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -55,6 +55,10 @@ export const VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER = 'wazuh.cluster.name';
 export const WAZUH_FIM_PATTERN = 'wazuh-states-fim-*';
 export const WAZUH_FIM_FILES_PATTERN = 'wazuh-states-fim-files-*';
 export const WAZUH_FIM_REGISTRIES_PATTERN = 'wazuh-states-fim-registries-*';
+export const WAZUH_FIM_REGISTRY_KEYS_PATTERN =
+  'wazuh-states-fim-registry-keys-*';
+export const WAZUH_FIM_REGISTRY_VALUES_PATTERN =
+  'wazuh-states-fim-registry-values-*';
 
 // System inventory
 export const WAZUH_IT_HYGIENE_PATTERN = 'wazuh-states-inventory-*';
@@ -101,9 +105,13 @@ export const WAZUH_SETTING_FIM_FILES_SAMPLE_PREFIX = {
   indexPatternPrefix: WAZUH_FIM_FILES_PATTERN.replace('*', ''),
   dataSet: 'states-fim-files',
 };
-export const WAZUH_SETTING_FIM_REGISTRIES_SAMPLE_PREFIX = {
-  indexPatternPrefix: WAZUH_FIM_REGISTRIES_PATTERN.replace('*', ''),
-  dataSet: 'states-fim-registries',
+export const WAZUH_SETTING_FIM_REGISTRY_KEYS_SAMPLE_PREFIX = {
+  indexPatternPrefix: WAZUH_FIM_REGISTRY_KEYS_PATTERN.replace('*', ''),
+  dataSet: 'states-fim-registry-keys',
+};
+export const WAZUH_SETTING_FIM_REGISTRY_VALUES_SAMPLE_PREFIX = {
+  indexPatternPrefix: WAZUH_FIM_REGISTRY_VALUES_PATTERN.replace('*', ''),
+  dataSet: 'states-fim-registry-values',
 };
 export const WAZUH_SETTING_INVENTORY_HARDWARE_SAMPLE_PREFIX = {
   indexPatternPrefix: WAZUH_IT_HYGIENE_HARDWARE_PATTERN.replace('*', ''),
@@ -282,10 +290,14 @@ export const WAZUH_SAMPLE_DATA_CATEGORIES_TYPE_DATA = {
       dataSet: WAZUH_SETTING_FIM_FILES_SAMPLE_PREFIX.dataSet,
     },
     {
-      registries: true,
       indexPatternPrefix:
-        WAZUH_SETTING_FIM_REGISTRIES_SAMPLE_PREFIX.indexPatternPrefix,
-      dataSet: WAZUH_SETTING_FIM_REGISTRIES_SAMPLE_PREFIX.dataSet,
+        WAZUH_SETTING_FIM_REGISTRY_KEYS_SAMPLE_PREFIX.indexPatternPrefix,
+      dataSet: WAZUH_SETTING_FIM_REGISTRY_KEYS_SAMPLE_PREFIX.dataSet,
+    },
+    {
+      indexPatternPrefix:
+        WAZUH_SETTING_FIM_REGISTRY_VALUES_SAMPLE_PREFIX.indexPatternPrefix,
+      dataSet: WAZUH_SETTING_FIM_REGISTRY_VALUES_SAMPLE_PREFIX.dataSet,
     },
   ],
   [WAZUH_SAMPLE_INVENTORY_AGENT]: [

--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -54,7 +54,6 @@ export const VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER = 'wazuh.cluster.name';
 // FIM
 export const WAZUH_FIM_PATTERN = 'wazuh-states-fim-*';
 export const WAZUH_FIM_FILES_PATTERN = 'wazuh-states-fim-files-*';
-export const WAZUH_FIM_REGISTRIES_PATTERN = 'wazuh-states-fim-registries-*';
 export const WAZUH_FIM_REGISTRY_KEYS_PATTERN =
   'wazuh-states-fim-registry-keys-*';
 export const WAZUH_FIM_REGISTRY_VALUES_PATTERN =

--- a/plugins/main/public/components/common/data-source/pattern/fim/data-source-repository.ts
+++ b/plugins/main/public/components/common/data-source/pattern/fim/data-source-repository.ts
@@ -1,11 +1,15 @@
 import {
   WAZUH_FIM_FILES_PATTERN,
-  WAZUH_FIM_REGISTRIES_PATTERN,
+  WAZUH_FIM_REGISTRY_KEYS_PATTERN,
+  WAZUH_FIM_REGISTRY_VALUES_PATTERN,
 } from '../../../../../../common/constants';
 import { createPatternDataSourceRepositoryUseValue } from '../pattern-data-source-repository-use-setting-value';
 
 export const FIMFilesStatesDataSourceRepository =
   createPatternDataSourceRepositoryUseValue(WAZUH_FIM_FILES_PATTERN);
 
-export const FIMRegistriesStatesDataSourceRepository =
-  createPatternDataSourceRepositoryUseValue(WAZUH_FIM_REGISTRIES_PATTERN);
+export const FIMRegistryKeysStatesDataSourceRepository =
+  createPatternDataSourceRepositoryUseValue(WAZUH_FIM_REGISTRY_KEYS_PATTERN);
+
+export const FIMRegistryValuesStatesDataSourceRepository =
+  createPatternDataSourceRepositoryUseValue(WAZUH_FIM_REGISTRY_VALUES_PATTERN);

--- a/plugins/main/public/components/common/data-source/pattern/fim/data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/fim/data-source.ts
@@ -33,11 +33,7 @@ export class FIMRegistryKeysStatesDataSource extends PatternDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [
-      ...this.getClusterManagerFilters(),
-      ...super.getFixedFilters(),
-      this.getRegistryTypeFilter(),
-    ];
+    return [...this.getClusterManagerFilters(), ...super.getFixedFilters()];
   }
 
   getClusterManagerFilters() {
@@ -45,15 +41,6 @@ export class FIMRegistryKeysStatesDataSource extends PatternDataSource {
       this.id,
       DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
       VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER,
-    );
-  }
-
-  getRegistryTypeFilter() {
-    return PatternDataSourceFilterManager.createFilter(
-      FILTER_OPERATOR.IS,
-      'event.category',
-      'registry_key',
-      this.id,
     );
   }
 }
@@ -64,11 +51,7 @@ export class FIMRegistryValuesStatesDataSource extends PatternDataSource {
   }
 
   getFixedFilters(): tFilter[] {
-    return [
-      ...this.getClusterManagerFilters(),
-      ...super.getFixedFilters(),
-      this.getRegistryTypeFilter(),
-    ];
+    return [...this.getClusterManagerFilters(), ...super.getFixedFilters()];
   }
 
   getClusterManagerFilters() {
@@ -76,15 +59,6 @@ export class FIMRegistryValuesStatesDataSource extends PatternDataSource {
       this.id,
       DATA_SOURCE_FILTER_CONTROLLED_CLUSTER_MANAGER,
       VULNERABILITY_IMPLICIT_CLUSTER_MODE_FILTER,
-    );
-  }
-
-  getRegistryTypeFilter() {
-    return PatternDataSourceFilterManager.createFilter(
-      FILTER_OPERATOR.IS,
-      'event.category',
-      'registry_value',
-      this.id,
     );
   }
 }

--- a/plugins/main/public/components/overview/fim/common/hocs/validate-fim-states-index-pattern.tsx
+++ b/plugins/main/public/components/overview/fim/common/hocs/validate-fim-states-index-pattern.tsx
@@ -10,7 +10,8 @@ import {
 } from '../../../../common/hocs/with-index-pattern';
 import {
   WAZUH_FIM_FILES_PATTERN,
-  WAZUH_FIM_REGISTRIES_PATTERN,
+  WAZUH_FIM_REGISTRY_KEYS_PATTERN,
+  WAZUH_FIM_REGISTRY_VALUES_PATTERN,
 } from '../../../../../../common/constants';
 
 const errorPromptTypes = {
@@ -57,8 +58,14 @@ export const withFIMFilesDataSource = withIndexPatternFromValue({
   ),
 });
 
-export const withFIMRegistriesDataSource = withIndexPatternFromValue({
-  indexPattern: WAZUH_FIM_REGISTRIES_PATTERN,
+export const withFIMRegistryKeysDataSource = withIndexPatternFromValue({
+  indexPattern: WAZUH_FIM_REGISTRY_KEYS_PATTERN,
+  ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),
+  validate: ensureIndexPatternIsCreated(),
+});
+
+export const withFIMRegistryValuesDataSource = withIndexPatternFromValue({
+  indexPattern: WAZUH_FIM_REGISTRY_VALUES_PATTERN,
   ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),
   validate: ensureIndexPatternIsCreated(
     mapFieldsFormat({

--- a/plugins/main/public/components/overview/fim/inventory/inventories/registry-keys/inventory.tsx
+++ b/plugins/main/public/components/overview/fim/inventory/inventories/registry-keys/inventory.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
-  FIMRegistriesStatesDataSourceRepository,
   FIMRegistryKeysStatesDataSource,
+  FIMRegistryKeysStatesDataSourceRepository,
 } from '../../../../../common/data-source';
 import tableColumns from './table-columns';
 import managedFilters from './managed-filters';
 withSystemInventoryHardwareDataSource;
 import { getDashboard } from './dashboard';
 import { withSystemInventoryHardwareDataSource } from '../../../../it-hygiene/common/hocs/validate-system-inventory-index-pattern';
-import { withFIMRegistriesDataSource } from '../../../common/hocs/validate-fim-states-index-pattern';
+import { withFIMRegistryKeysDataSource } from '../../../common/hocs/validate-fim-states-index-pattern';
 import { InventoryDashboardTable } from '../../../../../common/dashboards';
 import { WAZUH_SAMPLE_FILE_INTEGRITY_MONITORING } from '../../../../../../../common/constants';
 import { compose } from 'redux';
@@ -16,13 +16,13 @@ import { withAgent } from '../hocs';
 
 export const InventoryFIMRegistryKeys = compose(
   withAgent,
-  withFIMRegistriesDataSource,
+  withFIMRegistryKeysDataSource,
 )(props => {
   return (
     <div style={{ margin: '0 12px' }}>
       <InventoryDashboardTable
         DataSource={FIMRegistryKeysStatesDataSource}
-        DataSourceRepositoryCreator={FIMRegistriesStatesDataSourceRepository}
+        DataSourceRepositoryCreator={FIMRegistryKeysStatesDataSourceRepository}
         tableDefaultColumns={tableColumns}
         managedFilters={managedFilters}
         getDashboardPanels={getDashboard}

--- a/plugins/main/public/components/overview/fim/inventory/inventories/registry-values/inventory.tsx
+++ b/plugins/main/public/components/overview/fim/inventory/inventories/registry-values/inventory.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
-  FIMRegistriesStatesDataSourceRepository,
   FIMRegistryValuesStatesDataSource,
+  FIMRegistryValuesStatesDataSourceRepository,
 } from '../../../../../common/data-source';
 import tableColumns from './table-columns';
 import managedFilters from './managed-filters';
 withSystemInventoryHardwareDataSource;
 import { getDashboard } from './dashboard';
 import { withSystemInventoryHardwareDataSource } from '../../../../it-hygiene/common/hocs/validate-system-inventory-index-pattern';
-import { withFIMRegistriesDataSource } from '../../../common/hocs/validate-fim-states-index-pattern';
+import { withFIMRegistryValuesDataSource } from '../../../common/hocs/validate-fim-states-index-pattern';
 import { InventoryDashboardTable } from '../../../../../common/dashboards';
 import { WAZUH_SAMPLE_FILE_INTEGRITY_MONITORING } from '../../../../../../../common/constants';
 import { compose } from 'redux';
@@ -16,13 +16,15 @@ import { withAgent } from '../hocs';
 
 export const InventoryFIMRegistryValues = compose(
   withAgent,
-  withFIMRegistriesDataSource,
+  withFIMRegistryValuesDataSource,
 )(props => {
   return (
     <div style={{ margin: '0 12px' }}>
       <InventoryDashboardTable
         DataSource={FIMRegistryValuesStatesDataSource}
-        DataSourceRepositoryCreator={FIMRegistriesStatesDataSourceRepository}
+        DataSourceRepositoryCreator={
+          FIMRegistryValuesStatesDataSourceRepository
+        }
         tableDefaultColumns={tableColumns}
         managedFilters={managedFilters}
         getDashboardPanels={getDashboard}

--- a/plugins/main/server/lib/sample-data/dataset/states-fim-files/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-fim-files/main.js
@@ -4,8 +4,33 @@ const {
   pathsLinux,
 } = require('../../../generate-alerts/sample-data/integrity-monitoring');
 
+function generateRandomChecksum() {
+  return {
+    hash: {
+      sha1: random.choice([
+        '6853b29eef33ff39d8b63911673cf7b078f95485',
+        'c3499c2729730a7f807efb8676a92dcb6f8a3f8f',
+        'a80ed2ef79e22f1d8af817cea1dbbf01bef516cc',
+        '272ae13f02a9c805923917a42d2f27bd02654dec',
+      ]),
+    },
+  };
+}
+
+const permissionsChars = ['r', 'w', 'x'];
+function generatePermissions() {
+  return Array.from({ length: 9 })
+    .map((_, index) => random.choice([permissionsChars[index % 3], '-']))
+    .join('');
+}
+
 function generateRandomFile() {
   return {
+    attributes: random.sample(
+      ['hidden', 'read_only', 'system', 'archive', 'temporary'],
+      random.int(1, 5),
+    ),
+    device: random.choice(['sda', 'sdb', 'sdc']),
     gid: `gid${random.int(0, 1000)}`,
     group: `group${random.int(0, 1000)}`,
     hash: {
@@ -17,6 +42,7 @@ function generateRandomFile() {
     mtime: random.date(),
     owner: `owner${random.int(0, 1000)}`,
     path: random.choice(pathsLinux),
+    permissions: generatePermissions(),
     size: random.int(1000, 1000000),
     uid: `uid${random.int(0, 1000)}`,
   };
@@ -26,6 +52,7 @@ function generateDocument(params) {
   // https://github.com/wazuh/wazuh-indexer/pull/744
   return {
     agent: generateRandomAgent(),
+    checksum: generateRandomChecksum(),
     file: generateRandomFile(),
     wazuh: generateRandomWazuh(params),
   };

--- a/plugins/main/server/lib/sample-data/dataset/states-fim-registry-keys/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-fim-registry-keys/main.js
@@ -1,0 +1,47 @@
+const random = require('../../lib/random');
+const { generateRandomWazuh, generateRandomAgent } = require('../shared-utils');
+
+function generateRandomChecksum() {
+  return {
+    hash: {
+      sha1: random.choice([
+        '6853b29eef33ff39d8b63911673cf7b078f95485',
+        'c3499c2729730a7f807efb8676a92dcb6f8a3f8f',
+        'a80ed2ef79e22f1d8af817cea1dbbf01bef516cc',
+        '272ae13f02a9c805923917a42d2f27bd02654dec',
+      ]),
+    },
+  };
+}
+
+function generateRandomRegistry() {
+  return {
+    architecture: random.choice(['x86_64', 'arm64']),
+    gid: `gid${random.int(0, 1000)}`,
+    group: `group${random.int(0, 1000)}`,
+    hive: 'HKLM',
+    key: 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe',
+    mtime: random.date(),
+    owner: `owner${random.int(0, 1000)}`,
+    path: `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe`,
+    permissions: [
+      '{"S-1-5-32-544":{"name":"Administrators","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]}}',
+    ],
+    uid: `uid${random.int(0, 1000)}`,
+  };
+}
+
+function generateDocument(params) {
+  // https://github.com/wazuh/wazuh-indexer/pull/744
+  // https://github.com/wazuh/wazuh-indexer-plugins/issues/506
+  return {
+    agent: generateRandomAgent(),
+    checksum: generateRandomChecksum(),
+    registry: generateRandomRegistry(),
+    wazuh: generateRandomWazuh(params),
+  };
+}
+
+module.exports = {
+  generateDocument,
+};

--- a/plugins/main/server/lib/sample-data/dataset/states-fim-registry-keys/template.json
+++ b/plugins/main/server/lib/sample-data/dataset/states-fim-registry-keys/template.json
@@ -1,41 +1,7 @@
 {
-  "index_patterns": ["wazuh-states-fim-registries*"],
+  "index_patterns": ["wazuh-states-fim-registry-keys*"],
   "priority": 1,
   "template": {
-    "settings": {
-      "index": {
-        "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "query.default_field": [
-          "agent.host.architecture",
-          "agent.host.ip",
-          "agent.id",
-          "agent.name",
-          "agent.version",
-          "event.action",
-          "event.category",
-          "registry.architecture",
-          "registry.data.hash.md5",
-          "registry.data.hash.sha1",
-          "registry.data.hash.sha256",
-          "registry.data.type",
-          "registry.gid",
-          "registry.group",
-          "registry.hive",
-          "registry.key",
-          "registry.mtime",
-          "registry.owner",
-          "registry.path",
-          "registry.size",
-          "registry.uid",
-          "registry.value",
-          "wazuh.cluster.name",
-          "wazuh.cluster.node",
-          "wazuh.schema.version"
-        ],
-        "refresh_interval": "5s"
-      }
-    },
     "mappings": {
       "date_detection": false,
       "dynamic": "strict",
@@ -67,15 +33,15 @@
             }
           }
         },
-        "event": {
+        "checksum": {
           "properties": {
-            "action": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "hash": {
+              "properties": {
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
@@ -84,30 +50,6 @@
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "data": {
-              "properties": {
-                "hash": {
-                  "properties": {
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
             },
             "gid": {
               "ignore_above": 1024,
@@ -136,14 +78,11 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "size": {
-              "type": "long"
-            },
-            "uid": {
+            "permissions": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "value": {
+            "uid": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -173,6 +112,35 @@
             }
           }
         }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "checksum.hash.sha1",
+          "registry.architecture",
+          "registry.gid",
+          "registry.group",
+          "registry.hive",
+          "registry.key",
+          "registry.mtime",
+          "registry.owner",
+          "registry.path",
+          "registry.permissions",
+          "registry.uid",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
+        ],
+        "refresh_interval": "5s"
       }
     }
   }

--- a/plugins/main/server/lib/sample-data/dataset/states-fim-registry-values/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-fim-registry-values/main.js
@@ -1,10 +1,16 @@
 const random = require('../../lib/random');
 const { generateRandomWazuh, generateRandomAgent } = require('../shared-utils');
 
-function generateRandomEvent() {
+function generateRandomChecksum() {
   return {
-    category: random.choice(['registry_value', 'registry_key', 'file']),
-    action: random.choice(['added', 'modified', 'deleted']),
+    hash: {
+      sha1: random.choice([
+        '6853b29eef33ff39d8b63911673cf7b078f95485',
+        'c3499c2729730a7f807efb8676a92dcb6f8a3f8f',
+        'a80ed2ef79e22f1d8af817cea1dbbf01bef516cc',
+        '272ae13f02a9c805923917a42d2f27bd02654dec',
+      ]),
+    },
   };
 }
 
@@ -19,24 +25,20 @@ function generateRandomRegistry() {
       },
       type: random.choice(['REG_SZ', 'REG_DWORD']),
     },
-    gid: `gid${random.int(0, 1000)}`,
-    group: `group${random.int(0, 1000)}`,
     hive: 'HKLM',
-    key: 'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe',
-    mtime: random.date(),
-    owner: `owner${random.int(0, 1000)}`,
-    path: `/path/to/file_${random.int(0, 20)}`,
+    key: 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe',
+    path: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe',
     size: random.int(1000, 1000000),
-    uid: `uid${random.int(0, 1000)}`,
     value: `registry_value${random.int(0, 1000)}`,
   };
 }
 
 function generateDocument(params) {
   // https://github.com/wazuh/wazuh-indexer/pull/744
+  // https://github.com/wazuh/wazuh-indexer-plugins/issues/506
   return {
     agent: generateRandomAgent(),
-    event: generateRandomEvent(),
+    checksum: generateRandomChecksum(),
     registry: generateRandomRegistry(),
     wazuh: generateRandomWazuh(params),
   };

--- a/plugins/main/server/lib/sample-data/dataset/states-fim-registry-values/template.json
+++ b/plugins/main/server/lib/sample-data/dataset/states-fim-registry-values/template.json
@@ -1,41 +1,7 @@
 {
-  "index_patterns": ["wazuh-states-fim-files*"],
+  "index_patterns": ["wazuh-states-fim-registry-values*"],
   "priority": 1,
   "template": {
-    "settings": {
-      "index": {
-        "auto_expand_replicas": "0-1",
-        "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "query.default_field": [
-          "agent.host.architecture",
-          "agent.host.ip",
-          "agent.id",
-          "agent.name",
-          "agent.version",
-          "checksum.hash.sha1",
-          "file.attributes",
-          "file.device",
-          "file.gid",
-          "file.group",
-          "file.hash.md5",
-          "file.hash.sha1",
-          "file.hash.sha256",
-          "file.inode",
-          "file.mtime",
-          "file.owner",
-          "file.path",
-          "file.path.fields.text",
-          "file.permissions",
-          "file.size",
-          "file.uid",
-          "wazuh.cluster.name",
-          "wazuh.cluster.node",
-          "wazuh.schema.version"
-        ],
-        "refresh_interval": "5s"
-      }
-    },
     "mappings": {
       "date_detection": false,
       "dynamic": "strict",
@@ -79,48 +45,41 @@
             }
           }
         },
-        "file": {
+        "registry": {
           "properties": {
-            "attributes": {
+            "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "device": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "gid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "group": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hash": {
+            "data": {
               "properties": {
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
+                "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
               }
             },
-            "inode": {
+            "hive": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "mtime": {
-              "type": "date"
-            },
-            "owner": {
+            "key": {
               "ignore_above": 1024,
               "type": "keyword"
             },
@@ -128,14 +87,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "permissions": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "size": {
               "type": "long"
             },
-            "uid": {
+            "value": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -165,6 +120,35 @@
             }
           }
         }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "checksum.hash.sha1",
+          "registry.architecture",
+          "registry.data.hash.md5",
+          "registry.data.hash.sha1",
+          "registry.data.hash.sha256",
+          "registry.data.type",
+          "registry.hive",
+          "registry.key",
+          "registry.path",
+          "registry.size",
+          "registry.value",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
+        ],
+        "refresh_interval": "5s"
       }
     }
   }

--- a/plugins/main/server/lib/sample-data/lib/random.js
+++ b/plugins/main/server/lib/sample-data/lib/random.js
@@ -22,6 +22,22 @@ function choice(array) {
 }
 
 /**
+ * Choose a sample elements from an array
+ * @param {Array} array - Array to choose from
+ * @param {number} elements - Array to choose from
+ * @returns {*} Random sample from the array
+ */
+function sample(array, elements) {
+  const shuffled = array.slice(); // make a copy
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]; // swap
+  }
+
+  return shuffled.slice(0, elements);
+}
+
+/**
  * Generate a random boolean value
  * @returns {boolean} Random boolean
  */
@@ -100,4 +116,5 @@ module.exports = {
   ip,
   macAddress,
   float,
+  sample,
 };


### PR DESCRIPTION
### Description

This pull request applies changes in the FIM data.

It splits the FIM registry data into 2 index patterns:
- wazuh-states-inventory-registry-keys-*
- wazuh-states-inventory-registry-values-*

Add/remove some fields

### Changes
- Split the registry index into 2 indices:
      - registry-keys
        - Add `checksum.hash.sha1`
        - Add `registry.permissions`
        - Remove `event`
      - registry-values
        - Add `checksum.hash.sha1`
        - Remove `event`
    - Remove the managed filter using `event.category` field in Registry
      keys and Registry values tabs of File Integrity Monitoring > Inventory
    - Adapted the index pattern in File Integrity Monitoring > Inventory > Registry keys and Registry values
      to using separate index pattern: wazuh-states-inventory-registry-keys-* and wazuh-states-inventory-registry-values-*
    - Change fields in the sample data indices:
      - fim-files:
        - Add `file.attributes`, `file.device`, `file.permissions`, `checksum.hash.sha`
        - Remove `event`

### Issues Resolved
#7601

### Evidence

FIM sample data indices
<img width="1664" height="308" alt="image" src="https://github.com/user-attachments/assets/fd734822-9726-4e1a-b370-dfe1c1186af4" />


FIM Files
<img width="950" height="851" alt="image" src="https://github.com/user-attachments/assets/bda17cb0-5ea6-41e9-9b04-c3be79a53ae0" />

FIM Registry keys
<img width="939" height="828" alt="image" src="https://github.com/user-attachments/assets/fe114cb9-1c41-4002-9ff7-66e190e6202d" />

FIM Registry values
<img width="926" height="782" alt="image" src="https://github.com/user-attachments/assets/5218f593-7f46-4e30-b976-f3e9e35040ef" />

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With a clean installation, go to Sample data and add for FIM inventory, this should create 3 indices (use the Dev tools to list the indices) | :black_circle: | :black_circle: | :black_circle: |
| With FIM files data, go to File Integrity Monitoring > Inventory > Files and ensure the file.attributes, file.device, file.permissions and checksum.hash.sha1 are present in the available fields, review their render in the table and document details. Use filters with these fields. | :black_circle: | :black_circle: | :black_circle: |
| With FIM files data, go to File Integrity Monitoring > Inventory > Registry keys and ensure the checksum.hash.sha1 and registry.permissions fields are present in the available fields, review their render in the table and document details. Use filters with these fields. | :black_circle: | :black_circle: | :black_circle: |
| With FIM files data, go to File Integrity Monitoring > Inventory > Registry values and ensure the checksum.hash.sha1 field is present in the available fields, review its render in the table and document details. Use filters with this fields. | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With a clean installation, go to Sample data and add for FIM inventory, this should create 3 indices (use the Dev tools to list the indices)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM files data, go to File Integrity Monitoring > Inventory > Files and ensure the file.attributes, file.device, file.permissions and checksum.hash.sha1 are present in the available fields, review their render in the table and document details. Use filters with these fields.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM files data, go to File Integrity Monitoring > Inventory > Registry keys and ensure the checksum.hash.sha1 and registry.permissions fields are present in the available fields, review their render in the table and document details. Use filters with these fields.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: With FIM files data, go to File Integrity Monitoring > Inventory > Registry values and ensure the checksum.hash.sha1 field is present in the available fields, review its render in the table and document details. Use filters with this fields.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
