### PR TITLE
Ask for the answer on the final tool round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8893](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8893) | Fixed the AI Assistant ending a turn with no written answer after using up its tool rounds, leaving fallback text above a populated results table                                              |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8893](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8893) | Fixed the AI Assistant ending a turn with no written answer after using up its tool rounds, leaving fallback text above a populated results table                                              |
+| [#8893](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8893) | Fixed the AI Assistant ending a turn with no written answer after using up its tool rounds, leaving fallback text above a populated results table                                             |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8893](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8893) | Fixed the AI Assistant ending a turn with no written answer after using up its tool rounds, leaving fallback text above a populated results table                                             |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/routes/chat-final-round-instruction.test.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/chat-final-round-instruction.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { ChatMessage } from '../../common/types';
+import {
+  FINAL_ROUND_ANSWER_INSTRUCTION,
+  withFinalRoundAnswerInstruction,
+} from './chat';
+
+/**
+ * Issue #8893: a turn that exhausted the tool-round budget ended with no model-written text at all.
+ * Dropping `tools` on the final round terminates the tool loop but never ASKS for a conclusion, so
+ * the model rationally produced nothing and the user got the `!sawAnyDelta` fallback copy sitting
+ * above a populated results table (4 of 6 such turns in a 40-question persona bank).
+ * `withFinalRoundAnswerInstruction` is chat.ts's fix, kept pure so the decision is testable without
+ * standing up a fake `orchestrate` run.
+ *
+ * NOTE (needs the OSD tree to actually run): server/routes/chat.ts imports
+ * `../../../../src/core/server` and `@osd/config-schema`, which only resolve inside the full
+ * wazuh-dashboard checkout this repo is built against — same constraint as
+ * chat-stream-limiter.test.ts, and this file follows the same colocated-unit-test convention.
+ */
+
+function conversation(): ChatMessage[] {
+  return [
+    { role: 'system', content: 'system prompt' },
+    { role: 'user', content: 'which agents have critical findings?' },
+    {
+      role: 'assistant',
+      content: '',
+      toolCalls: [
+        { id: 'call_1', name: 'get_critical_findings', arguments: {} },
+      ],
+    },
+    { role: 'tool', content: '{"counts":{"total":26}}', toolCallId: 'call_1' },
+  ];
+}
+
+test('withFinalRoundAnswerInstruction: appends the instruction on the final round of a tool-using turn', () => {
+  const messages = conversation();
+  const out = withFinalRoundAnswerInstruction(messages, true, true);
+
+  assert.equal(
+    out.length,
+    messages.length + 1,
+    'exactly one message is added, never more',
+  );
+  assert.deepEqual(out[out.length - 1], {
+    role: 'system',
+    content: FINAL_ROUND_ANSWER_INSTRUCTION,
+  });
+});
+
+test('withFinalRoundAnswerInstruction: the instruction goes LAST, after the tool results', () => {
+  const out = withFinalRoundAnswerInstruction(conversation(), true, true);
+  // The whole point is that it is the most recent thing the model reads — placed before the tool
+  // results it would be answering a question about data it had not seen yet.
+  assert.equal(out[out.length - 1].content, FINAL_ROUND_ANSWER_INSTRUCTION);
+  assert.equal(out[out.length - 2].role, 'tool');
+});
+
+test('withFinalRoundAnswerInstruction: no-tool turn is left alone, even on the final round', () => {
+  // A `general`-routed turn has no gathered results, so "use only the tool results already
+  // gathered" would be a lie; that path's silence has its own fix and its own fallback copy.
+  const messages = conversation();
+  const out = withFinalRoundAnswerInstruction(messages, true, false);
+  assert.equal(out, messages, 'returns the SAME reference, not a copy');
+});
+
+test('withFinalRoundAnswerInstruction: non-final rounds are left alone', () => {
+  const messages = conversation();
+  assert.equal(
+    withFinalRoundAnswerInstruction(messages, false, true),
+    messages,
+  );
+  assert.equal(
+    withFinalRoundAnswerInstruction(messages, false, false),
+    messages,
+  );
+});
+
+test('withFinalRoundAnswerInstruction: never mutates the caller array', () => {
+  // chat.ts passes `messages` ITSELF (the turn's accumulating source of truth) whenever privacy
+  // mode is off, so a mutating implementation would leak this per-request nudge into conversation
+  // history and re-send it on every later turn.
+  const messages = conversation();
+  const before = messages.length;
+  withFinalRoundAnswerInstruction(messages, true, true);
+  assert.equal(messages.length, before);
+  assert.ok(
+    !messages.some(m => m.content === FINAL_ROUND_ANSWER_INSTRUCTION),
+    'the instruction must not end up in the source-of-truth array',
+  );
+});
+
+test('FINAL_ROUND_ANSWER_INSTRUCTION: constrains the model to the gathered results', () => {
+  // Guards the anti-fabrication property against a well-meaning future reword. Asking a model for
+  // an answer it cannot support is how invented counts and agent names appear — the instruction has
+  // to buy analysis WITHOUT buying invention, and has to leave the honest "I can't answer" reachable.
+  assert.match(
+    FINAL_ROUND_ANSWER_INSTRUCTION,
+    /only the tool results already gathered/i,
+  );
+  assert.match(
+    FINAL_ROUND_ANSWER_INSTRUCTION,
+    /do not state anything the results do not show/i,
+  );
+  assert.match(FINAL_ROUND_ANSWER_INSTRUCTION, /say so plainly/i);
+});

--- a/plugins/wazuh-ai-assistant/server/routes/chat.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/chat.ts
@@ -90,6 +90,58 @@ const NO_MATCHING_RESULTS_MESSAGE =
 const NO_ANSWER_MESSAGE =
   'I was not able to come up with an answer for that. Try rephrasing your question.';
 
+/**
+ * Appended to the FINAL round's outbound messages when the turn ran at least one tool (issue
+ * #8893) — see the append site in `orchestrate` below for the measurement and for why it goes on
+ * the outbound copy only. This is the request for a conclusion that dropping `tools` does not by
+ * itself make.
+ *
+ * Every clause is load-bearing, so edit with care:
+ *  - "using only the tool results already gathered" and "Do not state anything the results do not
+ *    show" keep this from becoming a fabrication prompt. Asking a model to produce an answer it
+ *    could not support is exactly how invented numbers and agent names appear, and the fallbacks
+ *    above exist precisely because an honest silence was preferable to that. The instruction has
+ *    to buy analysis WITHOUT buying invention.
+ *  - "If they do not answer the question, say so plainly" gives the model a licensed exit, so the
+ *    honest outcome stays reachable rather than being squeezed out by the request for text.
+ *  - no mention of tools being unavailable: the round already omits `tools` entirely, and naming
+ *    the absent capability invites the model to narrate the mechanism ("I cannot query further…")
+ *    instead of answering.
+ */
+export const FINAL_ROUND_ANSWER_INSTRUCTION =
+  "Now answer the user's question directly, using only the tool results already gathered in " +
+  'this conversation. Do not state anything the results do not show. If they do not answer the ' +
+  'question, say so plainly and state what is missing.';
+
+/**
+ * Appends FINAL_ROUND_ANSWER_INSTRUCTION to the messages bound for the provider, but only on the
+ * final round of a turn that actually ran a tool (issue #8893). Exported for unit testing only —
+ * not part of this route's HTTP contract — and kept as a pure function precisely so the decision
+ * can be tested without standing up a whole fake `orchestrate` run.
+ *
+ * Returns the input array UNCHANGED (same reference) when the instruction does not apply, and a
+ * fresh array when it does — never mutates the input, which matters because the caller may pass
+ * `messages` itself (the turn's accumulating source of truth) when privacy mode is off.
+ *
+ * Gated on `toolUsedThisTurn`: on a `general`-routed (no-tool) turn the final round IS the whole
+ * answer and there are no gathered results to reason over, so the instruction would be a lie.
+ * That path's silence is a different defect with its own fix (the reasoning-channel fallback in
+ * openai-compatible.ts) and its own fallback copy (NO_ANSWER_MESSAGE above).
+ */
+export function withFinalRoundAnswerInstruction(
+  messages: ChatMessage[],
+  isFinalRound: boolean,
+  toolUsedThisTurn: boolean,
+): ChatMessage[] {
+  if (!isFinalRound || !toolUsedThisTurn) {
+    return messages;
+  }
+  return [
+    ...messages,
+    { role: 'system', content: FINAL_ROUND_ANSWER_INSTRUCTION },
+  ];
+}
+
 /** Picks which of the three no-text fallbacks above fits a turn that ended without any `delta`
  * text — shared by both `!sawAnyDelta` exit points below (the normal per-round `done` branch and
  * the round-budget-exhausted path) so the same three-way decision lives in exactly one place. */
@@ -889,9 +941,30 @@ async function* orchestrate(
 
     // Outbound scrub: a fresh transformed COPY per round — `messages` itself keeps
     // accumulating unscrubbed below so later rounds re-scrub from the same source of truth.
-    const outboundMessages = privacyCtx
+    const scrubbedMessages = privacyCtx
       ? scrubMessagesForProvider(messages, privacyCtx.pseudonymizer)
       : messages;
+    // Final round of a tool-using turn: ask for the answer (issue #8893). Dropping `tools` above
+    // terminates the tool loop, but on its own it only stops the model from CALLING anything — it
+    // never asks for a conclusion. The model is handed a transcript of tool results with no
+    // outstanding request, so "I already presented the data, nothing to add" is a rational
+    // completion rather than a malfunction, and the turn ends with no text at all: measured on
+    // openai/gpt-oss-120b over a 40-question analyst-persona bank, 6/40 turns ended on the
+    // `!sawAnyDelta` fallback below, every one with the same 4-tool-call signature (the 3
+    // tool-bearing rounds this budget allows plus stage 1's own forced `route_question`), and 4 of
+    // those 6 had already rendered a NON-EMPTY table — a non-answer sitting directly above real
+    // data the user asked to have interpreted.
+    //
+    // Applied to the outbound COPY only, never to `messages`: this is a per-request nudge, not
+    // conversation history, so it must not persist into the saved conversation or be re-sent by a
+    // later turn. Applied AFTER the scrub deliberately — it is static first-party text with no user
+    // data in it, so there is nothing for the pseudonymizer to find, and running it through would
+    // only risk `prescanAndMint` mangling a word in our own copy.
+    const outboundMessages = withFinalRoundAnswerInstruction(
+      scrubbedMessages,
+      isFinalRound,
+      toolUsedThisTurn,
+    );
     // Inbound un-scrub: this is why the ANSWER the analyst reads carries real hostnames/IPs even
     // with privacy mode on — every delta is run back through the pseudonym map here, so `HOST_1`
     // becomes the real hostname again before it leaves the server. Pseudonyms exist for the provider


### PR DESCRIPTION
## Description

Dropping `tools` on the final round terminates the tool loop, but it only stops the model from calling anything — it never asks for a conclusion. The model receives a transcript of tool results with no outstanding request, so producing no text is a rational completion, and the turn ends with the `!sawAnyDelta` fallback copy sitting above a populated results table.

Measured on `openai/gpt-oss-120b` over a 40-question analyst-persona bank: 6/40 turns ended on fallback copy, every one with the same 4-tool-call signature (the 3 tool-bearing rounds the budget allows plus stage 1's own forced `route_question`), and 4 of those 6 had already rendered a non-empty table.

This PR appends a short instruction to the final round's outbound messages asking the model to answer from the results already gathered. It's constrained so it buys analysis without buying invention: it scopes the answer to the gathered results, forbids stating what the results do not show, and keeps an honest "this does not answer the question" reachable.

Applied to the outbound copy only, so it never enters conversation history, and gated on the turn having actually run a tool — a general-routed turn has no results to reason over. Extracted as a pure `withFinalRoundAnswerInstruction` so the decision is unit-testable without a fake orchestrate run.

Refs https://github.com/wazuh/wazuh-dashboard-plugins/issues/8893

## How to Test

- Run the AI Assistant chat and exhaust the tool-round budget on a question that requires multiple tool calls.
- Confirm the final turn produces a written answer grounded in the gathered results instead of falling back to placeholder copy.
- `yarn test:jest --testPathPattern=chat-final-round-instruction` in `plugins/wazuh-ai-assistant` (inside the OSD dev container).

## Verification

- Prettier (`--check`) on changed files: **PASS**
- ESLint on changed files: **PASS**
- `tsc -p tsconfig.typecheck.json`: fails, but identically on unrelated sibling files (`chat-stage1-usage.test.ts`, `chat-stream-limiter.test.ts`, `chat-usage.test.ts`, `chat.ts` itself) because this plugin repo standalone can't resolve `../../../../src/core/server` / `@osd/config-schema` / test globals outside the full `wazuh-dashboard` checkout it's built against — a pre-existing environment gap, not introduced by this change.
- `yarn test:jest --testPathPattern=chat-final-round-instruction` not run in this environment (needs the OSD-mounted dev container); please run it as part of review.
