### PR TITLE
Renames services tab to listeners in networks inventory

### DIFF
--- a/plugins/main/public/components/overview/it-hygiene/networks/inventory.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/networks/inventory.tsx
@@ -25,8 +25,8 @@ const tabs = [
     component: ITHygieneNetworksInventoryProtocols,
   },
   {
-    id: 'services',
-    name: 'Services',
+    id: 'listeners',
+    name: 'Listeners',
     component: ITHygieneNetworksInventoryServices,
   },
   {


### PR DESCRIPTION
### Description

The name of the Services tab has been changed to Listeners in the Networks inventory.
 
### Issues Resolved

- #7739 

### Evidence

<img width="1400" height="1296" alt="image" src="https://github.com/user-attachments/assets/db9ccedf-9f14-497f-9cde-008284633c25" />

### Test

- Navigate to IT Hygiene > Networks 
- The Listeners sub-tab should appear.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
