### PR TITLE
Fix: Bring back missing code in main after recent upward merges

### DIFF
--- a/plugins/main/public/components/common/data-source/pattern/system-inventory/data-source-repository.ts
+++ b/plugins/main/public/components/common/data-source/pattern/system-inventory/data-source-repository.ts
@@ -37,7 +37,7 @@ export const SystemInventoryUsersStatesDataSourceRepository =
 export const SystemInventoryGroupsStatesDataSourceRepository =
   createPatternDataSourceRepositoryUseValue(WAZUH_IT_HYGIENE_GROUPS_PATTERN);
 
-export const SystemInventoryPortsStatesDataSourceRepository =
+export const SystemInventoryTrafficStatesDataSourceRepository =
   createPatternDataSourceRepositoryUseValue(WAZUH_IT_HYGIENE_PORTS_PATTERN);
 
 export const SystemInventoryPackagesStatesDataSourceRepository =

--- a/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/common/hocs/validate-system-inventory-index-pattern.tsx
@@ -128,7 +128,7 @@ export const withSystemInventoryGroupsDataSource = withIndexPatternFromValue({
   ErrorComponent: withMapErrorPromptErrorEnsureIndexPattern(errorPromptTypes),
 });
 
-export const withSystemInventoryPortsDataSource = withIndexPatternFromValue({
+export const withSystemInventoryTrafficDataSource = withIndexPatternFromValue({
   indexPattern: WAZUH_IT_HYGIENE_PORTS_PATTERN,
   validate: ensureIndexPatternIsCreated(
     mapFieldsFormat({


### PR DESCRIPTION
### Description
- This pull request restores code that was mistakenly deleted from the `main` branch during the scheduled upward merges ([Issue](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7614)).
- Restore code from IT hygiene > network > traffic. This code was part of this [PR](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7588)


### Evidence


### Test
- Verify that the app does not stay blank.
- Go to IT Hygiene > Networks > Traffic and verify that all works properly.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
