### PR TITLE
Adapt services dashboard to new fields mapping

### DIFF
--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-services/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-services/main.js
@@ -1,103 +1,148 @@
 const random = require('../../lib/random');
 const { generateRandomWazuh, generateRandomAgent } = require('../shared-utils');
 
-function generateRandomService() {
-  const linux = Math.random() >= 0.5;
-  const names = [
-    'Administrateurs',
-    'Administrators',
-    'Admin Group',
-    'root',
-    'wheel',
-    'sys',
-    'Utilisateurs',
-    'Users',
-    'Standard Users',
-    'sudo',
-    'adm',
-    'IIS_IUSRS',
-    'WWW-Data',
-    'Web Users',
-    'daemon',
-    'bin',
-    'Utilisateurs du Bureau à distance',
-    'Remote Desktop Users',
-    'RDP Users',
-    'docker',
-    'container',
-    'virtualization',
-    'Opérateurs de sauvegarde',
-    'Backup Operators',
-    'Backup Users',
-    'wazuh',
-    'security',
-    'monitoring',
-  ];
+function generateRandomService(os) {
+  let service = {};
+  if (os === 'linux') {
+    const processName = random.choice(['nginx', 'sshd', 'cron']);
+    const target = {
+      ephemeral_id: String(random.int(1, 9999)),
+      type: random.choice(['start', 'stop']),
+      address: `/systemd/job${processName}`,
+    };
+    service.id = processName;
+    service.description = `${processName} service`;
+    service.state = random.choice(['active', 'inactive', 'failed']);
+    service.sub_state = random.choice(['running', 'dead', 'exited']);
+    service.enabled = random.choice(['enabled', 'disabled', 'static']);
+    service.following = random.choice(['multi-user.target', 'none']);
+    service.object_path = `/lib/systemd/system/${processName}.service`;
+    service.target = target;
+  } else if (os === 'windows') {
+    const processName = random.choice(['wuauserv', 'winlogon', 'svchost']);
+    service.id = processName;
+    service.name = random.choice([
+      'Windows Update',
+      'Background Intelligent Transfer Service',
+      'Windows Security Center',
+    ]);
+    service.description = `${processName} service`;
+    service.state = random.choice(['RUNNING', 'STOPPED']);
+    service.start_type = random.choice(['AUTO_START', 'DEMAND_START']);
+    service.type = 'OWN_PROCESS';
+    service.exit_code = random.int(0, 15);
+    service.win32_exit_code = random.int(0, 15);
+    service.address = random.choice(['localhost', 'remotehost']);
+  } else {
+    const processName = random.choice([
+      'com.apple.safari',
+      'com.apple.finder',
+      'com.apple.Terminal',
+    ]);
+    const name =
+      processName.split('.').pop().charAt(0).toUpperCase() +
+      processName.split('.').pop().slice(1);
+    const starts = {
+      on_mount: random.choice([true, false]),
+      on_path_modified: ['/usr/local', '/etc'],
+      on_not_empty_directory: ['/var/log'],
+    };
 
-  const processName = linux
-    ? random.choice(['nginx', 'sshd', 'cron'])
-    : random.choice(['wuauserv', 'winlogon', 'svchost']);
+    service.id = processName;
+    service.name = name;
+    service.description = `${processName} service`;
+    service.start_type = random.choice(['AUTO_START', 'DEMAND_START']);
+    service.type = 'OWN_PROCESS';
+    service.enabled = random.choice(['enabled', 'disabled']);
+    service.restart = random.choice(['always', 'never', 'on-failure']);
+    service.frequency = random.int(10, 3600);
+    service.starts = starts;
+    service.inetd_compatibility = random.choice([true, false]);
+  }
+  return service;
+}
 
-  const state = linux
-    ? random.choice(['active', 'inactive', 'failed'])
-    : random.choice(['RUNNING', 'STOPPED']);
-
-  return {
-    service: {
-      id: processName,
-      name: processName.charAt(0).toUpperCase() + processName.slice(1),
-      state: state,
-      sub_state: linux ? random.choice(['running', 'dead', 'exited']) : null,
-      description: `${processName} service`,
-      exit_code:
-        state === 'active' || state === 'RUNNING' ? 0 : random.int(1, 5),
-      win32_exit_code: linux
-        ? null
-        : state === 'STOPPED'
-        ? random.int(1, 5)
-        : 0,
-      address: linux
-        ? `/lib/${processName}.so`
-        : `C:\\Windows\\System32\\${processName}.dll`,
-      enabled: linux ? random.choice(['enabled', 'disabled', 'static']) : null,
-      type: linux
-        ? 'system'
-        : random.choice(['OWN_PROCESS', 'WIN32_SHARE_PROCESS']),
-      following: linux ? random.choice(['none', 'multi-user.target']) : null,
-      object_path: linux ? `/org/freedesktop/${processName}` : null,
-      start_type: linux
-        ? null
-        : random.choice(['AUTO_START', 'DEMAND_START', 'DISABLED']),
-      target: {
-        ephemeral_id: String(random.int(1, 9999)),
-        type: random.choice(['start', 'stop']),
-        address: linux
-          ? `/systemd/job${processName}`
-          : `C:\\Jobs\\${processName}`,
-      },
-    },
-    process: {
-      pid: random.int(1, 9999),
-      executable: linux
-        ? `/usr/bin/${processName}`
-        : `${random.choice([
-            'C:\\Program Files\\App\\app.exe',
-            'C:\\Windows\\System32\\svchost.exe',
-          ])}`,
-    },
-    file: {
-      path: linux
-        ? `/usr/lib/systemd/system/${processName}.service`
-        : `C:\\Windows\\System32\\${processName}.exe`,
-    },
+function generateRandomProcess(os, state) {
+  let process = {
     user: {
-      name: random.choice(names),
+      name: random.choice(['root', 'admin', 'user']),
     },
   };
+
+  if (os === 'linux') {
+    process.executable = random.choice([
+      '/usr/bin/python3',
+      '/usr/sbin/sshd',
+      '/usr/sbin/nginx',
+    ]);
+  } else if (os === 'windows') {
+    process.pid = state === 'RUNNING' ? random.int(100, 5000) : null;
+    process.executable = random.choice([
+      'C:\\Program Files\\App\\app.exe',
+      'C:\\Windows\\System32\\svchost.exe',
+    ]);
+  } else {
+    process.executable = random.choice([
+      '/Applications/App.app/Contents/MacOS/App',
+      '/usr/bin/terminal',
+    ]);
+    process.args = random.choice([['-l', '-a'], ['--options 123'], ['-v']]);
+    process.group = {
+      name: random.choice(['admin', 'staff', 'users']),
+    };
+    process.working_directory = `/home/${random.choice([
+      'user1',
+      'user2',
+      'user3',
+    ])}`;
+    process.root_directory = `/home/${random.choice([
+      'user1',
+      'user2',
+      'user3',
+    ])}`;
+  }
+
+  return process;
 }
 
 function generateDocument(params) {
-  let document = generateRandomService();
+  let document = {};
+
+  const os = random.choice(['linux', 'windows', 'mac']);
+  if (os === 'linux') {
+    document.file = {
+      path: `/usr/lib/systemd/system/${random.choice([
+        'nginx.service',
+        'sshd.service',
+        'cron.service',
+      ])}`,
+    };
+  } else if (os === 'mac') {
+    document.file = {
+      path: `/Applications/${random.choice(['App.app', 'Service.app'])}`,
+    };
+    document.log = {
+      file: {
+        path: `/var/log/${random.choice([
+          'App.error.log',
+          'Service.error.log',
+        ])}`,
+      },
+    };
+    document.error = {
+      log: {
+        file: {
+          path: `/var/log/${random.choice([
+            'App.error.log',
+            'Service.error.log',
+          ])}`,
+        },
+      },
+    };
+  }
+
+  document.service = generateRandomService(os);
+  document.process = generateRandomProcess(os, document.service.state);
   document.agent = generateRandomAgent();
   document.wazuh = generateRandomWazuh(params);
   return document;

--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-services/template.json
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-services/template.json
@@ -18,13 +18,19 @@
           "service.state",
           "service.sub_state",
           "service.description",
-          "service.state",
+          "service.restart",
+          "service.type",
+          "service.start_type",
+          "log.file.path",
+          "error.log.file.path",
+          "process.args",
           "service.exit_code",
           "service.win32_exit_code",
           "process.pid",
           "process.executable",
           "service.address",
-          "user.name",
+          "process.user.name",
+          "process.group.name",
           "service.enabled",
           "file.path",
           "wazuh.cluster.name",
@@ -65,6 +71,22 @@
             }
           }
         },
