### PR TITLE
Restore imposter spec

### DIFF
--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -1,6 +1,6 @@
 ---
 plugin: openapi
-specFile: https://raw.githubusercontent.com/wazuh/wazuh/v4.13.0-rc4/api/api/spec/spec.yaml
+specFile: https://raw.githubusercontent.com/wazuh/wazuh/4.13.0/api/api/spec/spec.yaml
 system:
   stores:
     # this store is preloaded from file


### PR DESCRIPTION
### Description
This pull request restores the imposter API spec reference.
 
### Issues Resolved
Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/7702


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
