### PR TITLE
Narrow get_agent_inventory ports filter to listening-state sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
 | [#8910](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8910) | Fixed AI Assistant `get_agent_inventory` tool being unable to answer presence questions (e.g. "is a package/port/process present") by adding an optional `filter` parameter                  |
+| [#8914](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8914) | Fixed AI Assistant `get_agent_inventory` numeric `ports` filter matching every connection touching a port instead of preferring the listening socket(s), by narrowing on the `interface.state` field when present |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#8910](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8910) | Fixed AI Assistant `get_agent_inventory` tool being unable to answer presence questions (e.g. "is a package/port/process present") by adding an optional `filter` parameter                  |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#8910](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8910) | Fixed AI Assistant `get_agent_inventory` tool being unable to answer presence questions (e.g. "is a package/port/process present") by adding an optional `filter` parameter                  |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -359,7 +359,14 @@ test('get_agent_inventory: kind="os" filter matches either host.hostname or host
   });
 });
 
-test('get_agent_inventory: kind="ports" filter is numeric equality on source.port OR destination.port', () => {
+// #8914: a numeric ports filter matched EITHER side of the socket with no state narrowing, so
+// "what's listening on port 9200" returned every connection touching 9200 instead of just the
+// listener(s). The outer clause narrowed here: still a port match on EITHER side (`bool.filter`
+// unchanged in spirit), AND (via a nested `bool.should`/`minimum_should_match: 1`) either
+// `interface.state` is "LISTEN" or the field is absent from that document -- the graceful fallback
+// so a deployment/document without `interface.state` still gets the plain port match back instead
+// of the query going silently empty.
+test('get_agent_inventory: kind="ports" numeric filter matches the port on either side AND prefers the listening state', () => {
   const req = buildIndexer({
     agent_id: '003',
     kind: 'ports',
@@ -371,9 +378,20 @@ test('get_agent_inventory: kind="ports" filter is numeric equality on source.por
         { term: { 'wazuh.agent.id': '003' } },
         {
           bool: {
+            filter: [
+              {
+                bool: {
+                  should: [
+                    { term: { 'source.port': 9200 } },
+                    { term: { 'destination.port': 9200 } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+            ],
             should: [
-              { term: { 'source.port': 9200 } },
-              { term: { 'destination.port': 9200 } },
+              { term: { 'interface.state': 'LISTEN' } },
+              { bool: { must_not: { exists: { field: 'interface.state' } } } },
             ],
             minimum_should_match: 1,
           },
@@ -381,6 +399,25 @@ test('get_agent_inventory: kind="ports" filter is numeric equality on source.por
       ],
     },
   });
+});
+
+test('get_agent_inventory: kind="ports" numeric filter still returns a document lacking "interface.state" (fallback)', () => {
+  // Same request as above -- this test documents the query SHAPE's fallback behavior (a document
+  // with no "interface.state" field satisfies the "must_not: exists" should-clause, so it is not
+  // excluded by the state narrowing), since this is a static request-building test with no live
+  // Indexer to execute the query against.
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'ports',
+    filter: '9200',
+  });
+  const portFilterClause = (
+    req.body.query as { bool: { filter: unknown[] } }
+  ).bool.filter[1] as { bool: { should: unknown[]; minimum_should_match: number } };
+  assert.deepEqual(portFilterClause.bool.should[1], {
+    bool: { must_not: { exists: { field: 'interface.state' } } },
+  });
+  assert.equal(portFilterClause.bool.minimum_should_match, 1);
 });
 
 test('get_agent_inventory: kind="ports" a non-numeric filter falls back to a process.name match', () => {

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -401,12 +401,18 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
             should: [
               {
                 term: {
-                  'interface.state': { value: 'listening', case_insensitive: true },
+                  'interface.state': {
+                    value: 'listening',
+                    case_insensitive: true,
+                  },
                 },
               },
               {
                 term: {
-                  'interface.state': { value: 'listen', case_insensitive: true },
+                  'interface.state': {
+                    value: 'listen',
+                    case_insensitive: true,
+                  },
                 },
               },
               { bool: { must_not: { exists: { field: 'interface.state' } } } },
@@ -429,14 +435,18 @@ test('get_agent_inventory: kind="ports" listening-state match is case-insensitiv
     kind: 'ports',
     filter: '9200',
   });
-  const portFilterClause = (
-    req.body.query as { bool: { filter: unknown[] } }
-  ).bool.filter[1] as {
-    bool: { should: Array<Record<string, unknown>>; minimum_should_match: number };
+  const portFilterClause = (req.body.query as { bool: { filter: unknown[] } })
+    .bool.filter[1] as {
+    bool: {
+      should: Array<Record<string, unknown>>;
+      minimum_should_match: number;
+    };
   };
   const stateClauses = portFilterClause.bool.should.filter(
     clause => 'term' in clause,
-  ) as Array<{ term: { 'interface.state': { value: string; case_insensitive: boolean } } }>;
+  ) as Array<{
+    term: { 'interface.state': { value: string; case_insensitive: boolean } };
+  }>;
   assert.ok(
     stateClauses.length > 0,
     'expected at least one "term" clause on interface.state',
@@ -469,9 +479,10 @@ test('get_agent_inventory: kind="ports" numeric filter still returns a document 
     kind: 'ports',
     filter: '9200',
   });
-  const portFilterClause = (
-    req.body.query as { bool: { filter: unknown[] } }
-  ).bool.filter[1] as { bool: { should: unknown[]; minimum_should_match: number } };
+  const portFilterClause = (req.body.query as { bool: { filter: unknown[] } })
+    .bool.filter[1] as {
+    bool: { should: unknown[]; minimum_should_match: number };
+  };
   assert.deepEqual(
     portFilterClause.bool.should[portFilterClause.bool.should.length - 1],
     {

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -363,9 +363,18 @@ test('get_agent_inventory: kind="os" filter matches either host.hostname or host
 // "what's listening on port 9200" returned every connection touching 9200 instead of just the
 // listener(s). The outer clause narrowed here: still a port match on EITHER side (`bool.filter`
 // unchanged in spirit), AND (via a nested `bool.should`/`minimum_should_match: 1`) either
-// `interface.state` is "LISTEN" or the field is absent from that document -- the graceful fallback
-// so a deployment/document without `interface.state` still gets the plain port match back instead
-// of the query going silently empty.
+// `interface.state` case-insensitively matches "listening"/"listen" or the field is absent from
+// that document -- the graceful fallback so a deployment/document without `interface.state` still
+// gets the plain port match back instead of the query going silently empty.
+//
+// The exact clause shape (`term` with `{value, case_insensitive: true}`, not a bare string) is
+// pinned here on purpose: a live query against a real wazuh-indexer deployment (issue #8914)
+// found the actual `interface.state` vocabulary is lowercase full words ("listening",
+// "established", "time_wait", "close_wait") -- NOT the "LISTEN"/"ESTABLISHED" short forms
+// plugins/main's synthetic sample-data generator uses. An exact-cased `term: {'interface.state':
+// 'LISTEN'}` (this file's previous revision) never matches real "listening" documents, so this
+// test's assertion on the case-insensitive shape is what would catch a future regression back to
+// an exact-cased term.
 test('get_agent_inventory: kind="ports" numeric filter matches the port on either side AND prefers the listening state', () => {
   const req = buildIndexer({
     agent_id: '003',
@@ -390,7 +399,16 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
               },
             ],
             should: [
-              { term: { 'interface.state': 'LISTEN' } },
+              {
+                term: {
+                  'interface.state': { value: 'listening', case_insensitive: true },
+                },
+              },
+              {
+                term: {
+                  'interface.state': { value: 'listen', case_insensitive: true },
+                },
+              },
               { bool: { must_not: { exists: { field: 'interface.state' } } } },
             ],
             minimum_should_match: 1,
@@ -399,6 +417,46 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
       ],
     },
   });
+});
+
+// Pins the case-insensitivity specifically (issue #8914's live-verified defect): the live
+// `wazuh-states-inventory-ports*` vocabulary is lowercase ("listening"), so a `term` clause
+// without `case_insensitive: true` -- or one restored to an exact-cased literal like "LISTEN" or
+// "Listening" -- must fail this assertion loudly rather than silently reintroducing the bug.
+test('get_agent_inventory: kind="ports" listening-state match is case-insensitive, not an exact-cased literal', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'ports',
+    filter: '9200',
+  });
+  const portFilterClause = (
+    req.body.query as { bool: { filter: unknown[] } }
+  ).bool.filter[1] as {
+    bool: { should: Array<Record<string, unknown>>; minimum_should_match: number };
+  };
+  const stateClauses = portFilterClause.bool.should.filter(
+    clause => 'term' in clause,
+  ) as Array<{ term: { 'interface.state': { value: string; case_insensitive: boolean } } }>;
+  assert.ok(
+    stateClauses.length > 0,
+    'expected at least one "term" clause on interface.state',
+  );
+  for (const clause of stateClauses) {
+    const termValue = clause.term['interface.state'];
+    assert.equal(
+      typeof termValue,
+      'object',
+      'interface.state term clause must use the {value, case_insensitive} object form, not a bare string',
+    );
+    assert.equal(termValue.case_insensitive, true);
+  }
+  const matchedValues = stateClauses.map(
+    clause => clause.term['interface.state'].value,
+  );
+  assert.ok(
+    matchedValues.includes('listening'),
+    'must match the live-confirmed "listening" value',
+  );
 });
 
 test('get_agent_inventory: kind="ports" numeric filter still returns a document lacking "interface.state" (fallback)', () => {
@@ -414,9 +472,12 @@ test('get_agent_inventory: kind="ports" numeric filter still returns a document 
   const portFilterClause = (
     req.body.query as { bool: { filter: unknown[] } }
   ).bool.filter[1] as { bool: { should: unknown[]; minimum_should_match: number } };
-  assert.deepEqual(portFilterClause.bool.should[1], {
-    bool: { must_not: { exists: { field: 'interface.state' } } },
-  });
+  assert.deepEqual(
+    portFilterClause.bool.should[portFilterClause.bool.should.length - 1],
+    {
+      bool: { must_not: { exists: { field: 'interface.state' } } },
+    },
+  );
   assert.equal(portFilterClause.bool.minimum_should_match, 1);
 });
 

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -425,30 +425,6 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
   });
 });
 
