### PR TITLE
Make cross-category tool references conditional, not directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8919](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8919) | Fixed AI Assistant tool descriptions and guardrail messages that named a tool from a different two-stage-router category than the one guaranteed offered that turn, leaving the model unable to call it |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8919](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8919) | Fixed AI Assistant tool descriptions and guardrail messages that named a tool from a different two-stage-router category than the one guaranteed offered that turn, leaving the model unable to call it |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-sca-results.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-sca-results.test.ts
@@ -91,3 +91,21 @@ test('get_sca_results: still passes lintDsl at its maximum advertised limit', ()
   const result = lintDsl(request.body, request.index);
   assert.equal(result.ok, true, result.ok ? '' : result.reason);
 });
+
+// Cross-category tool audit (same bug shape as issue #8913): this tool's own category is `sca`
+// (server/tools/router.ts), while get_threat_intel_components -- named here for the "you actually
+// want a Security Analytics pipeline policy" case -- is the separate `security_analytics`
+// category, not guaranteed offered on the same turn. Pins the conditional wording so a future edit
+// cannot silently reintroduce an unconditional "use get_threat_intel_components instead" naming a
+// tool that may not be offered.
+test('get_sca_results: names get_threat_intel_components only conditionally on it being offered, not unconditionally', () => {
+  const description = getScaResultsTool.spec.description;
+  assert.match(
+    description,
+    /if\s+the question is actually about pipeline policies and get_threat_intel_components \(with\s+component_type="policies"\) is available to you this turn, use that one instead/,
+  );
+  assert.doesNotMatch(
+    description,
+    /\(use get_threat_intel_components with component_type="policies"\)/,
+  );
+});

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-sca-results.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-sca-results.ts
@@ -22,6 +22,17 @@ import {
  * model computes/narrates the ratio when asked. `check.result` values are confirmed live against
  * a real 5.0 stack to be capitalized -- `"Passed"`/`"Failed"`/`"Not applicable"` -- NOT the
  * lowercase 4.14 values; a lowercase `term` filter here silently matches nothing.
+ *
+ * Cross-category tool audit: this tool's own category is `sca` (server/tools/router.ts), while
+ * `get_threat_intel_components` -- named in the disambiguation sentence below for the "not SCA,
+ * you want pipeline policies" case -- is a DIFFERENT category (`security_analytics`). The two-stage
+ * router only offers one turn's categories at a time, so a stage-1 route of `sca` alone (plausible:
+ * "policy"/"policies" is genuinely overloaded between an SCA benchmark and a Security Analytics
+ * pipeline policy) would leave that named tool unavailable -- the same "instruction names a tool
+ * that may not be offered" shape as issue #8913, just between two data tools' descriptions instead
+ * of the system prompt. Worded conditionally ("if ... is available to you this turn") instead of
+ * an unconditional "use X instead" so the model degrades to admitting the gap rather than stalling
+ * on a tool it was not given.
  */
 export const getScaResultsTool: ToolDefinition = {
   spec: {
@@ -31,8 +42,9 @@ export const getScaResultsTool: ToolDefinition = {
       'passed/failed check counts per compliance benchmark (e.g. CIS Ubuntu). Use for "SCA"/' +
       '"configuration assessment"/"compliance policy score" questions about a specific agent. ' +
       'The compliance ratio is passed/(passed+failed). NOT for Security Analytics pipeline ' +
-      'policies (use get_threat_intel_components with component_type="policies") -- SCA is a ' +
-      'per-agent scan result, unrelated to that pipeline configuration.',
+      'policies -- SCA is a per-agent scan result, unrelated to that pipeline configuration; if ' +
+      'the question is actually about pipeline policies and get_threat_intel_components (with ' +
+      'component_type="policies") is available to you this turn, use that one instead.',
     parameters: objectSchema(
       {
         agent_id: {

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-threat-intel-components.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-threat-intel-components.test.ts
@@ -153,3 +153,19 @@ test('get_threat_intel_components: buildSecurityAnalyticsLink maps each componen
     url: '/app/kvdbs#/kvdbs?space=test',
   });
 });
+
+// Cross-category tool audit (same bug shape as issue #8913): this tool's own category is
+// `security_analytics` (server/tools/router.ts), while get_sca_results -- named here for the
+// "you actually want an SCA benchmark" case -- is the separate `sca` category, not guaranteed
+// offered on the same turn. Pins the conditional wording so a future edit cannot silently
+// reintroduce an unconditional "use get_sca_results instead" naming a tool that may not be
+// offered. get_rules stays unconditional since it shares this tool's own category.
+test('get_threat_intel_components: names get_sca_results only conditionally on it being offered, not unconditionally', () => {
+  const description = getThreatIntelComponentsTool.spec.description;
+  assert.match(
+    description,
+    /if that is what the question needs and get_sca_results is\s+available to you this turn, use that one instead/,
+  );
+  assert.doesNotMatch(description, /-- for that, use get_sca_results instead/);
+  assert.match(description, /Not for rules \(use get_rules\)/);
+});

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-threat-intel-components.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-threat-intel-components.ts
@@ -66,6 +66,17 @@ const COMPONENT_SECURITY_ANALYTICS_PATH: Record<
  *
  * `wazuh-threatintel-filters*` is a real, currently EMPTY index (0 docs, live-confirmed) -- a
  * 0-row result there is correct, not a bug.
+ *
+ * Cross-category tool audit: the SCA disambiguation sentence below names `get_sca_results`, which
+ * lives in the `sca` router category (server/tools/router.ts) -- a DIFFERENT category from this
+ * tool's own `security_analytics`. Stage-1 only offers one turn's routed categories at a time, so a
+ * route of `security_analytics` alone (plausible: "policy"/"policies" is genuinely overloaded
+ * between an SCA benchmark and a pipeline policy) would leave `get_sca_results` unavailable -- the
+ * same "instruction names a tool that may not be offered" shape as issue #8913, between two data
+ * tools' descriptions rather than the system prompt. Worded conditionally ("if ... is available to
+ * you this turn") rather than an unconditional "use X instead" so the model degrades to admitting
+ * the gap instead of stalling on a tool it was not given. `get_rules` is untouched: it shares this
+ * tool's OWN category, so it is guaranteed present whenever this description is read.
  */
 export const getThreatIntelComponentsTool: ToolDefinition = {
   spec: {
@@ -75,8 +86,9 @@ export const getThreatIntelComponentsTool: ToolDefinition = {
       'or KVDBs (key-value databases). Use for "which decoders/integrations/policies are ' +
       'active" questions. `component_type="policies"` here means a Security Analytics pipeline ' +
       'policy (config content), NOT a Security Configuration Assessment (SCA) compliance ' +
-      'benchmark like CIS Ubuntu -- for that, use get_sca_results instead. Not for rules (use ' +
-      'get_rules) or threat intel indicators/IOCs.',
+      'benchmark like CIS Ubuntu -- if that is what the question needs and get_sca_results is ' +
+      'available to you this turn, use that one instead. Not for rules (use get_rules) or ' +
+      'threat intel indicators/IOCs.',
     parameters: objectSchema(
       {
         component_type: {

--- a/plugins/wazuh-ai-assistant/server/tools/guardrails.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/guardrails.test.ts
@@ -194,6 +194,35 @@ test('lintDsl: steers a "prefix" clause on a vulnerability field away from the f
   }
 });
 
+// Cross-category tool audit (same bug shape as issue #8913): this reason reaches the model via
+// search_wazuh_data/find_document_by_field (`free_search`, always offered), but the four tools it
+// used to name unconditionally live in the separate `vulnerabilities` category, which is not
+// guaranteed to be offered on the same turn. Pins the conditional wording and the explicit
+// no-tools-available fallback so a future edit cannot silently reintroduce an unconditional
+// "use the vulnerability tools" instruction naming a tool set that may not exist this turn.
+test('lintDsl: the vulnerability-field steering reason is conditional on those tools being offered, not unconditional', () => {
+  const body = {
+    query: {
+      bool: {
+        filter: [
+          { range: { '@timestamp': { gte: 'now-1d', lte: 'now' } } },
+          { term: { 'vulnerability.severity': 'Critical' } },
+        ],
+      },
+    },
+    size: 20,
+  };
+  const result = lintDsl(body, 'wazuh-events-v5-*');
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /whichever of those is offered to you this\s+turn/);
+    assert.match(
+      result.reason,
+      /If none of them\s+are available to you this turn, tell the user this assistant cannot check\s+vulnerability data\s+from here/,
+    );
+  }
+});
+
 test('lintDsl: a "prefix" clause on a non-vulnerability field is unaffected by the steering check', () => {
   const body = {
     query: {

--- a/plugins/wazuh-ai-assistant/server/tools/guardrails.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/guardrails.test.ts
@@ -215,7 +215,10 @@ test('lintDsl: the vulnerability-field steering reason is conditional on those t
   const result = lintDsl(body, 'wazuh-events-v5-*');
   assert.equal(result.ok, false);
   if (!result.ok) {
-    assert.match(result.reason, /whichever of those is offered to you this\s+turn/);
+    assert.match(
+      result.reason,
+      /whichever of those is offered to you this\s+turn/,
+    );
     assert.match(
       result.reason,
       /If none of them\s+are available to you this turn, tell the user this assistant cannot check\s+vulnerability data\s+from here/,

--- a/plugins/wazuh-ai-assistant/server/tools/guardrails.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/guardrails.ts
@@ -446,11 +446,24 @@ function findNumericRangeOnKeywordField(
   return reason;
 }
 
+// Cross-category tool audit: this reason reaches the model via lintDsl, which
+// executor.ts's executeIndexerRequest runs against EVERY Indexer-backed tool call with "no
+// per-tool exemptions" (see that file) -- in practice the realistic caller is search_wazuh_data
+// or find_document_by_field, both `free_search` (server/tools/router.ts), which is one of the two
+// categories ALWAYS offered whenever any tools are offered at all (resolveStage2Tools always adds
+// search_wazuh_data). The four named tools below, though, all live in the separate
+// `vulnerabilities` category, which stage-1 routing has no obligation to also offer on the SAME
+// turn -- an unconditional "use the vulnerability tools" here would be the same "instruction names
+// a tool that may not be offered" shape as issue #8913. Worded conditionally, with an explicit
+// fallback, so the model degrades to telling the user about the gap instead of stalling on tools
+// it was not given.
 const VULN_FIELD_ON_FINDINGS_REASON =
-  'Vulnerability data is not in the findings/events index. Use the vulnerability tools ' +
-  '(get_vulnerabilities, get_critical_vulnerabilities, ' +
-  'get_vulnerabilities_by_agent, get_vulnerability_by_cve) instead of querying vulnerability ' +
-  'fields on a findings/events index.';
+  'Vulnerability data is not in the findings/events index. The vulnerability tools ' +
+  '(get_vulnerabilities, get_critical_vulnerabilities, get_vulnerabilities_by_agent, ' +
+  'get_vulnerability_by_cve) cover this instead -- use whichever of those is offered to you this ' +
+  'turn rather than querying vulnerability fields on a findings/events index. If none of them ' +
+  'are available to you this turn, tell the user this assistant cannot check vulnerability data ' +
+  'from here.';
 
 /** Shared by both the `script` and `runtime_mappings` checks in `lintDsl` below, so the two
  * trigger paths can never report drifted wording — a scripted


### PR DESCRIPTION
## Description

Closes #8919

Model-facing text told the model to call a specific tool by name, but two-stage routing only offers the tools of the 1–2 categories stage 1 picked. When the naming text and the named tool sit in different categories, the model was instructed to call a tool it was never given, and it stalled or improvised instead. An audit of every model-facing tool reference found three instances of this shape: `get_sca_results`'s description pointed at `get_threat_intel_components` (a different category) and vice versa, and `guardrails.ts`'s vulnerability-field message named four vulnerability tools while being reachable from always-offered free-search tools on turns where the `vulnerabilities` category wasn't routed.

## Proposed Changes

- Made the three cross-category tool references conditional rather than imperative: the alternative is named only if available this turn, with a fallback (answer from what the model has, or tell the user) when it is not.

### Results and Evidence

Colocated unit tests pin the conditional phrasing so a reword cannot silently restore the imperative form. No user-facing UI changes.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`plugins/wazuh-ai-assistant/server/tools/catalog/get-sca-results.test.ts`, `get-threat-intel-components.test.ts`, and `server/tools/guardrails.test.ts`: cross-category tool references are conditional, not directive.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
