### PR TITLE
Harden privacy-mode pseudonymization robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8889](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8889) | Fixed privacy-mode pseudonymization misclassifying some field names, over-scrubbing dotted field-path mentions and version strings in free text, missing identifiers embedded in allow-listed field values, and `wazuh.rule.title` having no explicit field policy                          |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8889](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8889) | Fixed privacy-mode pseudonymization misclassifying some field names, over-scrubbing dotted field-path mentions and version strings in free text, missing identifiers embedded in allow-listed field values, and `wazuh.rule.title` having no explicit field policy                          |
+| [#8889](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8889) | Fixed privacy mode misclassifying some field names, over-scrubbing dotted field paths and version strings in free text, and missing identifiers embedded in allow-listed field values         |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8889](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8889) | Fixed privacy mode misclassifying some field names, over-scrubbing dotted field paths and version strings in free text, and missing identifiers embedded in allow-listed field values         |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
@@ -8,8 +8,10 @@ import {
   prescanAndMint,
   prescanAndMintToolContent,
   FieldPolicyEntry,
+  FIELD_POLICY_DEFAULTS,
 } from './privacy';
 import { Digest } from './digest';
+import { WAZUH_FIELD } from '../../common/wazuh-fields';
 
 // --- prescanAndMint (first-mention inbound pre-scan) ------------------------------------------
 
@@ -51,6 +53,40 @@ test('prescanAndMint: leaves an ISO-8601 timestamp fragment untouched (29.000Z)'
   const out = prescanAndMint('at 2026-07-15T21:59:29.000Z something', p);
   assert.doesNotMatch(out, /HOST_\d+/);
   assert.match(out, /29\.000Z/);
+});
+
+// --- prescanAndMint: #8889 dotted-token scanner narrowing --------------------------------------
+
+test('prescanAndMint: leaves a field-path mention (wazuh.agent.name) untouched', () => {
+  const p = new Pseudonymizer();
+  // Before this fix, naming a dotted field in free text ("what is wazuh.agent.name for host X?")
+  // got that mention replaced with a HOST_n, breaking the user's own query.
+  const out = prescanAndMint('what does wazuh.agent.name look like here?', p);
+  assert.doesNotMatch(out, /HOST_\d+/);
+  assert.match(out, /wazuh\.agent\.name/);
+});
+
+test('prescanAndMint: leaves another field-path mention (wazuh.rule.id) untouched', () => {
+  const p = new Pseudonymizer();
+  const out = prescanAndMint('filter on wazuh.rule.id please', p);
+  assert.doesNotMatch(out, /HOST_\d+/);
+  assert.match(out, /wazuh\.rule\.id/);
+});
+
+test('prescanAndMint: leaves a Debian/Ubuntu-style package version string untouched', () => {
+  const p = new Pseudonymizer();
+  // Before this fix, a version string like this minted a bogus HOST_n, undermining a
+  // package.version:{allow} query about the same package.
+  const out = prescanAndMint('openssl 5.2.5-2ubuntu1 is installed', p);
+  assert.doesNotMatch(out, /HOST_\d+/);
+  assert.match(out, /5\.2\.5-2ubuntu1/);
+});
+
+test('prescanAndMint: still mints a real hostname that is not field-path or version shaped', () => {
+  const p = new Pseudonymizer();
+  const out = prescanAndMint('connect to backup-vault.internal.corp now', p);
+  assert.match(out, /HOST_\d+/);
+  assert.doesNotMatch(out, /backup-vault\.internal\.corp/);
 });
 
 // --- prescanAndMintToolContent (JSON-aware digest pre-scan) -----------------------------------