-test('get_agent_inventory: kind="ports" filter is numeric equality on source.port OR destination.port', () => {
-  const req = buildIndexer({
-    agent_id: '003',
-    kind: 'ports',
-    filter: '9200',
-  });
-  assert.deepEqual(req.body.query, {
-    bool: {
-      filter: [
-        { term: { 'wazuh.agent.id': '003' } },
-        {
-          bool: {
-            should: [
-              { term: { 'source.port': 9200 } },
-              { term: { 'destination.port': 9200 } },
-            ],
-            minimum_should_match: 1,
-          },
-        },
-      ],
-    },
-  });
-});
-
 // Pins the case-insensitivity specifically (issue #8914's live-verified defect): the live
 // `wazuh-states-inventory-ports*` vocabulary is lowercase ("listening"), so a `term` clause
 // without `case_insensitive: true` -- or one restored to an exact-cased literal like "LISTEN" or

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -376,7 +376,7 @@ test('get_agent_inventory: kind="os" filter matches either host.hostname or host
 // test's assertion on the case-insensitive shape is what would catch a future regression back to
 // an exact-cased term.
 test('get_agent_inventory: kind="ports" numeric filter matches the port on either side AND prefers the listening state', () => {
-    const req = buildIndexer({
+  const req = buildIndexer({
     agent_id: '003',
     kind: 'ports',
     filter: '9200',
@@ -416,7 +416,7 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
                 },
               },
               { bool: { must_not: { exists: { field: 'interface.state' } } } },
-              ],
+            ],
             minimum_should_match: 1,
           },
         },
@@ -426,7 +426,7 @@ test('get_agent_inventory: kind="ports" numeric filter matches the port on eithe
 });
 
 test('get_agent_inventory: kind="ports" filter is numeric equality on source.port OR destination.port', () => {
-    const req = buildIndexer({
+  const req = buildIndexer({
     agent_id: '003',
     kind: 'ports',
     filter: '9200',

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts
@@ -221,3 +221,222 @@ test('get_agent_inventory: deriveColumns is set (no static tableSpec/digest for 
   assert.deepEqual(getAgentInventoryTool.tableSpec.columns, []);
   assert.deepEqual(getAgentInventoryTool.digest.sampleColumns, []);
 });
+
+// --- issue #8910: an optional "filter" narrows results on the kind's primary name field, so
+// presence questions ("is openssl installed?", "what's on port 9200?") no longer depend on the
+// answer sorting into the first `limit` rows of a possibly much larger inventory. ---
+
+test('get_agent_inventory: "filter" is an optional string param in the schema', () => {
+  const filterProperty = getAgentInventoryTool.spec.parameters.properties
+    .filter as unknown as { type?: string };
+  assert.equal(filterProperty.type, 'string');
+  assert.ok(
+    !(getAgentInventoryTool.spec.parameters.required ?? []).includes('filter'),
+    'filter must not be required',
+  );
+});
+
+test('get_agent_inventory: omitting "filter" leaves the request body unchanged (regression)', () => {
+  const req = buildIndexer({ agent_id: '003', kind: 'packages' });
+  assert.deepEqual(req.body.query, {
+    bool: { filter: [{ term: { 'wazuh.agent.id': '003' } }] },
+  });
+});
+
+test('get_agent_inventory: kind="packages" filter narrows on package.name, case-insensitive prefix', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'packages',
+    filter: 'openssl',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          wildcard: {
+            'package.name': { value: 'openssl*', case_insensitive: true },
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: kind="hotfixes" filter narrows on package.hotfix.name', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'hotfixes',
+    filter: 'KB5001',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          wildcard: {
+            'package.hotfix.name': {
+              value: 'KB5001*',
+              case_insensitive: true,
+            },
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: kind="processes" filter matches either process.name or process.command_line', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'processes',
+    filter: 'nginx',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          bool: {
+            should: [
+              {
+                wildcard: {
+                  'process.name': { value: 'nginx*', case_insensitive: true },
+                },
+              },
+              {
+                wildcard: {
+                  'process.command_line': {
+                    value: 'nginx*',
+                    case_insensitive: true,
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: kind="os" filter matches either host.hostname or host.os.name', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'os',
+    filter: 'web-prod-01',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          bool: {
+            should: [
+              {
+                wildcard: {
+                  'host.hostname': {
+                    value: 'web-prod-01*',
+                    case_insensitive: true,
+                  },
+                },
+              },
+              {
+                wildcard: {
+                  'host.os.name': {
+                    value: 'web-prod-01*',
+                    case_insensitive: true,
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: kind="ports" filter is numeric equality on source.port OR destination.port', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'ports',
+    filter: '9200',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          bool: {
+            should: [
+              { term: { 'source.port': 9200 } },
+              { term: { 'destination.port': 9200 } },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: kind="ports" a non-numeric filter falls back to a process.name match', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'ports',
+    filter: 'nginx',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          wildcard: {
+            'process.name': { value: 'nginx*', case_insensitive: true },
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: filter value is sanitized so a caller-supplied "*"/"?" cannot produce a leading wildcard', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'packages',
+    filter: '*ssl?',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: {
+      filter: [
+        { term: { 'wazuh.agent.id': '003' } },
+        {
+          wildcard: {
+            'package.name': { value: 'ssl*', case_insensitive: true },
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('get_agent_inventory: a blank/whitespace-only filter is treated as omitted', () => {
+  const req = buildIndexer({
+    agent_id: '003',
+    kind: 'packages',
+    filter: '   ',
+  });
+  assert.deepEqual(req.body.query, {
+    bool: { filter: [{ term: { 'wazuh.agent.id': '003' } }] },
+  });
+});
+
+test('get_agent_inventory: description advertises "filter" for presence questions (routing guidance)', () => {
+  assert.match(
+    getAgentInventoryTool.spec.description,
+    /check whether one specific package\/port\/process is present.*pass "filter"/,
+  );
+});

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
@@ -157,10 +157,10 @@ function parseKind(value: unknown): InventoryKind {
  *   `filter` silently ignored for exactly one of the five kinds would be a worse (surprising)
  *   contract than a uniform, if lower-value, one.
  * - `ports` has no single name field (see `buildInventoryFilterClause`'s own handling): a numeric
- *   filter matches `source.port`/`destination.port` AND prefers `interface.state: LISTEN` (issue
- *   #8914 -- see `PORT_LISTENING_STATE`'s doc comment below), a non-numeric one matches
- *   `process.name` (the process bound to the port), matching the issue's own worked example ("what
- *   process is on port 9200").
+ *   filter matches `source.port`/`destination.port` AND prefers a listening `interface.state`
+ *   (issue #8914 -- see `PORT_LISTENING_STATE_VALUES`'s doc comment below), a non-numeric one
+ *   matches `process.name` (the process bound to the port), matching the issue's own worked
+ *   example ("what process is on port 9200").
  */
 const INVENTORY_FILTER_FIELDS: Partial<Record<InventoryKind, string[]>> = {
   os: ['host.hostname', 'host.os.name'],
@@ -223,21 +223,39 @@ function anyFieldMatches(
 }
 
 /**
- * `interface.state` value the syscollector ports schema uses for a bound/listening socket.
- * Evidence: the outbound `_source` for `ports` already carries `interface.state` (see
- * `INVENTORY_KIND_CONFIG` above, unchanged by this fix), and `plugins/main`'s own
- * `states-inventory-ports` sample-data generator (`server/lib/sample-data/dataset/
- * states-inventory-ports/main.js`) sets it to exactly `random.choice(['LISTEN', 'ESTABLISHED'])`
- * -- the same two-value vocabulary `plugins/main`'s IT Hygiene dashboards filter on with
- * `interface.state: LISTEN`/`interface.state: ESTABLISHED` KQL queries (e.g.
- * `public/components/overview/it-hygiene/networks/inventories/traffic/dashboard.ts`), sourced
- * from the wazuh-indexer ports template (referenced in that same generator file as
- * https://github.com/wazuh/wazuh-indexer/pull/744). No index template/mapping JSON for
- * `wazuh-states-inventory-ports*` is checked into this repo, so this is the same standard of
- * "confirmed live-checked-in evidence, not a guessed sibling field" this file already applies
- * elsewhere (see `INVENTORY_KIND_CONFIG`'s `hotfixes` doc comment).
+ * `interface.state` value(s) the syscollector ports schema uses for a bound/listening socket.
+ *
+ * Evidence (issue #8914, live query against a real wazuh-indexer deployment): a terms aggregation
+ * over `interface.state` on `wazuh-states-inventory-ports*` (84 docs) returned exactly
+ * `listening` (14), `established` (59), `time_wait` (6), `close_wait` (3) -- lowercase, full
+ * English words, NOT the `LISTEN`/`ESTABLISHED` short forms this constant previously held. That
+ * mismatch was a live wrong-answer bug: a case-sensitive `term: { 'interface.state': 'LISTEN' }`
+ * never matches real `listening` documents, so `get_agent_inventory(kind='ports',
+ * filter='9200')` silently returned zero rows against a live cluster (the "OR field absent"
+ * fallback below never firing either, since real documents DO carry `interface.state`) and the
+ * assistant confidently reported nothing listening on a port that was, live, bound by `java`.
+ *
+ * `plugins/main`'s own `states-inventory-ports` sample-data generator (`server/lib/sample-data/
+ * dataset/states-inventory-ports/main.js`, `random.choice(['LISTEN', 'ESTABLISHED'])`) is
+ * SYNTHETIC test fixture data, not a live-verified schema -- it does not match the real
+ * wazuh-indexer vocabulary above and MUST NOT be treated as authoritative for this field's casing
+ * or wording (this file's previous revision made exactly that mistake). Both `listening` (the
+ * confirmed live value) and `listen` (in case an older/differently-provisioned indexer still
+ * writes the sample-data generator's short form) are matched below, each case-insensitively, so
+ * this survives casing differences in either vocabulary without having to guess which one a given
+ * deployment actually writes.
  */
-const PORT_LISTENING_STATE = 'LISTEN';
+const PORT_LISTENING_STATE_VALUES = ['listening', 'listen'];
+
+/** Case-insensitive exact-value match for one of `PORT_LISTENING_STATE_VALUES` -- `term` (not
+ * `match`) with `case_insensitive: true`, the shape OpenSearch supports for an exact-but-cased-
+ * agnostic match on a `keyword` field ("keyword field" per `_source` company in
+ * `INVENTORY_KIND_CONFIG`'s `ports` entry; a prefix/wildcard match would be wrong here since a
+ * substring like "listening" must not accidentally match some other unrelated state word). Kept as
+ * its own helper so both values in `PORT_LISTENING_STATE_VALUES` build the identical clause shape. */
+function listeningStateClause(value: string): Record<string, unknown> {
+  return { term: { 'interface.state': { value, case_insensitive: true } } };
+}
 
 /**
  * Resolves the optional `filter` param (issue #8910) to zero or one extra `bool.filter` clause,
@@ -259,14 +277,18 @@ const PORT_LISTENING_STATE = 'LISTEN';
  * narrows this: the outer clause is `bool.filter` on the port match (unchanged, still both sides --
  * a `source.port`/`destination.port` OR, since a caller-supplied port can legitimately be either
  * side of a real socket) AND (via a nested `bool.should`/`minimum_should_match: 1`) either
- * `interface.state` is `LISTEN` OR the `interface.state` field is absent from that document. The
- * "OR absent" arm is the graceful fallback the issue asks for: `interface.state` is NOT made a hard
- * requirement (a `must`/`filter` on `term: LISTEN` alone would silently return zero rows for any
- * document that happens to lack the field -- e.g. an older/partial doc from before the field
- * existed), so a deployment where some or all `ports` documents never carry `interface.state` still
- * gets its port-only match back exactly as before this fix, one document at a time, rather than the
- * whole query going empty. A document that DOES carry `interface.state` and holds a non-listening
- * value (e.g. `ESTABLISHED`) is excluded -- that is the actual narrowing this issue exists for.
+ * `interface.state` case-insensitively matches one of `PORT_LISTENING_STATE_VALUES` OR the
+ * `interface.state` field is absent from that document. The "OR absent" arm is the graceful
+ * fallback the issue asks for: `interface.state` is NOT made a hard requirement (a `must`/`filter`
+ * on a listening-state term alone would silently return zero rows for any document that happens to
+ * lack the field -- e.g. an older/partial doc from before the field existed), so a deployment where
+ * some or all `ports` documents never carry `interface.state` still gets its port-only match back
+ * exactly as before this fix, one document at a time, rather than the whole query going empty. A
+ * document that DOES carry `interface.state` and holds a non-listening value (e.g. `established`)
+ * is excluded -- that is the actual narrowing this issue exists for. See
+ * `PORT_LISTENING_STATE_VALUES`'s doc comment for why the match is a case-insensitive `term` (not
+ * an exact-cased one) against two known spellings, not just the live-confirmed `listening` value
+ * alone.
  */
 function buildInventoryFilterClause(
   kind: InventoryKind,
@@ -296,7 +318,7 @@ function buildInventoryFilterClause(
         bool: {
           filter: [portMatch],
           should: [
-            { term: { 'interface.state': PORT_LISTENING_STATE } },
+            ...PORT_LISTENING_STATE_VALUES.map(listeningStateClause),
             { bool: { must_not: { exists: { field: 'interface.state' } } } },
           ],
           minimum_should_match: 1,

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
@@ -157,9 +157,10 @@ function parseKind(value: unknown): InventoryKind {
  *   `filter` silently ignored for exactly one of the five kinds would be a worse (surprising)
  *   contract than a uniform, if lower-value, one.
  * - `ports` has no single name field (see `buildInventoryFilterClause`'s own handling): a numeric
- *   filter matches `source.port`/`destination.port`, a non-numeric one matches `process.name` (the
- *   process bound to the port), matching the issue's own worked example ("what process is on port
- *   9200").
+ *   filter matches `source.port`/`destination.port` AND prefers `interface.state: LISTEN` (issue
+ *   #8914 -- see `PORT_LISTENING_STATE`'s doc comment below), a non-numeric one matches
+ *   `process.name` (the process bound to the port), matching the issue's own worked example ("what
+ *   process is on port 9200").
  */
 const INVENTORY_FILTER_FIELDS: Partial<Record<InventoryKind, string[]>> = {
   os: ['host.hostname', 'host.os.name'],
@@ -222,6 +223,23 @@ function anyFieldMatches(
 }
 
 /**
+ * `interface.state` value the syscollector ports schema uses for a bound/listening socket.
+ * Evidence: the outbound `_source` for `ports` already carries `interface.state` (see
+ * `INVENTORY_KIND_CONFIG` above, unchanged by this fix), and `plugins/main`'s own
+ * `states-inventory-ports` sample-data generator (`server/lib/sample-data/dataset/
+ * states-inventory-ports/main.js`) sets it to exactly `random.choice(['LISTEN', 'ESTABLISHED'])`
+ * -- the same two-value vocabulary `plugins/main`'s IT Hygiene dashboards filter on with
+ * `interface.state: LISTEN`/`interface.state: ESTABLISHED` KQL queries (e.g.
+ * `public/components/overview/it-hygiene/networks/inventories/traffic/dashboard.ts`), sourced
+ * from the wazuh-indexer ports template (referenced in that same generator file as
+ * https://github.com/wazuh/wazuh-indexer/pull/744). No index template/mapping JSON for
+ * `wazuh-states-inventory-ports*` is checked into this repo, so this is the same standard of
+ * "confirmed live-checked-in evidence, not a guessed sibling field" this file already applies
+ * elsewhere (see `INVENTORY_KIND_CONFIG`'s `hotfixes` doc comment).
+ */
+const PORT_LISTENING_STATE = 'LISTEN';
+
+/**
  * Resolves the optional `filter` param (issue #8910) to zero or one extra `bool.filter` clause,
  * appended by `buildRequest` after the agent clause. Returns `undefined` for an omitted/blank
  * filter (existing callers with no `filter` supplied get exactly the same request body as before
@@ -234,6 +252,21 @@ function anyFieldMatches(
  * `long`, never `keyword`), since neither `source`/`destination` alone is "the" port a caller means
  * by "port 9200". A non-numeric filter ("which process is on port X" asked the other way, "what's
  * using nginx's port") falls back to the same `process.name` prefix match `processes` uses.
+ *
+ * Issue #8910: a numeric filter matched EITHER side of the socket with no state narrowing, so
+ * "what's listening on port 9200" returned every connection touching 9200 (both the listener AND
+ * every established peer connection through it) instead of just the listener(s). Issue #8914
+ * narrows this: the outer clause is `bool.filter` on the port match (unchanged, still both sides --
+ * a `source.port`/`destination.port` OR, since a caller-supplied port can legitimately be either
+ * side of a real socket) AND (via a nested `bool.should`/`minimum_should_match: 1`) either
+ * `interface.state` is `LISTEN` OR the `interface.state` field is absent from that document. The
+ * "OR absent" arm is the graceful fallback the issue asks for: `interface.state` is NOT made a hard
+ * requirement (a `must`/`filter` on `term: LISTEN` alone would silently return zero rows for any
+ * document that happens to lack the field -- e.g. an older/partial doc from before the field
+ * existed), so a deployment where some or all `ports` documents never carry `interface.state` still
+ * gets its port-only match back exactly as before this fix, one document at a time, rather than the
+ * whole query going empty. A document that DOES carry `interface.state` and holds a non-listening
+ * value (e.g. `ESTABLISHED`) is excluded -- that is the actual narrowing this issue exists for.
  */
 function buildInventoryFilterClause(
   kind: InventoryKind,
@@ -250,11 +283,21 @@ function buildInventoryFilterClause(
   if (kind === 'ports') {
     if (INTEGER_FILTER_RE.test(value)) {
       const port = Number.parseInt(value, 10);
-      return {
+      const portMatch = {
         bool: {
           should: [
             { term: { 'source.port': port } },
             { term: { 'destination.port': port } },
+          ],
+          minimum_should_match: 1,
+        },
+      };
+      return {
+        bool: {
+          filter: [portMatch],
+          should: [
+            { term: { 'interface.state': PORT_LISTENING_STATE } },
+            { bool: { must_not: { exists: { field: 'interface.state' } } } },
           ],
           minimum_should_match: 1,
         },
@@ -367,9 +410,12 @@ export const getAgentInventoryTool: ToolDefinition = {
             "Narrows results to rows matching this value on the kind's primary name field, " +
             'case-insensitive: package name for "packages", hotfix id for "hotfixes", process ' +
             'name/command line for "processes", hostname/OS name for "os". For "ports", a numeric ' +
-            'value matches that port number (source or destination); a non-numeric value matches ' +
-            "the process name bound to the port. Optional -- omit to return the kind's unfiltered " +
-            'rows (existing behavior, subject to "limit").',
+            'value matches that port number (source or destination) and prefers the LISTENING ' +
+            'socket(s) when a row carries the "interface.state" field ("what is listening on port ' +
+            '9200?" -- rows without that field are still returned, unnarrowed, so the port-only ' +
+            'match never goes silently empty); a non-numeric value matches the process name bound ' +
+            "to the port. Optional -- omit to return the kind's unfiltered rows (existing " +
+            'behavior, subject to "limit").',
         },
       },
       ['kind'],

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
@@ -141,6 +141,132 @@ function parseKind(value: unknown): InventoryKind {
 }
 
 /**
+ * Per-kind primary name field the optional `filter` param (issue #8910) narrows on, keyed the same
+ * as `INVENTORY_KIND_CONFIG`. Picked from that config's own `source` lists -- never a field invented
+ * for this feature -- so every entry here is already a confirmed part of this tool's outbound
+ * `_source`/query contract:
+ * - `packages` -> `package.name` (the field the failing live question, "is openssl installed on
+ *   agent X", is actually asking about).
+ * - `hotfixes` -> `package.hotfix.name`, the one confirmed field for that kind (see
+ *   `INVENTORY_KIND_CONFIG`'s own doc comment above).
+ * - `processes` -> `process.name`; `process.command_line` is matched too (see
+ *   `buildInventoryFilterClause` below) since "which process" questions are answered as often by a
+ *   command-line fragment as by the bare process name.
+ * - `os` matches `host.hostname` OR `host.os.name` -- the two fields that actually identify an OS
+ *   record by name -- even though `kind="os"` already returns at most 5 rows (`fixedSize`): leaving
+ *   `filter` silently ignored for exactly one of the five kinds would be a worse (surprising)
+ *   contract than a uniform, if lower-value, one.
+ * - `ports` has no single name field (see `buildInventoryFilterClause`'s own handling): a numeric
+ *   filter matches `source.port`/`destination.port`, a non-numeric one matches `process.name` (the
+ *   process bound to the port), matching the issue's own worked example ("what process is on port
+ *   9200").
+ */
+const INVENTORY_FILTER_FIELDS: Partial<Record<InventoryKind, string[]>> = {
+  os: ['host.hostname', 'host.os.name'],
+  packages: ['package.name'],
+  processes: ['process.name', 'process.command_line'],
+  hotfixes: ['package.hotfix.name'],
+};
+
+/** Digits only, matching a Wazuh/syscollector port number (`source.port`/`destination.port` are
+ * plain non-negative integers, never signed/floating) -- `parseInt` alone would accept "9200abc" as
+ * 9200, which is not what a caller who typed that meant. */
+const INTEGER_FILTER_RE = /^\d+$/;
+
+/**
+ * A caller-supplied `filter` is meant as a plain substring, not Lucene syntax -- stripping `*`/`?`
+ * before this tool ever builds its own trailing wildcard keeps the outbound value guardrail-safe by
+ * construction (guardrails.ts's `lintDsl` runs on every catalog tool's request with no per-tool
+ * exemption, and rejects a "wildcard" clause whose value has a LEADING `*`/`?` -- a caller who typed
+ * `filter: "*ssl"` would otherwise turn this tool's own `${value}*` into `"*ssl*"` and get a
+ * confusing guardrail rejection instead of the match they asked for).
+ */
+function sanitizeFilterValue(value: string): string {
+  return value.replace(/[*?]/g, '').trim();
+}
+
+/** Case-insensitive PREFIX match on a keyword field: `wildcard` with only a TRAILING `*` (never a
+ * leading one -- see `sanitizeFilterValue`'s doc comment) and `case_insensitive: true`, the shape
+ * this repo's `wazuh-states-*` fields are queried with elsewhere once analyzed matching isn't wanted
+ * (see e.g. `common.ts`'s `findingArtifactFilterClauses`, which uses `term`/exact match for the same
+ * reason: case_insensitive here trades exactness for a prefix substring UX, which the presence
+ * questions this feature exists for need -- "is openssl installed" should still match if the actual
+ * package name has different casing).
+ */
+function caseInsensitivePrefixClause(
+  field: string,
+  value: string,
+): Record<string, unknown> {
+  return {
+    wildcard: { [field]: { value: `${value}*`, case_insensitive: true } },
+  };
+}
+
+/** `bool.should`/`minimum_should_match: 1` wrapper for "match any of these name fields" -- used
+ * whenever a kind's `INVENTORY_FILTER_FIELDS` entry lists more than one field (`os`, `processes`). A
+ * single-field kind skips this wrapper entirely (see `buildInventoryFilterClause` below), so its
+ * outbound clause is unchanged from a bare `caseInsensitivePrefixClause` call. */
+function anyFieldMatches(
+  fields: string[],
+  value: string,
+): Record<string, unknown> {
+  if (fields.length === 1) {
+    return caseInsensitivePrefixClause(fields[0], value);
+  }
+  return {
+    bool: {
+      should: fields.map(field => caseInsensitivePrefixClause(field, value)),
+      minimum_should_match: 1,
+    },
+  };
+}
+
+/**
+ * Resolves the optional `filter` param (issue #8910) to zero or one extra `bool.filter` clause,
+ * appended by `buildRequest` after the agent clause. Returns `undefined` for an omitted/blank
+ * filter (existing callers with no `filter` supplied get exactly the same request body as before
+ * this existed) or the sanitized value collapses to '' after `sanitizeFilterValue` strips it.
+ *
+ * `ports` is the one kind with no single name field in `INVENTORY_FILTER_FIELDS` (its `_source` has
+ * `source.port`/`destination.port` instead of one name field) -- handled here directly rather than
+ * added to that map: a filter that parses as a plain non-negative integer (`INTEGER_FILTER_RE`)
+ * matches either port field by NUMERIC equality (`term`, not a string match -- these fields are
+ * `long`, never `keyword`), since neither `source`/`destination` alone is "the" port a caller means
+ * by "port 9200". A non-numeric filter ("which process is on port X" asked the other way, "what's
+ * using nginx's port") falls back to the same `process.name` prefix match `processes` uses.
+ */
+function buildInventoryFilterClause(
+  kind: InventoryKind,
+  params: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const raw = optionalStringParam(params.filter);
+  if (!raw) {
+    return undefined;
+  }
+  const value = sanitizeFilterValue(raw);
+  if (value === '') {
+    return undefined;
+  }
+  if (kind === 'ports') {
+    if (INTEGER_FILTER_RE.test(value)) {
+      const port = Number.parseInt(value, 10);
+      return {
+        bool: {
+          should: [
+            { term: { 'source.port': port } },
+            { term: { 'destination.port': port } },
+          ],
+          minimum_should_match: 1,
+        },
+      };
+    }
+    return caseInsensitivePrefixClause('process.name', value);
+  }
+  const fields = INVENTORY_FILTER_FIELDS[kind];
+  return fields ? anyFieldMatches(fields, value) : undefined;
+}
+
+/**
  * Resolves the agent-identifying filter clause from `agent_id`/`agent_name` (issue #8873: a live
  * 40-question run invoked this tool 0/40 times, including on 3 questions statically targeting it,
  * because `agent_id` was strictly required and numeric while the target personas ask deictically
@@ -205,7 +331,11 @@ export const getAgentInventoryTool: ToolDefinition = {
       'critical vulnerabilities already have a hotfix available"). Identify the agent by ' +
       '"agent_id" (numeric) OR "agent_name" -- if the question refers to "this server"/"the ' +
       'host" without naming or numbering it, and no agent id or name is otherwise known from the ' +
-      `conversation, call get_agents first to look one up. ${INVENTORY_CURRENT_STATE_NOTE}`,
+      `conversation, call get_agents first to look one up. ${INVENTORY_CURRENT_STATE_NOTE} To ` +
+      'check whether one specific package/port/process is present (e.g. "is openssl installed on ' +
+      'this host?", "what is listening on port 9200?"), pass "filter" instead of scanning the ' +
+      'returned rows yourself -- results are truncated well before every row is returned (see ' +
+      '"limit" below), so a specific entry can be absent from the sample even when it exists.',
     parameters: objectSchema(
       {
         agent_id: {
@@ -227,8 +357,20 @@ export const getAgentInventoryTool: ToolDefinition = {
         },
         limit: limitProperty(
           'Max number of rows to return (default 50, max 500). Ignored for kind="os": one agent ' +
-            'has at most one current OS record, so this always returns at most 5 rows regardless.',
+            'has at most one current OS record, so this always returns at most 5 rows regardless. ' +
+            'A large inventory (e.g. hundreds of packages) can exceed this before every row is ' +
+            'returned -- prefer "filter" over raising this for a targeted lookup.',
         ),
+        filter: {
+          type: 'string',
+          description:
+            "Narrows results to rows matching this value on the kind's primary name field, " +
+            'case-insensitive: package name for "packages", hotfix id for "hotfixes", process ' +
+            'name/command line for "processes", hostname/OS name for "os". For "ports", a numeric ' +
+            'value matches that port number (source or destination); a non-numeric value matches ' +
+            "the process name bound to the port. Optional -- omit to return the kind's unfiltered " +
+            'rows (existing behavior, subject to "limit").',
+        },
       },
       ['kind'],
     ),
@@ -246,12 +388,16 @@ export const getAgentInventoryTool: ToolDefinition = {
         config.limitRange?.[0] ?? 50,
         config.limitRange?.[1] ?? 500,
       );
+    const inventoryFilter = buildInventoryFilterClause(kind, params);
+    const filter = inventoryFilter
+      ? [agentFilter, inventoryFilter]
+      : [agentFilter];
     return {
       target: 'indexer',
       index: config.index,
       body: {
         query: {
-          bool: { filter: [agentFilter] },
+          bool: { filter },
         },
         _source: config.source,
         sort: ['_doc'],

--- a/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.ts
@@ -158,8 +158,8 @@ function parseKind(value: unknown): InventoryKind {
  *   contract than a uniform, if lower-value, one.
  * - `ports` has no single name field (see `buildInventoryFilterClause`'s own handling): a numeric
  *   filter matches `source.port`/`destination.port`AND prefers a listening `interface.state`
- *   (issue #8914 -- see `PORT_LISTENING_STATE_VALUES`'s doc comment below), a non-numeric one 
- *   matches `process.name` (the process bound to the port), matching the issue's own worked 
+ *   (issue #8914 -- see `PORT_LISTENING_STATE_VALUES`'s doc comment below), a non-numeric one
+ *   matches `process.name` (the process bound to the port), matching the issue's own worked
  *   example ("what process is on port 9200").
  */
 const INVENTORY_FILTER_FIELDS: Partial<Record<InventoryKind, string[]>> = {


### PR DESCRIPTION
## Description

Closes #8914

Depends on #8924 (branched from `fix/8910-inventory-filter-param`, not yet merged) — this PR targets that branch as its base until #8924 merges, at which point it should be retargeted to `5.0.0`.

`get_agent_inventory`'s numeric `filter` for `kind: ports` (#8910) matched the port on either side of the socket (`source.port` OR `destination.port`), so "what is listening on port 9200?" returned every connection touching 9200 — dozens of rows — instead of the listening socket(s). The answer was still derivable and correct in live runs, but the result set was much broader than the question, and data-fidelity scoring against a listening-state control query failed.

## Proposed Changes

- Narrowed the numeric ports filter to prefer listening-state sockets when the live indexer's `interface.state` field is present (matching `listening`/`listen`, case-insensitive, or falling back when the field is absent so non-listening lookups still work).
- Updated the tool description to state the listening-state semantics of the filtered result.

### Results and Evidence

Colocated unit tests cover the outbound query shape with and without the state field, and case-insensitivity of the state match. No user-facing UI changes.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`plugins/wazuh-ai-assistant/server/tools/catalog/get-agent-inventory.test.ts`: ports numeric filter narrows on `interface.state` when present; state match is case-insensitive; a document lacking `interface.state` is still returned (fallback).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
