### PR TITLE
BugFix - Capitalize first letter for 'Passed' and 'Failed' across dashboard components and constants

### DIFF
--- a/plugins/main/public/components/overview/sca/components/dashboard/utils/dashboard-kpis.ts
+++ b/plugins/main/public/components/overview/sca/components/dashboard/utils/dashboard-kpis.ts
@@ -18,14 +18,14 @@ const checkScore = (indexPatternId: string) => ({
             passed: {
               filter: {
                 term: {
-                  'check.result': 'passed',
+                  'check.result': 'Passed',
                 },
               },
             },
             failed: {
               filter: {
                 term: {
-                  'check.result': 'failed',
+                  'check.result': 'Failed',
                 },
               },
             },
@@ -105,7 +105,7 @@ export const getKPIsPanel = (
           aggsQuery: [
             {
               input: {
-                query: 'check.result: "passed"',
+                query: 'check.result: "Passed"',
                 language: 'kuery',
               },
               label: 'Passed',
@@ -127,7 +127,7 @@ export const getKPIsPanel = (
           aggsQuery: [
             {
               input: {
-                query: 'check.result: "failed"',
+                query: 'check.result: "Failed"',
                 language: 'kuery',
               },
               label: 'Failed',

--- a/plugins/main/public/components/overview/sca/components/dashboard/utils/visualization-helpers.ts
+++ b/plugins/main/public/components/overview/sca/components/dashboard/utils/visualization-helpers.ts
@@ -40,8 +40,8 @@ export const decimalFormat = () => {
 
 export const checkResultColors = () => {
   const colors = {
-    passed: '#209280',
-    failed: '#cc5642',
+    Passed: '#209280',
+    Failed: '#cc5642',
     'Not run': '#6092c0',
     checkScoreColor: core.uiSettings.get('theme:darkMode')
       ? '#dfe5ef'

--- a/plugins/main/public/components/overview/sca/components/inventory/utils/get-vis-sca-inventory.tsx
+++ b/plugins/main/public/components/overview/sca/components/inventory/utils/get-vis-sca-inventory.tsx
@@ -6,8 +6,8 @@ import {
 } from '../../../../../../services/visualizations';
 
 const checkResultColors = {
-  passed: '#54b399',
-  failed: '#cc5642',
+  Passed: '#54b399',
+  Failed: '#cc5642',
   'Not run': '#6092c0',
 };
 

--- a/plugins/main/public/components/overview/sca/utils/constants.ts
+++ b/plugins/main/public/components/overview/sca/utils/constants.ts
@@ -1,5 +1,5 @@
 export enum CheckResult {
-  Passed = 'passed',
-  Failed = 'failed',
-  NotRun = 'not run',
+  Passed = 'Passed',
+  Failed = 'Failed',
+  NotRun = 'Not run',
 }

--- a/plugins/main/server/lib/sample-data/dataset/states-sca/main.js
+++ b/plugins/main/server/lib/sample-data/dataset/states-sca/main.js
@@ -1,7 +1,7 @@
 const random = require('../../lib/random');
 const { generateRandomAgent, generateRandomWazuh } = require('../shared-utils');
 
-const scaResults = ['passed', 'failed', 'Not run'];
+const scaResults = ['Passed', 'Failed', 'Not run'];
 
 function word() {
   const words = ['network', 'smb', 'auth', 'firewall', 'admin', 'crypto'];


### PR DESCRIPTION
### Description

This change standardizes the capitalization of SCA check result values across all dashboard components and sample data. Previously, some components used lowercase values ('passed', 'failed') while others used capitalized versions ('Passed', 'Failed'). This inconsistency could cause visualization issues where colors and data wouldn't match properly.

The changes ensure that all SCA check results now consistently use capitalized first letters:

- 'passed' → 'Passed'
- 'failed' → 'Failed'
- 'Not run' (already capitalized, remains unchanged)

This affects queries, constants, sample data generation, and visualization color mappings.

### Issues Resolved

#7741 

### Evidence

<img width="1918" height="951" alt="image" src="https://github.com/user-attachments/assets/da95c534-e012-4a1e-bf91-c670581c7626" />

### Test

1. Endpoint Security --> Configuration Assessment
2. Verify that all check result values display with proper capitalization
3. Confirm that visualization colors are correctly applied to 'Passed', 'Failed', and 'Not run' results
4. Check sample data generation produces correctly capitalized values

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
