### PR TITLE
 Fix confusing terms in Integrity monitoring settings and update component names for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed missing provider and queue_size fields in whodata configuration [#7596](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7596)
 - Fixed an error that caused PDF report tables to overflow the page width [#7630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7630)
+- Fixed confusing terms in Integrity monitoring settings by correcting file/registry terminology and updating component names for clarity [#7639](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7639)
 
 ## Wazuh v4.13.1 - OpenSearch Dashboards 2.19.2 - Revision 00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.14.0
 - Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587)
 
+### Changed
+
+- Improved Integrity monitoring settings terminology by clarifying file/registry labels and updating component names for better user understanding [#7639](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7639)
+
 ### Fixed
 
 - Fixed missing provider and queue_size fields in whodata configuration [#7596](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7596)
 - Fixed an error that caused PDF report tables to overflow the page width [#7630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7630)
-- Fixed confusing terms in Integrity monitoring settings by correcting file/registry terminology and updating component names for clarity [#7639](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7639)
 
 ## Wazuh v4.13.1 - OpenSearch Dashboards 2.19.2 - Revision 00
 

--- a/docker/imposter/agents/configuration/syscheck-syscheck.json
+++ b/docker/imposter/agents/configuration/syscheck-syscheck.json
@@ -13,6 +13,10 @@
         "enabled": "yes",
         "entries": 100000
       },
+      "registry_limit": {
+        "enabled": "yes",
+        "entries": 100000
+      },
       "diff": {
         "disk_quota": {
           "enabled": "yes",

--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-file-limit.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-file-limit.js
@@ -23,17 +23,17 @@ const mainSettings = [
   {
     field: 'enabled',
     label: 'File limit status',
-    render: renderValueYesThenEnabled
+    render: renderValueYesThenEnabled,
   },
   {
     field: 'entries',
-    label: 'Maximum number of files to monitor'
+    label: 'Maximum number of files to monitor',
   },
 ];
 
-const FILE_LIMIT_PROP = 'file_limit'
+const FILE_LIMIT_PROP = 'file_limit';
 
-class WzConfigurationIntegrityMonitoringRegistryLimit extends Component {
+class WzConfigurationIntegrityMonitoringFileLimit extends Component {
   constructor(props) {
     super(props);
   }
@@ -46,8 +46,8 @@ class WzConfigurationIntegrityMonitoringRegistryLimit extends Component {
         currentConfig['syscheck-syscheck'].syscheck &&
         currentConfig['syscheck-syscheck'].syscheck[FILE_LIMIT_PROP] ? (
           <WzConfigurationSettingsHeader
-            title="Registry limit"
-            description="Limit the maximum registries in the FIM database"
+            title='Files limit'
+            description='Limit the maximum files in the FIM database'
             help={helpLinks}
           >
             <WzConfigurationSettingsGroup
@@ -58,11 +58,11 @@ class WzConfigurationIntegrityMonitoringRegistryLimit extends Component {
             />
           </WzConfigurationSettingsHeader>
         ) : (
-          <WzNoConfig error="not-present" help={helpLinks} />
+          <WzNoConfig error='not-present' help={helpLinks} />
         )}
       </Fragment>
     );
   }
 }
 
-export default WzConfigurationIntegrityMonitoringRegistryLimit;
+export default WzConfigurationIntegrityMonitoringFileLimit;

--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-registry-limit.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-registry-limit.js
@@ -21,18 +21,18 @@ import { renderValueYesThenEnabled } from '../utils/utils';
 const mainSettings = [
   {
     field: 'enabled',
-    label: 'File limit status',
-    render: renderValueYesThenEnabled
+    label: 'Registry limit status',
+    render: renderValueYesThenEnabled,
   },
   {
     field: 'entries',
-    label: 'Maximum number of registries values to monitor'
-  }
+    label: 'Maximum number of registries values to monitor',
+  },
 ];
 
-const FILE_LIMIT_PROP = 'registry_limit'
+const REGISTRY_LIMIT_PROP = 'registry_limit';
 
-class WzConfigurationIntegrityMonitoringFileLimit extends Component {
+class WzConfigurationIntegrityMonitoringRegistryLimit extends Component {
   constructor(props) {
     super(props);
   }
@@ -43,25 +43,25 @@ class WzConfigurationIntegrityMonitoringFileLimit extends Component {
         {currentConfig &&
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
-        currentConfig['syscheck-syscheck'].syscheck[FILE_LIMIT_PROP] ? (
+        currentConfig['syscheck-syscheck'].syscheck[REGISTRY_LIMIT_PROP] ? (
           <WzConfigurationSettingsHeader
-            title="Entries limit"
-            description="Limit the maximum entries in the FIM database"
+            title='Registries limit'
+            description='Limit the maximum registries in the FIM database'
             help={helpLinks}
           >
             <WzConfigurationSettingsGroup
               config={
-                currentConfig['syscheck-syscheck'].syscheck[FILE_LIMIT_PROP]
+                currentConfig['syscheck-syscheck'].syscheck[REGISTRY_LIMIT_PROP]
               }
               items={mainSettings}
             />
           </WzConfigurationSettingsHeader>
         ) : (
-          <WzNoConfig error="not-present" help={helpLinks} />
+          <WzNoConfig error='not-present' help={helpLinks} />
         )}
       </Fragment>
     );
   }
 }
 
-export default WzConfigurationIntegrityMonitoringFileLimit;
+export default WzConfigurationIntegrityMonitoringRegistryLimit;


### PR DESCRIPTION
### Description
This PR resolves terminology confusion in the Integrity monitoring configuration interface by:

- **Registry limit section**: Changed "File limit status" label to "Registry limit status" to avoid confusion with file monitoring
- **Files limit section**: Changed title from "Registry limit" to "Files limit" and updated description to reference "files" instead of "registries"
- **Component names**: Corrected class names to match their actual functionality:
  - `WzConfigurationIntegrityMonitoringRegistryLimit` for registry limit configuration
  - `WzConfigurationIntegrityMonitoringFileLimit` for file limit configuration
- **Constants**: Updated property names to be more descriptive (`REGISTRY_LIMIT_PROP` vs `FILE_LIMIT_PROP`)

These changes ensure that users can clearly distinguish between file monitoring limits and registry monitoring limits without terminology overlap.
 
### Issues Resolved
- Fixes [#7639](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7639) - Confusing terms in Settings > Integrity monitoring

<details>
<summary>Files limit tab </summary>

<img width="1288" height="431" alt="Files limit tab showing corrected terminology" src="https://github.com/user-attachments/assets/e08a5db4-3463-4ba7-baae-48322f231284" />

</details>

<details>
<summary>Registries limit tab </summary>

<img width="1300" height="442" alt="Registries limit tab showing corrected terminology" src="https://github.com/user-attachments/assets/8f989f5c-57e6-4182-84fa-c40a2104e0d5" />

</details>


### Test
To test this PR:

1. **Access Integrity Monitoring Configuration:**
   - Navigate to Wazuh Dashboard
   - Go to **Agents management**
   - Click on **Summary**
   - Select a **Windows agent** from the list
   - Go to **Configuration** tab
   - In the **Log data analysis** section, select **Integrity monitoring**

2. **Verify Files Limit Tab:**
   - Click on the **"Files limit"** tab
   - Confirm the title shows "Files limit" (not "Registry limit")
   - Verify the description states "Limit the maximum files in the FIM database"
   - Check that the status label shows "File limit status"

3. **Verify Registries Limit Tab:**
   - Click on the **"Registries limit"** tab
   - Confirm the title shows "Registries limit" (not "Entries limit")
   - Verify the description states "Limit the maximum registries in the FIM database"
   - Check that the status label shows "Registry limit status" (not "File limit status")

4. **Verify No Terminology Confusion:**
   - Ensure no tab references the other tab's terminology
   - Confirm that file-related settings only mention "files"
   - Confirm that registry-related settings only mention "registries"
   - Verify that both tabs have consistent and clear labeling without cross-references

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff