### PR TITLE
Fix Events tab crash on unknown data grid columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 | ----- | ----------------------- |
 |       | Support for Wazuh 5.1.0 |
 
+### Fixed
+
+| Issue                                                                 | Comment                                                                                 |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [#8300](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8300) | Fix the Events tab crashing when a displayed column is not defined in the index pattern |
+
 ## Prior versions
 
 - [v4.14.6](https://github.com/wazuh/wazuh-dashboard-plugins/blob/v4.14.6/CHANGELOG.md)

--- a/plugins/main/public/components/common/data-grid/data-grid-service.test.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.test.ts
@@ -1,5 +1,10 @@
-import { parseData } from './data-grid-service';
+import { parseData, parseColumns } from './data-grid-service';
 import { SearchResponse } from '../../../../../../src/core/server';
+import {
+  IFieldType,
+  IndexPattern,
+} from '../../../../../../src/plugins/data/common';
+import { tDataGridColumn } from './types';
 
 describe('describe-grid-test', () => {
   describe('parseData', () => {
@@ -42,6 +47,48 @@ describe('describe-grid-test', () => {
       const expectedResult = [{}, {}, {}];
 
       expect(parseData(resultsHits)).toEqual(expectedResult);
+    });
+  });
+
+  describe('parseColumns', () => {
+    const indexPattern = { id: 'index-pattern-id' } as IndexPattern;
+    // The module column definitions only declare the field `id`
+    const defaultColumns: tDataGridColumn[] = [
+      { id: '@timestamp', isSortable: true },
+      { id: 'wazuh.rule.level', initialWidth: 150 },
+    ];
+
+    const parse = (fields: IFieldType[]) =>
+      parseColumns(fields, defaultColumns, indexPattern, [], 10, [], () => {});
+
+    it('should name the columns after the index pattern fields', () => {
+      const fields = [
+        { name: '@timestamp', type: 'date' },
+        { name: 'wazuh.rule.level', type: 'number' },
+      ] as IFieldType[];
+
+      expect(parse(fields).map(({ id, name }) => ({ id, name }))).toEqual([
+        { id: '@timestamp', name: '@timestamp' },
+        { id: 'wazuh.rule.level', name: 'wazuh.rule.level' },
+      ]);
+    });
+
+    // Regression test for https://github.com/wazuh/wazuh-dashboard-plugins/issues/8300
+    // Without the index pattern fields the default columns were returned as is,
+    // so they reached the Available fields selector without the `name` it
+    // searches on and the Events tab crashed on `name.toLowerCase()`.
+    it('should derive the column name from the id without fields', () => {
+      expect(parse([]).map(({ id, name }) => ({ id, name }))).toEqual([
+        { id: '@timestamp', name: '@timestamp' },
+        { id: 'wazuh.rule.level', name: 'wazuh.rule.level' },
+      ]);
+    });
+
+    it('should keep the default column properties without fields', () => {
+      expect(parse([])).toEqual([
+        { id: '@timestamp', name: '@timestamp', isSortable: true },
+        { id: 'wazuh.rule.level', name: 'wazuh.rule.level', initialWidth: 150 },
+      ]);
     });
   });
 });

--- a/plugins/main/public/components/common/data-grid/data-grid-service.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.ts
@@ -193,6 +193,17 @@ const mapToDataGridColumn = (
   } as tDataGridColumn;
 };
 
+// The module column definitions only declare the `id` of the field. The columns
+// built from the index pattern fields always carry a `name`, which is the label
+// the Available fields selector displays and searches on. Derive it from the
+// `id` so the shape is the same whatever the index pattern fields availability.
+const withDerivedName = (column: tDataGridColumn): tDataGridColumn => {
+  return {
+    name: column.id,
+    ...column,
+  } as tDataGridColumn;
+};
+
 export const parseColumns = (
   fields: IFieldType[],
   defaultColumns: tDataGridColumn[] = [],
@@ -204,7 +215,9 @@ export const parseColumns = (
 ): tDataGridColumn[] => {
   // remove _source field becuase is a object field and is not supported
   // merge the properties of the field with the default columns
-  if (!fields?.length) return defaultColumns;
+  if (!fields?.length) {
+    return defaultColumns.map(column => withDerivedName(column));
+  }
 
   return fields
     .filter(field => field.name !== '_source')

--- a/plugins/main/public/components/common/data-grid/use-data-grid-columns.test.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid-columns.test.ts
@@ -155,6 +155,35 @@ describe('useDataGridColumns', () => {
     );
   });
 
+  // Regression test for https://github.com/wazuh/wazuh-dashboard-plugins/issues/8300
+  // A persisted column that the index pattern does not define has no schema
+  // definition. Spreading the missing definition produced a column without
+  // `id`, and the data grid column selector crashed rendering it with
+  // `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.
+  it('should discard visible columns without a schema definition', () => {
+    mockRetrieveState.mockReturnValue({
+      columns: ['col1', 'removed-field', 'col2'],
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderHook(() =>
+      useDataGridColumns({
+        moduleId,
+        defaultColumns,
+        columnSchemaDefinitionsMap,
+        indexPatternExists: true,
+        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
+      }),
+    );
+
+    expect(result.current.columns.map(({ id }) => id)).toEqual([
+      'col1',
+      'col2',
+    ]);
+    expect(result.current.columns.every(({ id }) => id)).toBe(true);
+  });
+
   it('should persist column width when onColumnResize is called', () => {
     const testColumnId = 'col1';
     const testColumnWidth = 150;

--- a/plugins/main/public/components/common/data-grid/use-data-grid-columns.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid-columns.ts
@@ -177,8 +177,18 @@ function useDataGridColumns({
     }
   };
 
+  // A visible column can reference a field the index pattern does not define,
+  // for example a module default column that is missing from the current index
+  // or a column persisted by a previous version. Those have no schema
+  // definition, and spreading the missing definition builds a column without
+  // `id` that breaks the data grid column selector. Discard them, the same way
+  // `setVisibleColumnsHandler` discards them before persisting the state.
+  const visibleColumnsWithSchema = visibleColumns.filter(
+    (columnId: string) => columnSchemaDefinitionsMap[columnId],
+  );
+
   // Don't use `useMemo` here because otherwise the DataGrid cell filter doesn't work
-  const retrieveVisibleDataGridColumns = visibleColumns.map(
+  const retrieveVisibleDataGridColumns = visibleColumnsWithSchema.map(
     (columnId: string) => {
       let column = { ...columnSchemaDefinitionsMap[columnId] };
       const savedColumnWidth =

--- a/plugins/main/public/components/common/wazuh-discover/components/visible-columns-selector.test.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/components/visible-columns-selector.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@osd/i18n/react';
+import { EuiDataGridColumn } from '@elastic/eui';
+import { DataGridVisibleColumnsSelector } from './visible-columns-selector';
+
+const renderComponent = (availableColumns: EuiDataGridColumn[]) =>
+  render(
+    <I18nProvider>
+      <DataGridVisibleColumnsSelector
+        availableColumns={availableColumns}
+        columnVisibility={{
+          visibleColumns: availableColumns.map(({ id }) => id),
+          setVisibleColumns: jest.fn(),
+        }}
+      />
+    </I18nProvider>,
+  );
+
+const searchColumns = (searchValue: string) => {
+  fireEvent.click(screen.getByRole('button'));
+  fireEvent.change(screen.getByLabelText('Search columns'), {
+    target: { value: searchValue },
+  });
+};
+
+describe('DataGridVisibleColumnsSelector', () => {
+  it('filters the columns by name', () => {
+    renderComponent([
+      { id: '@timestamp', name: '@timestamp' },
+      { id: 'wazuh.rule.level', name: 'wazuh.rule.level' },
+    ] as EuiDataGridColumn[]);
+
+    searchColumns('rule');
+
+    expect(screen.getByText('wazuh.rule.level')).toBeInTheDocument();
+    expect(screen.queryByText('@timestamp')).not.toBeInTheDocument();
+  });
+
+  // Regression test for https://github.com/wazuh/wazuh-dashboard-plugins/issues/8300
+  // The module column definitions only declare the field `id`, so the columns
+  // reached the selector without a `name` while the index pattern fields were
+  // not available yet and filtering them crashed the Events tab.
+  it('filters the columns without a name instead of throwing', () => {
+    renderComponent([
+      { id: '@timestamp' },
+      { id: 'wazuh.rule.level' },
+    ] as EuiDataGridColumn[]);
+
+    expect(() => searchColumns('rule')).not.toThrow();
+
+    expect(screen.getByText('wazuh.rule.level')).toBeInTheDocument();
+    expect(screen.queryByText('@timestamp')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/main/public/components/common/wazuh-discover/components/visible-columns-selector.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/components/visible-columns-selector.tsx
@@ -34,10 +34,15 @@ export const DataGridVisibleColumnsSelector = ({
 
   const searchValueLowerCase = searchValue.toLowerCase();
 
+  // `name` is not part of the EuiDataGridColumn specification, it is added by
+  // the data grid service. Fall back to the column `id` so a column without it
+  // is still searchable and labelled instead of breaking the selector.
+  const getColumnLabel = ({ name, id }: EuiDataGridColumn) => name ?? id;
+
   const filteredColumns = (
     searchValue
-      ? availableColumns.filter(({ name }) =>
-          name.toLowerCase().includes(searchValueLowerCase),
+      ? availableColumns.filter(column =>
+          getColumnLabel(column).toLowerCase().includes(searchValueLowerCase),
         )
       : availableColumns
   ).slice(0, maxAvailableColumns);
@@ -105,7 +110,8 @@ export const DataGridVisibleColumnsSelector = ({
         />
       </EuiPopoverTitle>
       <div className='euiDataGrid__controlScroll'>
-        {filteredColumns.map(({ name, id }) => {
+        {filteredColumns.map(column => {
+          const { id } = column;
           return (
             <div key={id} className='euiDataGridColumnSelector__item'>
               <EuiFlexGroup
@@ -116,7 +122,7 @@ export const DataGridVisibleColumnsSelector = ({
                 <EuiFlexItem>
                   <EuiSwitch
                     name={id}
-                    label={name}
+                    label={getColumnLabel(column)}
                     checked={visibleColumns.includes(id)}
                     compressed
                     className='euiSwitch--mini'


### PR DESCRIPTION

## Description

Closes #8300

The Events tab crashed with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`. The error is attributed to `WazuhDiscoverComponent`
because `withErrorBoundary` wraps it and reports anything thrown in its
subtree.

The throw is in the data grid column selector, which builds its filter list on
every render:

```js
// @elastic/eui/lib/components/datagrid/column_selector.js
var filteredColumns = sortedColumns.filter(function (id) {
  return (displayValues[id] || id).toLowerCase().indexOf(columnSearchText.toLowerCase()) !== -1;
});
```

`useDataGridColumns` fed it a column with no `id`. It builds one column per
visible column id by spreading the schema definition:

```ts
let column = { ...columnSchemaDefinitionsMap[columnId] };
```

When a visible column is not defined in the index pattern, that definition is
`undefined` and the spread yields `{}`. This happens whenever a module default
column is missing from the current index, or a column persisted in
`localStorage` by an earlier version no longer exists — the same class of
mismatch reported in #8070 for FIM and Malware Detection. No user interaction
is needed; the tab crashes as soon as the grid renders.

A related, lower-severity variant of the same error also existed:
`parseColumns()` returned the module column definitions untouched when the
index pattern exposed no fields. Those declare only `id`, so the Available
fields selector filtered them on an undefined `name` and threw the same
`TypeError` once the user typed in the field search.

### A note on confidence

This crash has been reproduced end to end in a running dashboard, and the
captured stack matches #8300 on every observable detail: the same error
message, thrown on plain render of the Events tab with no user interaction,
surfacing through the error boundary that wraps `WazuhDiscoverComponent` — which
is exactly how the issue titles it.

What is *not* confirmed is that this is the same instance the reporter hit. The
issue contains no stack trace and its reproduction stops at "click the Events
tab", and the reporter has not responded to follow-up. The precondition here — a
module default column absent from the index pattern — is environment-dependent,
so their 4.14.4-rc2 install may have tripped it for a different reason, or hit a
different `toLowerCase` entirely. I have kept `Closes #8300` because the match is
strong and the bug is real either way, but reviewers should treat the attribution
as inferred rather than confirmed by the reporter.

## Proposed Changes

- `useDataGridColumns` discards visible columns that have no schema definition,
  instead of turning them into `{}`. This mirrors `setVisibleColumnsHandler`,
  which already discards those ids before persisting the state.
- `parseColumns()` derives `name` from `id` when the index pattern fields are
  unavailable, so both of its return paths produce the same column shape.
- `DataGridVisibleColumnsSelector` falls back to the column `id` when `name` is
  absent. `EuiDataGridColumn` does not guarantee `name`, and the missing value
  was also rendering blank switch labels.

### Backport

The bug is present on `4.14.x`. `visible-columns-selector.tsx` is byte-identical
between `main` and `4.14.9`, and both the `{ ...columnSchemaDefinitionsMap[id] }`
spread and the `parseColumns` early return are unchanged there. The source fix
applies as is; only the test fixtures need adjusting, since the column ids
differ (`rule.mitre.id` on 4.14 vs `wazuh.rule.mitre.technique.id` on 5.x).
Happy to open a backport PR if maintainers want one — the issue was reported
against 4.14.4.

### Results and Evidence

**Before (crash):**

<img width="1600" height="1000" alt="before-crash" src="https://github.com/user-attachments/assets/3896694b-cfa7-43f0-972d-dd812cb66f06" />


**After (fix applied):**

<img width="1600" height="1000" alt="after-fixed" src="https://github.com/user-attachments/assets/5e4af403-5e11-44cb-9777-a628dbe752ff" />


Note: the "after" screenshot shows an empty results state rather than populated
rows. This dev environment's indexer (5.0.0, the only published 5.x tag at the
time) rejects 5.1.0-shaped documents due to a mapping mismatch, so no FIM
findings data could be seeded. This doesn't weaken the comparison — the crash
occurs at render time regardless of row count, as the "before" screenshot's
stack trace confirms (thrown inside EuiDataGrid before any data is displayed).


### Artifacts Affected

- Wazuh dashboard `main` plugin (all platforms)

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

- `use-data-grid-columns.test.ts`: asserts a persisted column with no schema
  definition is dropped and that no column reaches the grid without an `id`.
  Fails before this change.
- `data-grid-service.test.ts`: new `parseColumns` suite covering names from
  index pattern fields, names derived from `id` when there are no fields, and
  preservation of the default column properties.
- `visible-columns-selector.test.tsx`: renders columns without a `name`,
  searches them, and asserts the selector filters instead of throwing.

All run in the Docker dev environment against OSD 3.6.0:
`Test Suites: 3 passed`, `Tests: 18 passed`. The full `plugins/main` suite is
`200 passed / 1533 tests`; the 3 failing suites fail identically on a pristine
checkout (a gitignored generated `findings.json` and an OSD platform mock) and
are unrelated to this change.

## Review Checklist

- [x] Code changes reviewed
- [X] Relevant evidence provided
- [X] Tests cover the new functionality
- [X] Configuration changes documented
- [X] Developer documentation reflects the changes
- [X] Meets requirements and/or definition of done
- [X] No unresolved dependencies with other issues
- [X] PR is linked to the relevant issue(s)
