### PR TITLE
Prevent column overflow page in PDF reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed missing provider and queue_size fields in whodata configuration [#7596](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7596)
+- Fixed PDF report columns overflowing the page width [#7630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7630)
 
 ## Wazuh v4.13.1 - OpenSearch Dashboards 2.19.2 - Revision 00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed missing provider and queue_size fields in whodata configuration [#7596](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7596)
-- Fixed PDF report columns overflowing the page width [#7630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7630)
+- Fixed an error that caused PDF report tables to overflow the page width [#7630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7630)
 
 ## Wazuh v4.13.1 - OpenSearch Dashboards 2.19.2 - Revision 00
 


### PR DESCRIPTION
### Description
This PR adds logic to split the long words into several lines, to prevent the table overflowing the page in PDF reports
 
### Issues Resolved
#7609

### Evidence
<img width="786" height="565" alt="image" src="https://github.com/user-attachments/assets/e21985fd-eb72-4716-85bd-3e33930530c2" />

### Test
Navigate to File Integrity Monitoring, click on "Generate Report", and verify that the long strings in the columns (most likely in the `path`) are split into different lines. 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