@@ -138,6 +174,23 @@ test('inferPseudonymKind: infers kind prefixes from field names', () => {
   assert.equal(inferPseudonymKind('agent.name'), 'HOST');
   assert.equal(inferPseudonymKind('predecoder.hostname'), 'HOST');
   assert.equal(inferPseudonymKind('GeoLocation.country_name'), 'VAL');
+});
+
+test('inferPseudonymKind: #8889 no longer misclassifies "description" as an IP field', () => {
+  // 'wazuh.rule.description'.includes('ip') is true ("descr-IP-tion") under raw substring
+  // matching -- the bug this fix closes. A description field is generic free text (VAL), not IP.
+  assert.equal(inferPseudonymKind('wazuh.rule.description'), 'VAL');
+  // Same substring trap, different word: "recipient" also contains "ip" mid-word.
+  assert.equal(inferPseudonymKind('email.recipient'), 'VAL');
+});
+
+test('inferPseudonymKind: still infers IP for an actual "...ip"-shaped field', () => {
+  // A real, curated field (WAZUH_FIELD.AGENT_IP) whose final path segment IS the word "ip".
+  assert.equal(inferPseudonymKind(WAZUH_FIELD.AGENT_IP), 'IP');
+  // Legacy Wazuh alert field with no delimiter before "ip" -- must still match as a suffix.
+  assert.equal(inferPseudonymKind('data.srcip'), 'IP');
+  // "ip_address": splitting on '_' isolates "ip" as its own token.
+  assert.equal(inferPseudonymKind('data.ip_address'), 'IP');
 });
 
 // --- Pseudonymizer -----------------------------------------------------------------------------
