### PR TITLE
Name suggest_discover_query trigger conditions explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8915](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8915) | Fixed the AI Assistant never offering an "Open in Discover" handoff on an unanswerable turn (empty domain, zero-row result, or truncated sample) by naming the trigger conditions explicitly in the prompt and in the `suggest_discover_query` tool description                             |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8915](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8915) | Fixed the AI Assistant never offering an "Open in Discover" handoff on an unanswerable turn (empty domain, zero-row result, or truncated sample) by naming the trigger conditions explicitly in the prompt and in the `suggest_discover_query` tool description                             |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/prompts.test.ts
+++ b/plugins/wazuh-ai-assistant/server/prompts.test.ts
@@ -38,6 +38,53 @@ test('buildSystemPrompt: instructs the model to never assert a remediation/compl
   assert.match(prompt, /never from prose inside a result/);
 });
 
+// #8915: suggest_discover_query was attached to the tool list on every tool-bearing round but
+// measured live traffic (195 turns) showed it was never invoked — including on the turns it
+// exists for (an empty domain, a zero-row result, a truncated sample). Nothing in the prompt
+// named WHEN calling it is the right move, so it read as one more optional tool competing with
+// the data tools. Pins the three trigger conditions and the "non-optional, required last step"
+// framing so a reword that drops any of them fails loudly.
+
+test('buildSystemPrompt: states suggest_discover_query is a required, non-optional close-out step', () => {
+  const prompt = buildSystemPrompt('2026-01-01T00:00:00Z');
+  assert.match(
+    prompt,
+    /suggest_discover_query is the required last step of a turn you cannot fully answer, not an\s+optional extra/,
+  );
+});
+
+test('buildSystemPrompt: names "no tool covers the data" as a trigger condition', () => {
+  const prompt = buildSystemPrompt('2026-01-01T00:00:00Z');
+  assert.match(
+    prompt,
+    /no tool available to you covers what the user asked about\s+at all/,
+  );
+});
+
+test('buildSystemPrompt: names a zero-row tool result as a trigger condition', () => {
+  const prompt = buildSystemPrompt('2026-01-01T00:00:00Z');
+  assert.match(
+    prompt,
+    /a tool call came back with zero rows \(counts\.returned is 0\) and that zero is\s+your whole answer/,
+  );
+});
+
+test('buildSystemPrompt: names truncated rows as a trigger condition', () => {
+  const prompt = buildSystemPrompt('2026-01-01T00:00:00Z');
+  assert.match(
+    prompt,
+    /the rows you would need to answer with confidence were truncated\s+away \(counts\.truncated is true, or a samplesNote is present\)/,
+  );
+});
+
+test('buildSystemPrompt: instructs the model to still answer plainly before calling the handoff, never inventing missing rows', () => {
+  const prompt = buildSystemPrompt('2026-01-01T00:00:00Z');
+  assert.match(
+    prompt,
+    /still\s+answer first, in your own words, saying plainly what you checked and what you could not\s+confirm — never invent or assume the missing rows/,
+  );
+});
+
 test('buildSystemPrompt: embeds the current UTC time and stays a single joined string', () => {
   const prompt = buildSystemPrompt('2026-08-06T12:34:56Z');
   assert.match(prompt, /The current UTC time is 2026-08-06T12:34:56Z\./);

--- a/plugins/wazuh-ai-assistant/server/prompts.ts
+++ b/plugins/wazuh-ai-assistant/server/prompts.ts
@@ -83,9 +83,22 @@ export function buildSystemPrompt(nowIso: string): string {
       'search_findings_by_rule_tag with a wazuh.rule.tags value, or aggregate by rule first with ' +
       'get_top_rules to discover ids. If a narrowly-filtered query returns 0 rows for activity ' +
       'that plausibly exists, retry once with a broader filter before concluding there were none.',
-    'When the data the user needs is out of reach for every tool available to you — a blocked ' +
-      'index, a filter search_wazuh_data cannot express within its rules, or a time range beyond ' +
-      'the 90-day maximum — call suggest_discover_query with the index, query, and reason, then ' +
-      'say plainly what you could not check.',
+    // #8915: suggest_discover_query is attached to the tool list on every tool-bearing round, but
+    // measured live traffic showed it was NEVER invoked — including on the turns it exists for:
+    // an empty domain, a zero-row result, or a truncated sample. Nothing here named WHEN calling
+    // it is the right move, so it read as one more optional tool competing with the data tools
+    // instead of the required close-out step of an unanswerable turn. Name the trigger conditions
+    // explicitly and make the call itself non-optional whenever one holds — see this tool's own
+    // description (suggest-discover-query.ts) for the matching "required last step" framing.
+    'suggest_discover_query is the required last step of a turn you cannot fully answer, not an ' +
+      'optional extra — call it in every one of these cases before you finish, even if you have ' +
+      'already written an answer: (1) no tool available to you covers what the user asked about ' +
+      'at all; (2) a tool call came back with zero rows (counts.returned is 0) and that zero is ' +
+      'your whole answer; (3) the rows you would need to answer with confidence were truncated ' +
+      'away (counts.truncated is true, or a samplesNote is present) and the question depends on ' +
+      'seeing every row, e.g. "does X ever appear" or "are there any Y". In every case, still ' +
+      'answer first, in your own words, saying plainly what you checked and what you could not ' +
+      'confirm — never invent or assume the missing rows — then call suggest_discover_query so ' +
+      'the user gets a Discover link instead of a dead end.',
   ].join('\n');
 }

--- a/plugins/wazuh-ai-assistant/server/tools/suggest-discover-query.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/suggest-discover-query.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   resolveSuggestedDsl,
+  SUGGEST_DISCOVER_QUERY_TOOL,
   validateSuggestDiscoverQueryArgs,
 } from './suggest-discover-query';
 
