### PR TITLE
Fix privacy mode substring corruption via word boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8916](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8916) | Fixed the AI Assistant's privacy mode corrupting values (e.g. package versions) by substring-replacing a pseudonymized word wherever it appeared, instead of only at whole-token boundaries   |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8916](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8916) | Fixed the AI Assistant's privacy mode corrupting values (e.g. package versions) by substring-replacing a pseudonymized word wherever it appeared, instead of only at whole-token boundaries   |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
@@ -246,6 +246,65 @@ test('Pseudonymizer: applyToText replaces every known value, longest first', () 
   assert.match(out, /^Traffic from IP_\d+ and IP_\d+ was observed\.$/);
 });
 
+// #8916: applyToText previously did a plain substring replace, so a pseudonymized word could
+// corrupt an unrelated value it merely happened to appear inside of — observed live: "ubuntu"
+// (pseudonymized from host.os.platform) turned the package version "7.81.0-1ubuntu1.14" into
+// "7.81.0-1VAL_21.14". These pin the word-boundary discipline (boundary = any non-alphanumeric
+// character) that fixes it without breaking the cases that must keep working.
+
+test('Pseudonymizer: applyToText leaves a pseudonymized word untouched when it is glued inside a larger alphanumeric run (version string)', () => {
+  const p = new Pseudonymizer();
+  const pseudonym = p.pseudonymize('ubuntu', 'VAL');
+  const text = 'Installed openssh 7.81.0-1ubuntu1.14 on the host.';
+  const out = p.applyToText(text);
+  assert.equal(out, text, 'the version string must be left byte-identical');
+  assert.ok(!out.includes(pseudonym));
+});
+
+test('Pseudonymizer: applyToText still replaces a standalone occurrence of the same value', () => {
+  const p = new Pseudonymizer();
+  const pseudonym = p.pseudonymize('ubuntu', 'VAL');
+  const text = 'The agent reports its platform is ubuntu.';
+  const out = p.applyToText(text);
+  assert.equal(out, `The agent reports its platform is ${pseudonym}.`);
+});
+
+test('Pseudonymizer: applyToText still replaces a value glued to a larger token by "-" or "_" (whole token, not the compound)', () => {
+  const p = new Pseudonymizer();
+  const pseudonym = p.pseudonymize('ubuntu', 'VAL');
+  const hyphenated = p.applyToText(
+    'Image tag myapp-ubuntu-server was deployed.',
+  );
+  assert.equal(hyphenated, `Image tag myapp-${pseudonym}-server was deployed.`);
+  const underscored = p.applyToText(
+    'Image tag myapp_ubuntu_server was deployed.',
+  );
+  assert.equal(
+    underscored,
+    `Image tag myapp_${pseudonym}_server was deployed.`,
+  );
+});
+
+test('Pseudonymizer: applyToText still replaces an embedded IP address', () => {
+  const p = new Pseudonymizer();
+  const pseudonym = p.pseudonymize('10.0.0.5', 'IP');
+  const out = p.applyToText('Connection refused from 10.0.0.5 on port 22.');
+  assert.equal(out, `Connection refused from ${pseudonym} on port 22.`);
+});
+
+test('Pseudonymizer: applyToText still replaces an embedded FQDN', () => {
+  const p = new Pseudonymizer();
+  const pseudonym = p.pseudonymize('web01.corp.local', 'HOST');
+  const out = p.applyToText('Alert raised on web01.corp.local just now.');
+  assert.equal(out, `Alert raised on ${pseudonym} just now.`);
+});
+
+test('Pseudonymizer: applyToText skips an empty seeded value instead of matching every position', () => {
+  const p = new Pseudonymizer([{ value: '', pseudonym: 'VAL_1' }]);
+  const text = 'unchanged text';
+  assert.equal(p.applyToText(text), text);
+});
+
 test('Pseudonymizer: applyToObject deep-maps nested structures', () => {
   const p = new Pseudonymizer();
   const pseudonym = p.pseudonymize('web-01.corp', 'HOST');

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.ts
@@ -265,6 +265,14 @@ function deepMapStrings(
   return value;
 }
 
+/** Escapes every regex metacharacter in `value` so it can be embedded literally inside a
+ * dynamically-built `RegExp` — needed by `Pseudonymizer.applyToText` below, which (unlike a plain
+ * `split`/`join`) must express a word-boundary condition, and a raw attacker/data-controlled value
+ * cannot be interpolated into a regex source without first escaping it. */
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Per-request pseudonymizer (a stateless, conversation-scoped map): the map itself is
  * client-held across turns (the chat request body's `privacy.map`, common/types.ts's
@@ -335,11 +343,31 @@ export class Pseudonymizer {
     return this.minted.slice();
   }
 
-  /** Replaces every known REAL value with its pseudonym, longest-value-first so a shorter value
+  /**
+   * Replaces every known REAL value with its pseudonym, longest-value-first so a shorter value
    * that happens to be a substring of a longer one (e.g. "10.0.0.1" inside "10.0.0.10") is never
-   * substituted first and left corrupting the longer value. Uses plain `split`/`join` rather than
-   * a regex built from the (unescaped, attacker/data-controlled) value — sidesteps regex-escaping
-   * entirely instead of trying to get it right. */
+   * substituted first and left corrupting the longer value.
+   *
+   * #8916: a value is only ever replaced as a WHOLE token, never as a substring embedded inside a
+   * larger alphanumeric run — observed live: the word "ubuntu" (pseudonymized to "VAL_2" from an
+   * earlier `host.os.platform` value) turned the unrelated package version "7.81.0-1ubuntu1.14"
+   * into "7.81.0-1VAL_21.14". A "boundary" here is any NON-ALPHANUMERIC character (or start/end of
+   * string) — deliberately NOT the conventional regex `\b` (which treats "_" as a word character):
+   * real identifiers routinely embed "-"/"_" as separators (e.g. "mysql-server-DBPRIMARY03"), and
+   * requiring only an actual alphanumeric neighbor to disqualify a match means a "-"/"_"-glued
+   * compound identifier still matches as a whole token, exactly like a space- or
+   * punctuation-delimited one. Embedded IP/FQDN values minted by `prescanAndMint`'s shape scan are
+   * unaffected by this tightening: they were already matched (and therefore already delimited) as
+   * whole tokens by their own `\b`-anchored regexes before ever reaching this map, so they still
+   * satisfy this boundary check here — this only ever REJECTS matches the previous plain
+   * `split`/`join` wrongly accepted, never one it correctly accepted.
+   *
+   * This now needs a real `RegExp` (to express the boundary condition) instead of the previous
+   * plain `split`/`join` — every value is escaped first via `escapeRegExpLiteral` since values
+   * here are attacker/data-controlled text, never safe to interpolate into a regex source
+   * unescaped. An empty value is skipped outright: an empty pattern's zero-width match would
+   * otherwise insert a pseudonym at every non-alphanumeric-adjacent position in the text.
+   */
   applyToText(text: string): string {
     if (!text || this.valueToPseudonym.size === 0) {
       return text;
@@ -349,10 +377,14 @@ export class Pseudonymizer {
     );
     let out = text;
     for (const value of values) {
-      if (!out.includes(value)) {
+      if (!value || !out.includes(value)) {
         continue;
       }
-      out = out.split(value).join(this.valueToPseudonym.get(value) as string);
+      const pattern = new RegExp(
+        `(?<![A-Za-z0-9])${escapeRegExpLiteral(value)}(?![A-Za-z0-9])`,
+        'g',
+      );
+      out = out.replace(pattern, this.valueToPseudonym.get(value) as string);
     }
     return out;
   }


### PR DESCRIPTION
## Description

Closes #8916

In privacy mode, pseudonym substitution was applied as a plain substring replacement over field values, so a pseudonymized token that happened to occur inside an unrelated string corrupted that string. Observed on a live deployment: a package version `7.81.0-1ubuntu1.14` was sent to the provider as `7.81.0-1VAL_21.14`, because the word `ubuntu` had been pseudonymized to `VAL_2` from `host.os.platform` earlier in the same conversation. This is over-replacement, not a data leak, but it corrupts values the model then reasons over — a mangled version can make the assistant state the wrong package version or fail to match it against a vulnerability range.

## Proposed Changes

- Applied word-boundary discipline to the generic pseudonym substitution over field values, so a pseudonym only replaces a whole token rather than any substring — matching the discipline the known-entity dictionary scan (#8912) already uses.
- Left genuinely embedded identifiers (IPs, FQDNs) still covered, since those are matched by shape, not by dictionary substring.

### Results and Evidence

Colocated unit tests cover the word-boundary fix. No user-facing UI changes.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`plugins/wazuh-ai-assistant/server/tools/privacy.test.ts`: a pseudonymized word inside a version string leaves the version intact; a standalone occurrence of the same word is still replaced; an embedded IP/FQDN is still pseudonymized.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