+        "error": {
+          "properties": {
+            "log": {
+              "properties": {
+                "file": {
+                  "properties": {
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "file": {
           "properties": {
             "path": {
@@ -73,19 +95,54 @@
             }
           }
         },
+        "log": {
+          "properties": {
+            "file": {
+              "properties": {
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
         "process": {
           "properties": {
-            "executable": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
+            "args": {
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "executable": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "pid": {
               "type": "long"
+            },
+            "root_directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "working_directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -110,9 +167,15 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "frequency": {
+              "type": "long"
+            },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "inetd_compatibility": {
+              "type": "boolean"
             },
             "name": {
               "ignore_above": 1024,
@@ -122,9 +185,28 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "restart": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "start_type": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "starts": {
+              "properties": {
+                "on_mount": {
+                  "type": "boolean"
+                },
+                "on_not_empty_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "on_path_modified": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "state": {
               "ignore_above": 1024,
@@ -156,19 +238,6 @@
             },
             "win32_exit_code": {
               "type": "integer"
-            }
-          }
-        },
-        "user": {
-          "properties": {
-            "name": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },


### PR DESCRIPTION
### Description
This PR adapts the template and sample data to the new fields mapping defined in https://github.com/wazuh/wazuh-agent/issues/807#issuecomment-3212090933 for the services tab of IT Hygiene. 
 
### Issues Resolved
#7628

### Evidence
<img width="1815" height="913" alt="image" src="https://github.com/user-attachments/assets/9ef3e128-5f78-40df-bd82-483747b9cb25" />

### Test
Add sample data, navigate to the `IT Hygiene/Services` tab and verify that 
- The dashboards work as expected
- The fields in the sample data are correct according to the table mentioned in the description

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