@@ -240,4 +241,39 @@ test('resolveSuggestedDsl: a wazuh-states-* index uses state.modified_at for the
       ],
     },
   });
+});
+
+// #8915: the tool's own description previously read as one optional capability among several,
+// which measured live traffic showed the model never invoked. Pins the "required final step, not
+// an optional extra" framing and all three trigger conditions so a reword that drops any of them
+// fails loudly.
+
+test('SUGGEST_DISCOVER_QUERY_TOOL: description frames the call as the required final step, not an optional extra', () => {
+  assert.match(
+    SUGGEST_DISCOVER_QUERY_TOOL.description,
+    /The required final step of a turn you cannot fully answer — not an optional extra/,
+  );
+});
+
+test('SUGGEST_DISCOVER_QUERY_TOOL: description names all three #8915 trigger conditions', () => {
+  const { description } = SUGGEST_DISCOVER_QUERY_TOOL;
+  assert.match(
+    description,
+    /no other tool available to you covers what the user asked about\s+at all/,
+  );
+  assert.match(
+    description,
+    /a tool call came back with zero rows and that zero is\s+your whole answer/,
+  );
+  assert.match(
+    description,
+    /the\s+rows you would need were truncated away and the question depends on seeing every row/,
+  );
+});
+
+test('SUGGEST_DISCOVER_QUERY_TOOL: description still states it never fetches data itself', () => {
+  assert.match(
+    SUGGEST_DISCOVER_QUERY_TOOL.description,
+    /nothing here is executed on your behalf/,
+  );
 });

--- a/plugins/wazuh-ai-assistant/server/tools/suggest-discover-query.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/suggest-discover-query.ts
@@ -18,15 +18,51 @@ import { checkIndexAllowlist } from './guardrails';
  * Registered ALONGSIDE the real stage-2 tool list in chat.ts's `orchestrate`, not through
  * server/tools/registry.ts: the registry is the catalog of DATA tools `resolveStage2Tools`
  * (router.ts) routes by category, and this tool has no data-fetching behavior to route to.
