### PR TITLE
Rename Azure dashboard to Microsoft graph api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587)
 - Added ability to set the Wazuh data path (wazuh directory) within the directory defined through `path.data` setting [#7586](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7586)
 - Added a new Browser Extensions tab in IT Hygiene [#7641](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7641)
-- Added Azure module with ms-graph integration [#7516](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7516) [#7644](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7644)
+- Added Microsoft Graph API module [#7516](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7516) [#7644](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7644) [#7661](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7661)
 - Added a new Services tab in IT Hygiene [#7646](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7646)
 
 ### Fixed

--- a/plugins/main/common/wazuh-modules.ts
+++ b/plugins/main/common/wazuh-modules.ts
@@ -82,11 +82,11 @@ export const WAZUH_MODULES = {
     description:
       'Configuration assessment using Center of Internet Security scanner and SCAP checks.',
   },
-  azure: {
-    title: 'Azure',
-    appId: 'azure',
+  microsoftGraphAPI: {
+    title: 'Microsoft Graph API',
+    appId: 'microsoft-graph-api',
     description:
-      'Security events related to your Azure MS Graph services, collected directly via Azure API.',
+      'Security events related to your Microsoft Graph services, collected directly via Microsoft Graph API.',
   },
   aws: {
     title: 'AWS',

--- a/plugins/main/public/components/add-modules-data/sample-data.tsx
+++ b/plugins/main/public/components/add-modules-data/sample-data.tsx
@@ -38,7 +38,7 @@ import {
 import { getErrorOrchestrator } from '../../react-services/common-services';
 import {
   amazonWebServices,
-  azure,
+  microsoftGraphAPI,
   docker,
   fileIntegrityMonitoring,
   github,
@@ -55,7 +55,7 @@ const sampleSecurityInformationApplication = [
   office365.title,
   googleCloud.title,
   github.title,
-  azure.title,
+  microsoftGraphAPI.title,
   'authorization',
   'ssh',
   'web',

--- a/plugins/main/public/components/common/modules/modules-defaults.tsx
+++ b/plugins/main/public/components/common/modules/modules-defaults.tsx
@@ -151,7 +151,7 @@ export const ModulesDefaults = {
     ],
     availableFor: ['manager', 'agent'],
   },
-  azure: {
+  microsoftGraphAPI: {
     init: 'dashboard',
     tabs: [
       {
@@ -161,10 +161,10 @@ export const ModulesDefaults = {
         component: DashboardAzure,
       },
       renderDiscoverTab({
-        moduleId: 'azure',
+        moduleId: 'microsoftGraphAPI',
         tableColumns: azureColumns,
         DataSource: AzureDataSource,
-        categoriesSampleData: [WAZUH_SAMPLE_ALERTS_CATEGORY_SECURITY], // TODO: Change this when sample data is available for Azure
+        categoriesSampleData: [WAZUH_SAMPLE_ALERTS_CATEGORY_SECURITY],
       }),
     ],
     availableFor: ['manager', 'agent'],

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -491,25 +491,28 @@ export const office365 = {
     }`,
 };
 
-export const azure = {
+export const microsoftGraphAPI = {
   category: 'wz-category-cloud-security',
-  id: 'azure',
-  title: i18n.translate('wz-app-azure-title', {
-    defaultMessage: 'Azure',
+  id: 'microsoft-graph-api',
+  title: i18n.translate('wz-app-microsoft-graph-api-title', {
+    defaultMessage: 'Microsoft Graph API',
   }),
-  breadcrumbLabel: i18n.translate('wz-app-azure-breadcrumbLabel', {
-    defaultMessage: 'Azure',
-  }),
-  description: i18n.translate('wz-app-azure-description', {
+  breadcrumbLabel: i18n.translate(
+    'wz-app-microsoft-graph-api-breadcrumbLabel',
+    {
+      defaultMessage: 'Microsoft Graph API',
+    },
+  ),
+  description: i18n.translate('wz-app-microsoft-graph-api-description', {
     defaultMessage:
-      'Security events related to your Azure MS Graph services, collected directly via Azure API.',
+      'Security events related to your Microsoft Graph services, collected directly via Microsoft Graph API.',
   }),
   euiIconType: 'logoAzureMono',
   order: 505,
   showInOverviewApp: true,
   showInAgentMenu: true,
   redirectTo: () =>
-    `/overview/?tab=azure&tabView=dashboard${
+    `/overview/?tab=microsoftGraphAPI&tabView=dashboard${
       store.getState()?.appStateReducers?.currentAgentData?.id
         ? `&agentId=${store.getState()?.appStateReducers?.currentAgentData?.id}`
         : ''
@@ -875,7 +878,7 @@ export const Applications = [
   devTools,
   rulesetTest,
   security,
-  azure,
+  microsoftGraphAPI,
   amazonWebServices,
   googleCloud,
   github,


### PR DESCRIPTION
### Description

Azure module name changed to Microsoft Graph API
 
### Issues Resolved

- #7658 

### Evidence

<img width="2276" height="1201" alt="image" src="https://github.com/user-attachments/assets/1088e1de-6f5b-4216-a65e-9a4c85740504" />
<img width="2287" height="1066" alt="image" src="https://github.com/user-attachments/assets/53a7819f-e295-4f9b-bf66-3aa056d8adc7" />
<img width="2285" height="922" alt="image" src="https://github.com/user-attachments/assets/e2e57c0f-518f-4cb5-bbd7-c3ad15f5990c" />

### Test

In the sample data, overview and Microsoft Graph API view, the Azure name should have changed to Microsoft Graph API.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
