### PR TITLE
Replace top 5 user auth failures count visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh 4.14.0
-- Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587)
+- Create Users & Groups inventories [#7554](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7554) [#7587](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7587) [#7787](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7787)
 - Added ability to set the Wazuh data path (wazuh directory) within the directory defined through `path.data` setting [#7586](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7586)
 - Added a new Browser Extensions tab in IT Hygiene [#7641](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7641) [#7696](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7696) [#7729](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7729) [#7774](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7774)
 - Added Microsoft Graph API module [#7516](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7516) [#7644](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7644) [#7661](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7661)

--- a/plugins/main/public/components/overview/it-hygiene/users/inventories/users/dashboard.ts
+++ b/plugins/main/public/components/overview/it-hygiene/users/inventories/users/dashboard.ts
@@ -60,17 +60,24 @@ export const getOverviewUsersUsersTab = (indexPatternId: string) => {
   return buildDashboardKPIPanels([
     getVisStateHorizontalBarByField(
       indexPatternId,
+      'user.name',
+      'Top 5 users',
+      'it-hygiene-users',
+      { fieldCustomLabel: 'Users' },
+    ),
+    getVisStateHorizontalBarByField(
+      indexPatternId,
       'user.groups',
       'Top 5 user groups',
       'it-hygiene-users',
-      { fieldCustomLabel: 'User group' },
+      { fieldCustomLabel: 'User groups' },
     ),
     getVisStateHorizontalBarByField(
       indexPatternId,
       'user.shell',
       'Top 5 user shells',
       'it-hygiene-users',
-      { fieldCustomLabel: 'User shell' },
+      { fieldCustomLabel: 'User shells' },
     ),
   ]);
 };

--- a/plugins/main/public/components/overview/it-hygiene/users/inventories/users/dashboard.ts
+++ b/plugins/main/public/components/overview/it-hygiene/users/inventories/users/dashboard.ts
@@ -60,17 +60,6 @@ export const getOverviewUsersUsersTab = (indexPatternId: string) => {
   return buildDashboardKPIPanels([
     getVisStateHorizontalBarByField(
       indexPatternId,
-      'user.name',
-      'Top 5 user auth failures count',
-      'it-hygiene-users',
-      {
-        metricType: 'max',
-        metricField: 'user.auth_failures.count',
-        fieldCustomLabel: 'User name',
-      },
-    ),
-    getVisStateHorizontalBarByField(
-      indexPatternId,
       'user.groups',
       'Top 5 user groups',
       'it-hygiene-users',


### PR DESCRIPTION
### Description
This pull request replaces the Top 5 user auth failures count visualization from the `Identity` > `Users` with the "Top 5 users" visualization.

### Issues Resolved

Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/7786

### Evidence

<img width="3927" height="2330" alt="image" src="https://github.com/user-attachments/assets/0a230f13-830c-4e15-8100-f79ff90a47df" />


### Test
- Check "Top 5 user auth failures count visualization" has been replaced with the "Top 5 users" visualization.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
