### PR TITLE
Rename web browsers tab to browser extensions

### DIFF
--- a/plugins/main/public/components/overview/it-hygiene/packages/inventory.tsx
+++ b/plugins/main/public/components/overview/it-hygiene/packages/inventory.tsx
@@ -18,8 +18,8 @@ const tabs = [
     component: ITHygienePackagesInventoryHotfixes,
   },
   {
-    id: 'web-browsers',
-    name: 'Web browsers',
+    id: 'browser-extensions',
+    name: 'Browser extensions',
     component: ITHygienePackagesInventoryWebBrowsers,
   },
 ];


### PR DESCRIPTION
### Description
This pull request renames the `Software` > `Web browsers` tab to `Browser extensions`.
 
### Issues Resolved
Closes:
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7784

### Evidence
<img width="3923" height="2325" alt="image" src="https://github.com/user-attachments/assets/053c2588-1eeb-4f99-a46f-05e56db44afd" />


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