+ *
+ * #8915 — why there is no DETERMINISTIC (non-model) emission path, only the sharpened prompt/
+ * description guidance above: a deterministic "the turn is ending with nothing useful, auto-emit
+ * a suggested_query" backstop was evaluated and declined, for two independent reasons:
+ *  1. It already exists, structurally, for the one case where it would be safe to build: every
+ *     Indexer-backed tool call (executor.ts's `executeIndexerRequest`) already attaches a
+ *     `TableSpec.discover` link to its `table` event UNCONDITIONALLY — rows or not, truncated or
+ *     not (common/types.ts's `TableSpec.discover` doc comment). A zero-row or truncated result
+ *     from a real tool call this turn is therefore never actually link-less; the gap this issue
+ *     reports is that the model's own NARRATION doesn't call it out, which is a prompting problem
+ *     (fixed above), not a missing link.
+ *  2. For the two cases that genuinely have no such link, a safe deterministic query cannot be
+ *     built without fabricating one: (a) "no tool covers the data at all" means no tool call ever
+ *     ran this turn, so there is no executed index/DSL to derive anything from — synthesizing one
+ *     would mean guessing which index the user's free-text question maps to outside any tool
+ *     call, i.e. reimplementing the model's own topic-to-index judgment in code; (b) a Manager-API
+ *     tool's zero-item result (executeManagerRequest) has no index/DSL concept at all — Discover
+ *     searches OpenSearch indices, not Manager REST endpoints, so there is nothing sound to link
+ *     to. Both would violate the anti-fabrication constraint this fix is built under (the handoff
+ *     must be an admission the assistant cannot answer, never an invented query standing in for
+ *     one) — the model already carries the language-understanding needed to pick the right index
+ *     and reason for these cases; a deterministic backstop cannot.
+ * What it would take: a static, versioned map from tool-catalog category (router.ts's
+ * `resolveStage2Tools` categories, or `get_agents`/`get_vulnerabilities`-style tool names) to a
+ * default index/time-range DSL, so an "empty domain" turn with NO tool call could still resolve
+ * an index deterministically instead of relying on the model's own guess. That is a real feature
+ * (and a maintenance burden — it drifts every time a tool's backing index changes), not a small
+ * addition, so it is left to a follow-up rather than folded into this fix.
  */
 export const SUGGEST_DISCOVER_QUERY_TOOL: ToolSpec = {
   name: 'suggest_discover_query',
+  // #8915: this description previously read as one optional capability among several, and
+  // measured live traffic showed the model never called it — including on the turns it exists
+  // for. It now states plainly that the call is the REQUIRED close-out of an unanswerable turn,
+  // not an extra, and names all three trigger conditions — kept in sync with prompts.ts's
+  // buildSystemPrompt, which states the same three conditions in the system prompt.
   description:
-    'Use when the data the user asked about is out of reach for every other tool available to ' +
-    'you: a blocked/unsupported index, a filter search_wazuh_data cannot express within its ' +
-    'rules, or a time range beyond the 90-day maximum. Shows the user a query they can run ' +
-    'themselves in Discover, and your reason is shown alongside it — say plainly what you could ' +
-    'not check. This is NOT a way to fetch data yourself; nothing here is executed on your behalf.',
+    'The required final step of a turn you cannot fully answer — not an optional extra. Call it ' +
+    'before you finish whenever: no other tool available to you covers what the user asked about ' +
+    'at all; a tool call came back with zero rows and that zero is your whole answer; or the ' +
+    'rows you would need were truncated away and the question depends on seeing every row. Shows ' +
+    'the user a query they can run themselves in Discover, with your reason shown alongside it — ' +
+    'say plainly what you could not check or confirm. This is NOT a way to fetch data yourself: ' +
+    'nothing here is executed on your behalf, and it never replaces answering with data you ' +
+    'already have — use it to close out only the parts you could not verify.',
   parameters: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Description

Closes #8915

`suggest_discover_query` was attached to the tool list on every tool-bearing round, but it was never invoked in practice. Across 195 measured inventory-domain turns on three deployed builds, it was called zero times — including the turns where it is the designed graceful-failure path: questions over empty domains, and presence questions that couldn't be answered from a truncated sample. The likely cause: nothing in the prompt or the tool's own description told the model *when* the handoff is the right move, so it read as one more optional tool competing with the data tools instead of the expected final step of an unanswerable turn.

## Proposed Changes

- Named the trigger conditions explicitly in the system prompt and in the `suggest_discover_query` tool description: when a question can't be answered because no tool covers the data, a tool returned zero rows, or the needed rows were truncated away, call `suggest_discover_query` so the user gets a Discover handoff instead of a dead end.

### Results and Evidence

Colocated unit tests pin the trigger-condition guidance text. No user-facing UI changes.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`plugins/wazuh-ai-assistant/server/prompts.test.ts` and `server/tools/suggest-discover-query.test.ts`: trigger conditions (empty domain, zero-row result, truncated sample) are named explicitly in the prompt and tool description.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
