### PR TITLE
Hide sample data app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated Malware Detection dashboard with new index pattern definition [#8157](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8157)
 - Removed Manager UUID from Server APIs table and added Cluster UUID on About page [#8175](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8175) [#8209](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8209)
 - Updated Security Operations dashboards with new index pattern definition [#8146](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8146)
-- Removed Sample Data app and related endpoints to manage [#8214](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8214)
 
 ### Fixed
 
@@ -94,6 +93,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed `needle` dependency [#8125](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8125)
 - Removed `read-last-lines` dependency [#8125](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8125)
 - Removed Key Request configuration options from the Registration Service view [#8195](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8195)
+- Removed Sample Data app and related endpoints to manage [#8214](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8214)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.4 - Revision 00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated Malware Detection dashboard with new index pattern definition [#8157](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8157)
 - Removed Manager UUID from Server APIs table and added Cluster UUID on About page [#8175](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8175) [#8209](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8209)
 - Updated Security Operations dashboards with new index pattern definition [#8146](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8146)
+- Removed Sample Data app and related endpoints to manage [#8214](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8214)
 
 ### Fixed
 

--- a/plugins/main/public/components/visualize/components/sample-data-warning.tsx
+++ b/plugins/main/public/components/visualize/components/sample-data-warning.tsx
@@ -61,7 +61,7 @@ export const SampleDataWarning = ({
   };
 
   useEffect(() => {
-    request();
+    // request(); // Removed temporally
   }, []);
 
   if (isSampleData) {

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -798,7 +798,7 @@ export const Applications = [
   settings,
   serverApis,
   indexerSettings,
-  sampleData,
+  // sampleData,
   about,
   ITHygiene,
 ].sort((a, b) => {

--- a/plugins/main/server/routes/wazuh-elastic.ts
+++ b/plugins/main/server/routes/wazuh-elastic.ts
@@ -97,32 +97,32 @@ export function WazuhElasticRoutes(router: IRouter) {
       ctrl.haveSampleDataOfCategory(context, request, response),
   );
 
-  router.post(
-    {
-      path: '/indexer/sampledata/{category}',
-      validate: {
-        params: schema.object({
-          category: schemaSampleAlertsCategories,
-        }),
-        body: schema.any(),
-      },
-    },
-    async (context, request, response) =>
-      ctrl.createSampleData(context, request, response),
-  );
+  // router.post(
+  //   {
+  //     path: '/indexer/sampledata/{category}',
+  //     validate: {
+  //       params: schema.object({
+  //         category: schemaSampleAlertsCategories,
+  //       }),
+  //       body: schema.any(),
+  //     },
+  //   },
+  //   async (context, request, response) =>
+  //     ctrl.createSampleData(context, request, response),
+  // );
 
-  router.delete(
-    {
-      path: '/indexer/sampledata/{category}',
-      validate: {
-        params: schema.object({
-          category: schemaSampleAlertsCategories,
-        }),
-      },
-    },
-    async (context, request, response) =>
-      ctrl.deleteSampleData(context, request, response),
-  );
+  // router.delete(
+  //   {
+  //     path: '/indexer/sampledata/{category}',
+  //     validate: {
+  //       params: schema.object({
+  //         category: schemaSampleAlertsCategories,
+  //       }),
+  //     },
+  //   },
+  //   async (context, request, response) =>
+  //     ctrl.deleteSampleData(context, request, response),
+  // );
 
   router.get(
     {

--- a/plugins/main/server/routes/wazuh-elastic.ts
+++ b/plugins/main/server/routes/wazuh-elastic.ts
@@ -84,18 +84,18 @@ export function WazuhElasticRoutes(router: IRouter) {
       ctrl.getFieldTop(context, request, response),
   );
 
-  router.get(
-    {
-      path: '/indexer/sampledata/{category}',
-      validate: {
-        params: schema.object({
-          category: schemaSampleAlertsCategories,
-        }),
-      },
-    },
-    async (context, request, response) =>
-      ctrl.haveSampleDataOfCategory(context, request, response),
-  );
+  // router.get(
+  //   {
+  //     path: '/indexer/sampledata/{category}',
+  //     validate: {
+  //       params: schema.object({
+  //         category: schemaSampleAlertsCategories,
+  //       }),
+  //     },
+  //   },
+  //   async (context, request, response) =>
+  //     ctrl.haveSampleDataOfCategory(context, request, response),
+  // );
 
   // router.post(
   //   {


### PR DESCRIPTION
### Description
This pull request hides the sample data app and the endpoints to check existence, create and delete the indices.

Changes:
- Removed the Sample Data app (disabled in source code)
- Disabled endpoints to check existence create and delete  sample data indices of category
- Disabled request to check the existence of sample data category in the SampleDataWarning component
 
### Issues Resolved
#8213

### Evidence
<img width="307" height="450" alt="image" src="https://github.com/user-attachments/assets/92f4b43d-0a68-4a52-8624-e27f7b641634" />

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| In the side menu, go to Dashboard management and this should not display the sample data app. | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: In the side menu, go to Dashboard management and this should not display the sample data app.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
