### PR TITLE
Fix endpoint to add reload ruleset button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Changed
 
-- Changed the manager reset button to reload in Rules, Decoders and CDB list [#7657](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7657)
+- Changed the manager reset button to reload in Rules, Decoders and CDB list [#7657](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7657)[#7677](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7677)
 - Moved `/elastic/samplealerts` API endpoints to `/indexer/samplealerts` [#7373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7373)
 - Changed FIM inventory to display information ingested by the indexer [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368) [#7482](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7482) [#7538](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7538)
 - Changed macOS agent startup command [#7430](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7430)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Changed
 
-- Changed the manager reset button to reload in Rules, Decoders and CDB list [#7657](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7657)[#7677](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7677)
+- Changed the manager reset button to reload in Rules, Decoders and CDB list [#7657](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7657) [#7677](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7677)
 - Moved `/elastic/samplealerts` API endpoints to `/indexer/samplealerts` [#7373](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7373)
 - Changed FIM inventory to display information ingested by the indexer [#7368](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7368) [#7482](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7482) [#7538](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7538)
 - Changed macOS agent startup command [#7430](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7430)

--- a/plugins/main/public/components/common/reload-cluster-manager-callout.tsx
+++ b/plugins/main/public/components/common/reload-cluster-manager-callout.tsx
@@ -86,7 +86,7 @@ class WzReloadClusterManagerCallout extends Component<
           `Cluster reloaded in ${nodesReloaded.length} node(s)`,
           <div>
             <p>{message}:</p>
-            <strong>{nodesReloaded.join(', ')}</strong>
+            <strong>{nodesReloaded.map(node => node.name).join(', ')}</strong>
           </div>,
           10000,
         );

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -12,7 +12,6 @@
 
 import { WzRequest } from '../../../../../../react-services/wz-request';
 import { replaceIllegalXML } from './xml';
-import { getToasts } from '../../../../../../kibana-services';
 import { delayAsPromise } from '../../../../../../../common/utils';
 import { AGENT_SYNCED_STATUS } from '../../../../../../../common/constants';
 
@@ -543,14 +542,19 @@ export const clusterNodes = async () => {
  */
 export const reloadRuleset = async (nodes = []) => {
   try {
+    const clusterStatus = await WzRequest.apiReq('GET', `/cluster/status`, {});
+
+    const clusterData = ((clusterStatus || {}).data || {}).data || {};
+    const isCluster =
+      clusterData.enabled === 'yes' && clusterData.running === 'yes';
+
     const nodesString = nodes.join(',');
     const nodes_param = nodesString ? `?nodes_list=${nodesString}` : '';
+    const reloadEndpoint = isCluster
+      ? `/cluster/analysisd/reload${nodes_param}`
+      : `/manager/analysisd/reload${nodes_param}`;
 
-    const result = await WzRequest.apiReq(
-      'PUT',
-      `/analysisd/reload${nodes_param}`,
-      {},
-    );
+    const result = await WzRequest.apiReq('PUT', reloadEndpoint, {});
     return result;
   } catch (error) {
     throw error;

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -548,7 +548,7 @@ export const reloadRuleset = async (nodes = []) => {
 
     const result = await WzRequest.apiReq(
       'PUT',
-      `/cluster/analysisd/reload${nodes_param}`,
+      `/analysisd/reload${nodes_param}`,
       {},
     );
     return result;


### PR DESCRIPTION
### Description

Fix the endpoint path that saves any modifications to the rule set.

The endpoint to reload the rule set changes depending on whether cluster mode is enabled or not.
- Enabled: `PUT cluster/analysisd/reload`
- Disabled: `PUT manager/analysisd/reload`

[reference here](https://github.com/wazuh/wazuh/pull/31459).
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7653

### Evidence
https://github.com/user-attachments/assets/6bf0343a-fff5-419f-b6b2-f4ac7034b303



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
