### PR TITLE
Changes on It hygiene > Services

### DIFF
--- a/plugins/main/public/components/overview/it-hygiene/services/dashboard.ts
+++ b/plugins/main/public/components/overview/it-hygiene/services/dashboard.ts
@@ -1,5 +1,8 @@
 import { buildDashboardKPIPanels } from '../common/create-dashboard-panels-kpis';
-import { getVisStateHorizontalBarByField } from '../common/saved-vis/generators';
+import {
+  getVisStateHorizontalBarByField,
+  getVisStateMetricUniqueCountByField,
+} from '../common/saved-vis/generators';
 
 export const getOverviewServicesTab = (indexPatternId: string) => {
   return buildDashboardKPIPanels([
@@ -12,14 +15,12 @@ export const getOverviewServicesTab = (indexPatternId: string) => {
         customLabel: 'Services',
       },
     ),
-    getVisStateHorizontalBarByField(
+    getVisStateMetricUniqueCountByField(
       indexPatternId,
-      'process.user.name',
-      'Top 5 process user names',
+      'service.name',
+      '',
       'it-hygiene-services',
-      {
-        customLabel: 'User Names',
-      },
+      'Unique services',
     ),
   ]);
 };

--- a/plugins/main/public/components/overview/it-hygiene/services/table-columns.ts
+++ b/plugins/main/public/components/overview/it-hygiene/services/table-columns.ts
@@ -1,6 +1,1 @@
-export default [
-  { id: 'agent.name' },
-  { id: 'service.name' },
-  { id: 'process.user.name' },
-  { id: 'process.executable' },
-];
+export default [{ id: 'agent.name' }, { id: 'service.name' }];


### PR DESCRIPTION
### Description

Removed `process.user.name` and `process.executable` columns from the `IT Hygiene > Services` data grid

Replaced the "Top 5 process user names" visualization with a Unique count of the service.name field
 
### Issues Resolved

- #7789 

### Evidence

<img width="636" height="441" alt="image" src="https://github.com/user-attachments/assets/91458e65-0129-4a51-8f85-8597a190fb16" />

### Test

1. Navigate to IT Hygiene > Services
2. The data grid should not have the fields: `process.user.name` and `process.executable`
3. Should have both visualizations:  `Top 5 services` and `Unique services`.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
