### PR TITLE
Update Browser extension template and sample data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.14.0
 - Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587)
 - Added ability to set the Wazuh data path (wazuh directory) within the directory defined through `path.data` setting [#7586](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7586)
-- Added a new Browser Extensions tab in IT Hygiene [#7641](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7641)
+- Added a new Browser Extensions tab in IT Hygiene [#7641](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7641) [#7696](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7696)
 - Added Microsoft Graph API module [#7516](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7516) [#7644](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7644) [#7661](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7661)
 - Added a new Services tab in IT Hygiene [#7646](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7646)
 

--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-browser-extensions/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-browser-extensions/main.js
@@ -97,12 +97,15 @@ function generateRandomPackage() {
     ),
     name: packageBase.name,
     path: `/Extensions/${packageBase.name.toLowerCase().replace(/\s+/g, '')}`,
-    permissions: random.choice(attributesPool),
+    permissions: Array.from({ length: random.int(1, 4) }, () =>
+      random.choice(attributesPool),
+    ).filter((value, index, self) => self.indexOf(value) === index),
     persistent: random.boolean(),
     reference: packageBase.id,
     type: 'extension',
     vendor: packageBase.author,
     version: random.randomVersion(),
+    visible: random.boolean(),
   };
 }
 

--- a/plugins/main/server/lib/sample-data/dataset/states-inventory-browser-extensions/template.json
+++ b/plugins/main/server/lib/sample-data/dataset/states-inventory-browser-extensions/template.json
@@ -24,7 +24,7 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "2s"
       }
     },
     "mappings": {
@@ -149,6 +149,9 @@
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "visible": {
+              "type": "boolean"
             }
           }
         },


### PR DESCRIPTION
### Description

The Browser extension template is updated according to the [Pull request](https://github.com/wazuh/wazuh/pull/31608), and the sample data is modified according to the template.
 
### Issues Resolved
- #7627 

### Evidence

<img width="2347" height="1363" alt="image" src="https://github.com/user-attachments/assets/4a997768-116b-49fb-b99f-1570422d64e5" />

### Test

Add sample data from IT hygiene, then navigate to the IT hygiene > Browser extensions view, and there should be a package.visible column, package.persmissions should be an array and package.installed should be a date.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
