### PR TITLE
Add "Back to agent list" button at the end of agent deployment flow

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -1,5 +1,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import { EuiCallOut, EuiLink, EuiSteps } from '@elastic/eui';
+import { EuiCallOut, EuiLink, EuiSteps, EuiButton } from '@elastic/eui';
+import NavigationService from '../../../../../react-services/navigation-service';
+import { SECTIONS } from '../../../../../sections';
 import './steps.scss';
 import { OPERATING_SYSTEMS_OPTIONS } from '../../utils/register-agent-data';
 import {
@@ -256,6 +258,25 @@ export const Steps = ({
               onCopy={() => setStartCommandWasCopied(true)}
             />
           ) : null}
+        </>
+      ),
+      status: startCommandStepStatus,
+    },
+    {
+      title: 'Go to endpoints to verify the agent connection:',
+      children: (
+        <>
+          <EuiButton
+            color='primary'
+            fill
+            onClick={() => {
+              NavigationService.getInstance().navigate(
+                `${SECTIONS.AGENTS_PREVIEW}`,
+              );
+            }}
+          >
+            Back to agent list
+          </EuiButton>
         </>
       ),
       status: startCommandStepStatus,


### PR DESCRIPTION
### Description
Add a final step, "Back to agent list" button at the bottom of the final deployment step.
This will allow the user to smoothly return to the agents list once they finish the enrollment process.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7706

### Evidence

<details><summary>Evidence</summary>
<p>

https://github.com/user-attachments/assets/3310666d-5acd-41ad-895c-17013eee735e
<img width="1290" height="1858" alt="Screenshot 2025-09-08 at 6 38 17 AM" src="https://github.com/user-attachments/assets/355c0cbe-58dd-45a8-a793-e87cc5aa2173" />
<img width="1577" height="1038" alt="Screenshot 2025-09-08 at 7 16 58 AM" src="https://github.com/user-attachments/assets/3af16da8-aac5-46dd-abb6-8f0b1330d5e1" />
</p>
</details> 


### Test
- Go to the `Deploy new agent` section.
- Verify the button on the final step flow and the UX is correct and smooth.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 

