### PR TITLE
Sort top 5 groups visualization by agent count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed navigation problem in MITRE ATT&CK framework details flyout [#7689](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7689)
 - Fixed Events count evolution visualization in Endpoint detail to use server API context filter [#7710](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7710)
+- Fixed sorting by agent count in top 5 groups visualization in endpoints summary [#7783](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7783)
 
 ## Wazuh v4.14.0 - OpenSearch Dashboards 2.19.3 - Revision 00
 

--- a/plugins/main/public/components/endpoints-summary/services/get-agents-info.test.ts
+++ b/plugins/main/public/components/endpoints-summary/services/get-agents-info.test.ts
@@ -61,9 +61,9 @@ describe('getAgents', () => {
         { label: 'windows', value: 1, color: 'mockColor3' },
       ],
       groupsData: [
+        { label: 'test2', value: 3, color: 'mockColor3' },
         { label: 'default', value: 1, color: 'mockColor1' },
         { label: 'test', value: 2, color: 'mockColor2' },
-        { label: 'test2', value: 3, color: 'mockColor3' },
       ],
       statusData: [
         {

--- a/plugins/main/public/components/endpoints-summary/services/get-agents-info.test.ts
+++ b/plugins/main/public/components/endpoints-summary/services/get-agents-info.test.ts
@@ -62,8 +62,8 @@ describe('getAgents', () => {
       ],
       groupsData: [
         { label: 'test2', value: 3, color: 'mockColor3' },
-        { label: 'default', value: 1, color: 'mockColor1' },
         { label: 'test', value: 2, color: 'mockColor2' },
+        { label: 'default', value: 1, color: 'mockColor1' },
       ],
       statusData: [
         {

--- a/plugins/main/public/components/endpoints-summary/services/get-agents-info.ts
+++ b/plugins/main/public/components/endpoints-summary/services/get-agents-info.ts
@@ -95,7 +95,7 @@ export const getAgentsInfo = async (): Promise<AgentsInfoResult> => {
 
     return {
       osData: osData.sort((a, b) => b.value - a.value).slice(0, 5),
-      groupsData: groupsData.slice(0, 5),
+      groupsData: groupsData.sort((a, b) => b.value - a.value).slice(0, 5),
       statusData,
     };
   } catch (error) {


### PR DESCRIPTION
### Description
This pull request sorts the Top 5 groups by agent count.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7782

### Evidence
<img width="2602" height="1860" alt="image" src="https://github.com/user-attachments/assets/5195ac99-32f6-4189-b4eb-95c84b9907ec" />

### Test
- Create several groups with different amounts of agents assigned
- Verify the Top 5 groups visualization is sorted by agent count

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