@@ -290,6 +343,59 @@ test('applyFieldPolicy: "anonymize" field is pseudonymized', () => {
   const digest = baseDigest({ samples: [{ 'agent.name': 'web-01.corp' }] });
   const out = applyFieldPolicy(digest, policy, p);
   assert.match(out.samples[0]['agent.name'] as string, /^HOST_\d+$/);
+});
+
+// --- applyFieldPolicy: #8889 value-shape scan over allow-by-omission field values ---------------
+
+test('applyFieldPolicy: allow-by-omission value with an embedded IP still gets scanned', () => {
+  // "package.name" has no FIELD_POLICY_DEFAULTS entry -- it stays readable (allow-by-omission),
+  // but before this fix an identifier embedded in it had no secondary scan at all.
+  const policy: FieldPolicyEntry[] = [];
+  const p = new Pseudonymizer();
+  const digest = baseDigest({
+    samples: [
+      { 'package.name': 'connector reaching out to 203.0.113.7 for updates' },
+    ],
+  });
+  const out = applyFieldPolicy(digest, policy, p, undefined, undefined, false);
+  const value = out.samples[0]['package.name'] as string;
+  assert.doesNotMatch(value, /203\.0\.113\.7/);
+  assert.match(value, /^connector reaching out to IP_\d+ for updates$/);
+});
+
+test('applyFieldPolicy: allow-by-omission value with an embedded FQDN still gets scanned', () => {
+  const policy: FieldPolicyEntry[] = [];
+  const p = new Pseudonymizer();
+  const digest = baseDigest({
+    samples: [
+      {
+        'get_agent_processes/cmd':
+          'curl https://backup-vault.internal.corp/agent',
+      },
+    ],
+  });
+  const out = applyFieldPolicy(digest, policy, p, undefined, undefined, false);
+  const value = out.samples[0]['get_agent_processes/cmd'] as string;
+  assert.doesNotMatch(value, /backup-vault\.internal\.corp/);
+  assert.match(value, /^curl https:\/\/HOST_\d+\/agent$/);
+});
+
+test('applyFieldPolicy: an EXPLICIT "allow" entry is not scanned for embedded IPs/FQDNs', () => {
+  // Deliberate scoping (see the samples-loop comment in privacy.ts): an explicit entry is a
+  // reviewed decision (e.g. a curated taxonomy field), left exactly as before -- only the
+  // allow-BY-OMISSION path gets the new scan.
+  const policy: FieldPolicyEntry[] = [
+    { field: 'check.name', action: 'allow' },
+  ];
+  const p = new Pseudonymizer();
+  const digest = baseDigest({
+    samples: [{ 'check.name': 'Reach out to 203.0.113.7 if this fails' }],
+  });
+  const out = applyFieldPolicy(digest, policy, p, undefined, undefined, false);
+  assert.equal(
+    out.samples[0]['check.name'],
+    'Reach out to 203.0.113.7 if this fails',
+  );
 });
 
 test('applyFieldPolicy: unlisted field passes through when isEscapeHatch is false', () => {
@@ -522,15 +628,20 @@ test('applyFieldPolicy: resolves the aggregated field tool-scoped, like every ot
     'get_top_agents',
   );
   assert.deepEqual(scoped.samples, [{ doc_count: 7 }]);
-  // Another tool's aggregation over the same field is not affected by that scoped entry.
+  // Another tool's aggregation over the same field is not affected by that scoped entry. Uses a
+  // bare, non-dotted value on purpose (unlike the "scoped" case above): this resolves to
+  // allow-BY-OMISSION for "get_top_rules" (the policy only has a "get_top_agents/..." scoped
+  // entry), which since #8889 runs the IP/FQDN value-shape scan (see applyFieldPolicy's samples
+  // loop) — a dotted, FQDN-shaped value like "web-01.corp" would legitimately get minted there,
+  // which would test that scan instead of the tool-scoping isolation this test is actually about.
   const other = applyFieldPolicy(
-    baseDigest({ samples: [{ key: 'web-01.corp', doc_count: 7 }] }),
+    baseDigest({ samples: [{ key: 'web-01', doc_count: 7 }] }),
     policy,
     p,
     { top_agents: 'wazuh.agent.name' },
     'get_top_rules',
   );
-  assert.deepEqual(other.samples, [{ key: 'web-01.corp', doc_count: 7 }]);
+  assert.deepEqual(other.samples, [{ key: 'web-01', doc_count: 7 }]);
 });
 
 test('applyFieldPolicy: a real field named "key" is unaffected without an aggregation', () => {
@@ -559,4 +670,19 @@ test('applyFieldPolicy: an aggregation with no extractable field leaves "key" al
   assert.deepEqual(out.samples, [
     { key: '2026-07-31T00:00:00Z', doc_count: 3 },
   ]);
+});
+
+// --- FIELD_POLICY_DEFAULTS: #8889 explicit entry for a commonly-surfaced field -------------------
+
+test('FIELD_POLICY_DEFAULTS: wazuh.rule.title has an explicit entry, not allow-by-omission', () => {
+  const entry = FIELD_POLICY_DEFAULTS.find(
+    e => e.field === WAZUH_FIELD.RULE_TITLE,
+  );
+  assert.ok(
+    entry,
+    'wazuh.rule.title must have an explicit policy entry, not rely on allow-by-omission',
+  );
+  // Reviewed 'allow' (see the entry's own comment in privacy.ts for the reasoning and the
+  // residual risk) -- an intentional decision, not a default.
+  assert.equal(entry!.action, 'allow');
 });

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
@@ -384,9 +384,7 @@ test('applyFieldPolicy: an EXPLICIT "allow" entry is not scanned for embedded IP
   // Deliberate scoping (see the samples-loop comment in privacy.ts): an explicit entry is a
   // reviewed decision (e.g. a curated taxonomy field), left exactly as before -- only the
   // allow-BY-OMISSION path gets the new scan.
-  const policy: FieldPolicyEntry[] = [
-    { field: 'check.name', action: 'allow' },
-  ];
+  const policy: FieldPolicyEntry[] = [{ field: 'check.name', action: 'allow' }];
   const p = new Pseudonymizer();
   const digest = baseDigest({
     samples: [{ 'check.name': 'Reach out to 203.0.113.7 if this fails' }],

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.ts
@@ -77,6 +77,21 @@ export const FIELD_POLICY_DEFAULTS: FieldPolicyEntry[] = [
   // analyst/attacker-supplied — reviewed 'allow'.
   { field: WAZUH_FIELD.RULE_TAGS, action: 'allow' },
   { field: WAZUH_FIELD.RULE_CATEGORY, action: 'allow' },
+  // Explicit entry added for #8889: wazuh.rule.title is in every finding-hits tool's sample
+  // columns (catalog/common.ts's STANDARD_FINDING_SAMPLE_COLUMNS) but previously had no policy
+  // entry at all, so it reached the provider through allow-by-omission rather than an intentional
+  // decision. Reviewed 'allow', not 'anonymize': the overwhelming majority of titles are fixed
+  // strings from Wazuh's own curated ruleset — the model needs the real text to name/describe a
+  // finding, and anonymizing this high-cardinality field would replace nearly every distinct
+  // finding's label with its own opaque VAL_n, gutting the assistant's usefulness (the same
+  // tradeoff already made for rule.category/rule.tags above). The residual risk is real, not
+  // hypothetical, though: a LOCAL/custom rule's <description> can interpolate a decoder capture
+  // group (e.g. "Failed login from $(srcip)"), so a title CAN echo attacker-influenced log
+  // content, unlike the closed-vocabulary rule.category/rule.tags. That is not left unaddressed —
+  // it is covered at a different layer: chat.ts's scrubMessagesForProvider runs
+  // prescanAndMintToolContent over every tool-result string value (this one included) before it
+  // reaches the provider, so an embedded IP/FQDN in a custom title is still pseudonymized there.
+  { field: WAZUH_FIELD.RULE_TITLE, action: 'allow' },
   // Wildcard covers every compliance framework (pci_dss, hipaa, gdpr, iso_27001, nis2,
   // nist_800_171, nist_800_53, fedramp, cmmc, tsc, ...), not just the one this plugin has a
   // dedicated tool for — all are curated requirement-tag lists, equally not
@@ -115,22 +130,65 @@ export interface PseudonymEntry {
   pseudonym: string;
 }
 
+/** Splits a field name into lowercase word tokens on '.', '_', '-', and camelCase boundaries —
+ * e.g. "data.srcuser" -> ["data","srcuser"] (no internal boundary inside "srcuser"), "GeoLocation"
+ * -> ["geo","location"], "country_name" -> ["country","name"]. Used by `inferPseudonymKind` so a
+ * keyword match is checked against a whole TOKEN (or a token's own prefix/suffix), never against
+ * an arbitrary substring floating in the middle of an unrelated word. */
+function fieldNameTokens(field: string): string[] {
+  return field
+    .split(/[.\-_]+/)
+    .flatMap(segment => segment.split(/(?<=[a-z0-9])(?=[A-Z])/))
+    .map(token => token.toLowerCase())
+    .filter(token => token.length > 0);
+}
+
+/** True when `keyword` occupies the WHOLE of `token`, or is glued to it as a prefix/suffix with no
+ * delimiter in between (e.g. "srcip"/"dstip" end with "ip", "clientuser" ends with "user") — but
+ * NOT when it merely appears somewhere in the middle, which is what let 'wazuh.rule.description'
+ * misclassify as an IP field before this fix (`'description'.includes('ip')` is true — "descr-IP-
+ * tion" — because raw substring search has no concept of a word boundary). */
+function tokenMatchesKeyword(token: string, keyword: string): boolean {
+  return (
+    token === keyword || token.startsWith(keyword) || token.endsWith(keyword)
+  );
+}
+
 /** Infers which pseudonym kind a field name should mint, from the field name alone ("kind
  * inferred from field name"). Checked in this order so a field matching more than one heuristic
  * (there are none in FIELD_POLICY_DEFAULTS today) resolves predictably; falls back to the generic
- * `VAL` kind for a field that is none of host/ip/user/url. */
+ * `VAL` kind for a field that is none of host/ip/user/url.
+ *
+ * Matches on whole tokens (see `fieldNameTokens`/`tokenMatchesKeyword`), not a raw substring of
+ * the entire field string — the previous `lower.includes('ip')` style check flagged any field
+ * whose name merely *contained* "ip" as a substring, e.g. 'wazuh.rule.description' ("descr-IP-
+ * tion") or 'recipient', misclassifying them as IP fields and making the model narrate their
+ * (actually opaque, unrelated-kind) pseudonym tokens as literal IP addresses. Compound field names
+ * with no delimiter (e.g. legacy Wazuh alert fields like "data.srcip"/"data.srcuser") still match,
+ * because the keyword only needs to be a prefix/suffix of a token, not the whole token. */
 export function inferPseudonymKind(field: string): PseudonymKind {
-  const lower = field.toLowerCase();
-  if (lower.includes('url')) {
+  const tokens = fieldNameTokens(field);
+  const hasKeyword = (keyword: string) =>
+    tokens.some(token => tokenMatchesKeyword(token, keyword));
+  if (hasKeyword('url')) {
     return 'URL';
   }
-  if (lower.includes('ip')) {
+  if (hasKeyword('ip')) {
     return 'IP';
   }
-  if (lower.includes('user')) {
+  if (hasKeyword('user')) {
     return 'USER';
   }
-  if (lower.includes('hostname') || lower.endsWith('.name')) {
+  if (hasKeyword('hostname')) {
+    return 'HOST';
+  }
+  // A field path's LAST '.'-delimited segment being the bare word "name" is this repo's
+  // hostname-alias convention (e.g. "wazuh.agent.name") — deliberately an exact match on the
+  // final PATH segment (split only on '.', unlike the token check above) so a within-segment
+  // compound like "country_name" (a place name, not a host) is not swept in; only a path
+  // structurally ending in ".name" is.
+  const pathSegments = field.split('.');
+  if (pathSegments[pathSegments.length - 1].toLowerCase() === 'name') {
     return 'HOST';
   }
   return 'VAL';
@@ -407,6 +465,44 @@ const FQDN_TOKEN_RE = new RegExp(
  * two-label FQDN shape. `prescanAndMint` leaves these untouched. */
 const ALL_NUMERIC_DOTTED_RE = /^[0-9.]+Z?$/;
 
+/** A dotted token shaped like a package/software version string: an optional leading "v" (common
+ * in semver, e.g. "v1.2.3"), then one-or-more digit-only labels, optionally followed by a single
+ * "-suffix" (a Debian/Ubuntu-style package revision, e.g. the "-2ubuntu1" in "5.2.5-2ubuntu1").
+ * `prescanAndMint` leaves these untouched — otherwise minting a HOST_n for a version string
+ * undermines a `package.version:{allow}`-style query the user is asking about. Deliberately
+ * requires the token to START with (optional "v" +) a digit: a real hostname's first label is
+ * essentially never digits-only immediately followed by more dotted digit labels, so this can't
+ * exclude a genuine hostname like "backup-vault.internal.corp" (starts with a letter). */
+const VERSION_LIKE_TOKEN_RE = /^v?\d+(?:\.\d+)+(?:-[0-9A-Za-z.]+)?$/i;
+
+/** Every dot-path SEGMENT word appearing in a curated Wazuh/ECS field name — drawn from
+ * `WAZUH_FIELD`'s values and every plain field in `FIELD_POLICY_DEFAULTS` (a tool-scope
+ * "toolName/" prefix and the trailing ".*" wildcard are stripped first, since those aren't part of
+ * the path itself), all lowercased. Self-updating: a field added to either source is automatically
+ * recognized here — no separate list to hand-maintain. Used by `isFieldPathToken` below. */
+const FIELD_PATH_WORDS: ReadonlySet<string> = new Set(
+  [
+    ...Object.values(WAZUH_FIELD),
+    ...FIELD_POLICY_DEFAULTS.map(entry => entry.field),
+  ]
+    .map(field => field.split('/').pop() as string) // drop a "toolName/" scoping prefix, if any
+    .flatMap(field => field.replace(/\.\*$/, '').split('.'))
+    .map(segment => segment.toLowerCase())
+    .filter(segment => segment.length > 0),
+);
+
+/** True when every '.'-separated segment of `token` is a known field-path word (see
+ * `FIELD_PATH_WORDS`) — i.e. `token` reads as the user NAMING A FIELD (e.g. typing
+ * "wazuh.agent.name" or "wazuh.rule.id" into their own question), not an actual hostname.
+ * Deliberately requires ALL segments to match, not just one: a real hostname composed entirely of
+ * words that also happen to be field-path vocabulary is exotic enough to accept the (favorable)
+ * tradeoff of never mangling a user's own field-path mention into a broken HOST_n token. */
+function isFieldPathToken(token: string): boolean {
+  return token
+    .split('.')
+    .every(segment => FIELD_PATH_WORDS.has(segment.toLowerCase()));
+}
+
 /**
  * First-mention pre-scan: mints a pseudonym for every IPv4/IPv6 address
  * and dotted-hostname (FQDN) token found in `text`, using the SAME `pseudonymizer` instance the
@@ -420,6 +516,13 @@ const ALL_NUMERIC_DOTTED_RE = /^[0-9.]+Z?$/;
  * Scan order matters and is fixed: IPv4, then IPv6, then FQDN — an IPv4 octet run must be minted
  * (and thus removed from the text) before the FQDN pass runs, or a bare IP could otherwise be
  * mis-read as a dotted hostname and minted with the wrong `kind`.
+ *
+ * The FQDN pass additionally excludes (in order checked): an all-numeric dotted run or ISO
+ * timestamp fragment (`ALL_NUMERIC_DOTTED_RE`, pre-existing), a version/package-revision string
+ * (`VERSION_LIKE_TOKEN_RE` — e.g. "5.2.5-2ubuntu1" would otherwise undermine a
+ * `package.version:{allow}` query), and a field-path-shaped token (`isFieldPathToken` — e.g. the
+ * user typing "wazuh.agent.name"/"wazuh.rule.id" would otherwise get that mention replaced with a
+ * HOST_n, breaking their own query and making the model claim the field doesn't exist).
  *
  * Deliberately conservative (documented limitation): a bare
  * single-word hostname ("webserver", no dot) is NEVER matched — only `label.label[...]` forms are,
@@ -442,7 +545,11 @@ export function prescanAndMint(
     pseudonymizer.pseudonymize(token, 'IP'),
   );
   out = out.replace(FQDN_TOKEN_RE, token => {
-    if (ALL_NUMERIC_DOTTED_RE.test(token)) {
+    if (
+      ALL_NUMERIC_DOTTED_RE.test(token) ||
+      VERSION_LIKE_TOKEN_RE.test(token) ||
+      isFieldPathToken(token)
+    ) {
       return token;
     }
     return pseudonymizer.pseudonymize(token, 'HOST');
@@ -597,8 +704,12 @@ export function extractAggFields(
  * `breakdown`, and `message`.
  *
  * - `samples`: 'never' fields are dropped from the sample object entirely; 'anonymize' string
- *   values are pseudonymized (kind inferred from the field name); 'allow' fields pass through
- *   unchanged. An UNLISTED field's behavior depends on `isEscapeHatch` (see below).
+ *   values are pseudonymized (kind inferred from the field name); an explicit 'allow' field
+ *   passes through unchanged. An UNLISTED field's behavior depends on `isEscapeHatch` (see
+ *   below) — and, when it stays allowed (the non-escape-hatch default), its string value is
+ *   still run through `prescanAndMint`'s IP/FQDN value-shape scan (#8889) so an identifier
+ *   embedded in otherwise-readable free text is not missed just because the field itself is
+ *   trusted.
  *   AGGREGATION samples are the one exception to "resolve by the sample's own field name": a bucket
  *   row's keys are `key`/`doc_count` (digest.ts's `bucketsToRows`), and `key` holds a VALUE of the
  *   AGGREGATED field, not of a field literally called "key". Resolving it by name matched no policy
@@ -678,6 +789,22 @@ export function applyFieldPolicy(
           value,
           inferPseudonymKind(field),
         );
+      } else if (!entry && typeof value === 'string' && value.length > 0) {
+        // #8889: allow-BY-OMISSION (typed tool, no explicit policy entry — the escape-hatch case
+        // above already handled isEscapeHatch). The value still reaches the provider verbatim,
+        // same as before, but an IP/FQDN embedded in otherwise-free text (e.g. a package/process
+        // name that happens to mention a hostname) previously had no secondary scan at all.
+        // Deliberately narrower than "every allow-resolved value": an EXPLICIT policy entry
+        // (agent id, MITRE technique IDs — which use dotted sub-technique notation like
+        // "T1059.001" —, compliance citations, CIS benchmark content, ...) is a reviewed, curated
+        // decision (see FIELD_POLICY_DEFAULTS' comments above) and several of those values are
+        // legitimately FQDN-token-shaped without being hostnames; scanning them here too would
+        // misfire. Those stay covered end-to-end regardless: chat.ts's scrubMessagesForProvider
+        // runs prescanAndMintToolContent over every tool-result string value, regardless of field
+        // policy, right before the request leaves the server. Bare single-word identifiers are
+        // still not caught here (see prescanAndMint's own doc comment) — only the
+        // embedded-IP/FQDN case closes.
+        out[sampleKey] = prescanAndMint(value, pseudonymizer);
       } else {
         out[sampleKey] = value;
       }
@@ -713,6 +840,14 @@ export function applyFieldPolicy(
             bucket.key,
             inferPseudonymKind(field),
           ),
+        });
+      } else if (!entry) {
+        // #8889: same allow-by-omission value-shape scan as the samples loop above (see that
+        // branch's comment), applied to bucket keys — each bucket key IS a value of the
+        // aggregated field.
+        scrubbed.push({
+          ...bucket,
+          key: prescanAndMint(bucket.key, pseudonymizer),
         });
       } else {
         scrubbed.push(bucket);


### PR DESCRIPTION
## Description

Closes #8889

Privacy mode pseudonymizes sensitive values in tool results before they are sent to the model provider. A review of that path (`plugins/wazuh-ai-assistant/server/tools/privacy.ts`) surfaced four robustness gaps where the scrubbing was either too loose (an identifier reached the provider) or too aggressive (a value the user needed was rewritten). None of them is a new regression — they are pre-existing sharp edges in the pseudonymization heuristics. Two of them are user-visible: the over-aggressive dotted-token scanner silently breaks a query when a user names a dotted field (e.g. asks about `wazuh.agent.name`) or asks about a package version, and the substring-based field-kind inference makes the model narrate an unrelated field's opaque token as if it were a literal IP address.

The changes are confined to the pseudonymization layer; no tool, route, or provider contract changes.

## Proposed Changes

**1. Field-kind inference now matches whole tokens, not raw substrings** (`inferPseudonymKind`)

The old check was `field.toLowerCase().includes('ip')`, which is true for `wazuh.rule.description` — "descr-**ip**-tion" — so description-style fields were classified as IP fields and the model was told their opaque pseudonyms were IP addresses. Field names are now split into word tokens on `.`, `_`, `-`, and camelCase boundaries (`fieldNameTokens`), and a keyword must occupy a whole token or be glued to it as a prefix/suffix (`tokenMatchesKeyword`). Compound legacy Wazuh alert fields (`data.srcip`, `data.srcuser`) still classify correctly because the keyword only has to be a token suffix.

The `.name` → `HOST` alias rule was also tightened to an exact match on the final **path** segment, so `country_name` (a place, not a host) is no longer swept in while `wazuh.agent.name` still is.

**2. The FQDN/dotted-token scanner no longer rewrites version strings or field paths** (`prescanAndMint`)

Two new exclusions alongside the pre-existing all-numeric/timestamp one:

- `VERSION_LIKE_TOKEN_RE` — a semver/Debian-revision shape (`5.2.5-2ubuntu1`, `v1.2.3`). Minting a `HOST_n` here undermined the `package.version` query the user was asking about. It requires the token to start with an optional `v` plus a digit, so a real hostname (whose first label is essentially never digits-only) can't be excluded by it.
- `isFieldPathToken` — every `.`-separated segment being a known field-path word means the token reads as the user *naming a field*, not a hostname. The word set (`FIELD_PATH_WORDS`) is derived from `WAZUH_FIELD`'s values and `FIELD_POLICY_DEFAULTS`' entries, so it self-updates when a field is added — there is no parallel list to hand-maintain.

Real hostnames like `backup-vault.internal.corp` still mint as before.

**3. Allow-by-omission values now get a value-shape scan** (`applyFieldPolicy`)

A field with no `FIELD_POLICY_DEFAULTS` entry on a typed tool resolves to "allow" by omission and previously skipped any secondary scan, so an IP or FQDN embedded in otherwise free text passed through. Both the samples loop and the aggregation-breakdown loop now run `prescanAndMint` over that case. The field itself stays readable; only an embedded identifier is replaced.

> **Deviation from the issue's suggested treatment, deliberate.** The issue suggested scanning *all* allow-listed values. This is scoped to allow-**by-omission** only, and explicit `action: 'allow'` entries are left exactly as before. An explicit entry is a reviewed decision, and several of those curated values are legitimately FQDN-token-shaped without being hostnames — MITRE sub-technique IDs (`T1059.001`), compliance citations, CIS benchmark text — so scanning them would misfire and corrupt them. Those values are not left unscanned: `chat.ts`'s `scrubMessagesForProvider` runs `prescanAndMintToolContent` over every tool-result string value regardless of field policy, immediately before the request leaves the server. A test pins this scoping so it isn't "fixed" later by mistake.

**4. `wazuh.rule.title` has an explicit policy entry**

It appears in every finding-hits tool's sample columns (`catalog/common.ts`'s `STANDARD_FINDING_SAMPLE_COLUMNS`) but had no entry at all, so it reached the provider by omission rather than by decision. Reviewed and set to `'allow'`, with the reasoning and the accepted residual risk recorded inline: titles are overwhelmingly fixed strings from Wazuh's curated ruleset and the model needs the real text to name a finding, but a custom rule's `<description>` can interpolate a decoder capture group, so a title *can* echo attacker-influenced content. That case is covered by the `chat.ts` pass described above.

`catalog/common.ts` itself is unchanged — the issue referenced it only to identify which field was missing a policy.

### Results and Evidence

Unit tests (in the `osd-dev` container), full plugin suite:

```
Test Suites: 57 passed, 57 total
Tests:       755 passed, 755 total
Time:        34.863 s
```

`server/tools/privacy.test.ts` alone: **48 passed**, including all 10 new cases and the `FIELD_POLICY_DEFAULTS: wazuh.rule.title has an explicit entry, not allow-by-omission` guard.

Prettier (2.8.8, the version the plugins pin and CI installs) and ESLint are clean on all changed files.

<!-- Not a UI change: this is server-side scrubbing with no rendered surface. The
     observable behaviour is verified by the colocated unit tests above; the manual
     end-to-end reproduction is in "How to Test" below if a reviewer wants a screenshot
     of the assistant answering a dotted-field question with privacy mode on. -->

#### How to Test

With privacy mode enabled in the AI Assistant settings:

1. Ask a question that names a dotted field, e.g. *"how many findings per `wazuh.agent.name`?"* → the field name must appear verbatim in the request and the query must succeed. Before this change the mention was replaced with a `HOST_n` token and the model replied that the field did not exist.
2. Ask about a package version, e.g. *"which agents have openssl 3.0.2 installed?"* → the version string must survive intact.
3. Ask something that surfaces a description-style field → its pseudonym must be a `VAL_n`, not an `IP_n`, and the model must not describe it as an IP address.

### Artifacts Affected

- `plugins/wazuh-ai-assistant` — server-side only (`server/tools/privacy.ts`). No packaging, executable, or default-configuration change.

### Configuration Changes

None. No new settings and no changed defaults. `FIELD_POLICY_DEFAULTS` gains one explicit `wazuh.rule.title` entry, which records the behaviour that field already had (allowed) rather than changing it.

### Documentation Updates

None required. The reasoning for each decision — including the accepted residual risk on `wazuh.rule.title` and the deliberate scoping in item 3 — is documented inline at the code it governs.

### Tests Introduced

10 new colocated cases in `plugins/wazuh-ai-assistant/server/tools/privacy.test.ts`, one per acceptance criterion:

Scanner exclusions (`prescanAndMint`):
- leaves a field-path mention (`wazuh.agent.name`) untouched
- leaves another field-path mention (`wazuh.rule.id`) untouched
- leaves a Debian/Ubuntu-style package version string untouched
- still mints a real hostname that is not field-path or version shaped *(guards against over-correcting)*

Field-kind inference:
- no longer misclassifies `description` as an IP field
- still infers IP for an actual `...ip`-shaped field *(guards against over-correcting)*

Allow-by-omission scan (`applyFieldPolicy`):
- allow-by-omission value with an embedded IP still gets scanned
- allow-by-omission value with an embedded FQDN still gets scanned
- an EXPLICIT `allow` entry is **not** scanned for embedded IPs/FQDNs *(pins the deliberate scoping)*

Policy coverage:
- `FIELD_POLICY_DEFAULTS`: `wazuh.rule.title` has an explicit entry, not allow-by-omission

One pre-existing test's fixture was adjusted: it used `web-01.corp` for a field resolved by allow-by-omission, which the new scan now pseudonymizes. Changed to a non-dotted value so the test keeps asserting what it was written for (tool-scoping isolation) instead of accidentally asserting the new behaviour.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
