### PR TITLE
Provider configuration does not tell the administrator what state the provider is in

### DIFF
--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -36,7 +36,7 @@ describe('ProviderFormFlyout — create mode', () => {
     expect(
       screen.getByRole('heading', { name: /add provider/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/^name$/i)).toHaveValue('');
+    expect(screen.getByLabelText(/^name/i)).toHaveValue('');
   });
 
   it('clarifies the API key is optional for auth-free endpoints and encrypted at rest', () => {
@@ -56,7 +56,7 @@ describe('ProviderFormFlyout — create mode', () => {
     fireEvent.change(screen.getByLabelText(/endpoint url/i), {
       target: { value: 'not-a-url' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
 
     expect(
       await screen.findByText(/valid URL starting with http/i),
@@ -67,16 +67,16 @@ describe('ProviderFormFlyout — create mode', () => {
   it('submits trimmed values', async () => {
     render(<ProviderFormFlyout {...baseProps} />);
 
-    fireEvent.change(screen.getByLabelText(/^name$/i), {
+    fireEvent.change(screen.getByLabelText(/^name/i), {
       target: { value: '  Groq  ' },
     });
     fireEvent.change(screen.getByLabelText(/endpoint url/i), {
       target: { value: ' https://api.groq.com/openai/v1 ' },
     });
-    fireEvent.change(screen.getByLabelText(/^model$/i), {
+    fireEvent.change(screen.getByLabelText(/^model/i), {
       target: { value: 'llama-3.3-70b-versatile' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
 
     await waitFor(() => {
       expect(baseProps.onSubmit).toHaveBeenCalledWith({
@@ -107,11 +107,11 @@ describe('ProviderFormFlyout — edit mode', () => {
     expect(
       screen.getByRole('heading', { name: /edit provider/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/^name$/i)).toHaveValue('My OpenAI');
+    expect(screen.getByLabelText(/^name/i)).toHaveValue('My OpenAI');
     expect(screen.getByLabelText(/endpoint url/i)).toHaveValue(
       'https://api.openai.com/v1',
     );
-    expect(screen.getByLabelText(/^model$/i)).toHaveValue('gpt-4o');
+    expect(screen.getByLabelText(/^model/i)).toHaveValue('gpt-4o');
     expect(
       screen.getByText(/leave empty to keep the current key/i),
     ).toBeInTheDocument();
@@ -141,13 +141,13 @@ describe('ProviderFormFlyout — submit error and RBAC', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /save & test/i })).toBeDisabled();
   });
 });
 
 describe('ProviderFormFlyout — unsaved changes confirmation', () => {
   const dirtyTheForm = () => {
-    fireEvent.change(screen.getByLabelText(/^name$/i), {
+    fireEvent.change(screen.getByLabelText(/^name/i), {
       target: { value: 'Draft name' },
     });
   };
@@ -181,14 +181,14 @@ describe('ProviderFormFlyout — unsaved changes confirmation', () => {
 
     expect(screen.queryByText(/unsubmitted changes/i)).not.toBeInTheDocument();
     expect(baseProps.onClose).not.toHaveBeenCalled();
-    expect(screen.getByLabelText(/^name$/i)).toHaveValue('Draft name');
+    expect(screen.getByLabelText(/^name/i)).toHaveValue('Draft name');
   });
 
   it('closes directly again once edits are reverted to the initial values', () => {
     render(<ProviderFormFlyout {...baseProps} />);
 
     dirtyTheForm();
-    fireEvent.change(screen.getByLabelText(/^name$/i), {
+    fireEvent.change(screen.getByLabelText(/^name/i), {
       target: { value: '' },
     });
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
@@ -202,7 +202,7 @@ describe('ProviderFormFlyout — unsaved changes confirmation', () => {
       <ProviderFormFlyout {...baseProps} editingProvider={editingProvider} />,
     );
 
-    fireEvent.change(screen.getByLabelText(/^model$/i), {
+    fireEvent.change(screen.getByLabelText(/^model/i), {
       target: { value: 'gpt-4.1' },
     });
     fireEvent.click(
@@ -232,7 +232,7 @@ describe('ProviderFormFlyout — API key encryption gate', () => {
       <ProviderFormFlyout {...baseProps} apiKeyEncryptionEnabled={false} />,
     );
 
-    const saveButton = screen.getByRole('button', { name: /^save$/i });
+    const saveButton = screen.getByRole('button', { name: /save & test/i });
     expect(saveButton).toBeEnabled();
 
     fireEvent.change(screen.getByLabelText(/^api key$/i), {
@@ -254,7 +254,7 @@ describe('ProviderFormFlyout — API key encryption gate', () => {
     fireEvent.change(screen.getByLabelText(/^api key$/i), {
       target: { value: 'sk-secret' },
     });
-    expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /save & test/i })).toBeEnabled();
   });
 });
 

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -193,13 +193,6 @@ const PROVIDER_MODEL_GUIDANCE: Record<
   },
 };
 
-/**
- * Server-required fields (Name, Provider type, Endpoint URL, Model — see the create/update
- * validators in server/routes/settings.ts) carried no visual or accessible "required" marker
- * (issue #8854, "Also noticed"), so only the one OPTIONAL field (API key) explained itself. A
- * plain trailing asterisk mirrors how the rest of this repo's forms already flag required
- * fields — no new visual language introduced.
- */
 const RequiredLabel: React.FC<{ label: string }> = ({ label }) => (
   <>
     {label}{' '}
@@ -217,8 +210,6 @@ const emptyForm: ProviderInput = {
   apiKey: '',
 };
 
-// Requires at least one character after the scheme so a bare `https://` (which the server
-// round-trip would reject anyway) is caught here instead of only after a save attempt.
 function isValidEndpointUrl(value: string): boolean {
   return /^https?:\/\/.+/i.test(value.trim());
 }
@@ -436,13 +427,6 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
             </>
           )}
           {!canSave && (
-            // Issue #8854, point 5: the disabled Save button's own EuiToolTip below carries the
-            // same message, but a tooltip only reaches a mouse user who happens to hover the
-            // greyed-out button — an admin who fills in the whole form and then wonders why Save
-            // won't respond should not have to go looking for it. This callout is the
-            // always-visible copy of that same explanation, inside the form the admin is actually
-            // looking at (the page-level warning in settings-page.tsx sits behind this flyout
-            // once it's open).
             <>
               <EuiCallOut
                 color='warning'
@@ -664,13 +648,6 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               label={i18n.translate('wazuhAiAssistant.settings.form.apiKey', {
                 defaultMessage: 'API key',
               })}
-              // Issue #8854, point 4: the field itself is always blank on edit (the key is never
-              // sent back to the browser — ProviderSummary redacts it to `hasApiKey`), which used
-              // to read as "the key got deleted." The providers TABLE already shows "Configured"
-              // for this same provider; this badge is that same fact, moved to where an admin who
-              // opened the edit form would actually see it. Neutral (not success/warning) per the
-              // linked Kibana precedent (elastic/kibana#80657) choosing plain text over an alarm
-              // color after design review — this is informational, not a state to react to.
               labelAppend={
                 editingProvider?.hasApiKey ? (
                   <EuiBadge color='hollow'>
@@ -721,11 +698,6 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
           </EuiForm>
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
-          {/* Cancel-left/Save-right (issue #8854, "Also noticed": the two were reversed before)
-              plus a dedicated EuiFlyoutFooter — previously Save/Cancel sat inline at the end of
-              the form's own scrolling area, so on a tall form (the encryption callout, five
-              fields, three doc popovers) both could scroll out of view entirely; the footer is
-              pinned outside that scroll region. */}
           <EuiFlexGroup justifyContent='spaceBetween'>
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty onClick={requestClose} flush='left'>

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -10,8 +10,10 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiBadge,
   EuiFlyout,
   EuiFlyoutBody,
+  EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
@@ -21,6 +23,7 @@ import {
   EuiSelect,
   EuiSpacer,
   EuiText,
+  EuiTextColor,
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
@@ -90,7 +93,9 @@ const PROVIDER_URL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.baseUrlDocsOpenai',
-          { defaultMessage: 'OpenAI API reference' },
+          {
+            defaultMessage: 'OpenAI API reference',
+          },
         ),
         url: 'https://platform.openai.com/docs/api-reference',
       },
@@ -106,7 +111,9 @@ const PROVIDER_URL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.baseUrlDocsOllama',
-          { defaultMessage: 'Ollama API reference' },
+          {
+            defaultMessage: 'Ollama API reference',
+          },
         ),
         url: 'https://github.com/ollama/ollama/blob/main/docs/api.md',
       },
@@ -120,7 +127,9 @@ const PROVIDER_URL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.baseUrlDocsAnthropic',
-          { defaultMessage: 'Anthropic API reference' },
+          {
+            defaultMessage: 'Anthropic API reference',
+          },
         ),
         url: 'https://docs.anthropic.com/en/api/overview',
       },
@@ -144,7 +153,9 @@ const PROVIDER_MODEL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.modelDocsOpenai',
-          { defaultMessage: 'OpenAI model list' },
+          {
+            defaultMessage: 'OpenAI model list',
+          },
         ),
         url: 'https://platform.openai.com/docs/models',
       },
@@ -157,7 +168,9 @@ const PROVIDER_MODEL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.modelDocsOllama',
-          { defaultMessage: 'Ollama model library' },
+          {
+            defaultMessage: 'Ollama model library',
+          },
         ),
         url: 'https://ollama.com/library',
       },
@@ -170,13 +183,31 @@ const PROVIDER_MODEL_GUIDANCE: Record<
       {
         label: i18n.translate(
           'wazuhAiAssistant.settings.form.modelDocsAnthropic',
-          { defaultMessage: 'Anthropic model list' },
+          {
+            defaultMessage: 'Anthropic model list',
+          },
         ),
         url: 'https://docs.anthropic.com/en/docs/about-claude/models/overview',
       },
     ],
   },
 };
+
+/**
+ * Server-required fields (Name, Provider type, Endpoint URL, Model — see the create/update
+ * validators in server/routes/settings.ts) carried no visual or accessible "required" marker
+ * (issue #8854, "Also noticed"), so only the one OPTIONAL field (API key) explained itself. A
+ * plain trailing asterisk mirrors how the rest of this repo's forms already flag required
+ * fields — no new visual language introduced.
+ */
+const RequiredLabel: React.FC<{ label: string }> = ({ label }) => (
+  <>
+    {label}{' '}
+    <EuiTextColor color='danger' component='span' aria-hidden='true'>
+      *
+    </EuiTextColor>
+  </>
+);
 
 const emptyForm: ProviderInput = {
   name: '',
@@ -186,8 +217,10 @@ const emptyForm: ProviderInput = {
   apiKey: '',
 };
 
+// Requires at least one character after the scheme so a bare `https://` (which the server
+// round-trip would reject anyway) is caught here instead of only after a save attempt.
 function isValidEndpointUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value.trim());
+  return /^https?:\/\/.+/i.test(value.trim());
 }
 
 /** Collapses the (potentially multi-service, for openai_compatible) docs links behind a single
@@ -402,6 +435,39 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               <EuiSpacer size='m' />
             </>
           )}
+          {!canSave && (
+            // Issue #8854, point 5: the disabled Save button's own EuiToolTip below carries the
+            // same message, but a tooltip only reaches a mouse user who happens to hover the
+            // greyed-out button — an admin who fills in the whole form and then wonders why Save
+            // won't respond should not have to go looking for it. This callout is the
+            // always-visible copy of that same explanation, inside the form the admin is actually
+            // looking at (the page-level warning in settings-page.tsx sits behind this flyout
+            // once it's open).
+            <>
+              <EuiCallOut
+                color='warning'
+                iconType='alert'
+                title={i18n.translate(
+                  'wazuhAiAssistant.settings.form.accessWarningTitle',
+                  {
+                    defaultMessage: 'You cannot save this provider right now',
+                  },
+                )}
+              >
+                <p>
+                  {accessMessage ??
+                    i18n.translate(
+                      'wazuhAiAssistant.settings.access.warningFallback',
+                      {
+                        defaultMessage:
+                          'Administrator privileges are required to change AI Assistant settings.',
+                      },
+                    )}
+                </p>
+              </EuiCallOut>
+              <EuiSpacer size='m' />
+            </>
+          )}
           {error && (
             <>
               <EuiCallOut
@@ -419,12 +485,17 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
           <EuiForm component='div'>
             <EuiFormRow
               id='wz-ai-provider-name'
-              label={i18n.translate('wazuhAiAssistant.settings.form.name', {
-                defaultMessage: 'Name',
-              })}
+              label={
+                <RequiredLabel
+                  label={i18n.translate('wazuhAiAssistant.settings.form.name', {
+                    defaultMessage: 'Name',
+                  })}
+                />
+              }
             >
               <EuiFieldText
                 value={form.name}
+                aria-required='true'
                 onChange={event =>
                   setForm({ ...form, name: event.target.value })
                 }
@@ -432,9 +503,13 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
             </EuiFormRow>
             <EuiFormRow
               id='wz-ai-provider-type'
-              label={i18n.translate('wazuhAiAssistant.settings.form.type', {
-                defaultMessage: 'Provider type',
-              })}
+              label={
+                <RequiredLabel
+                  label={i18n.translate('wazuhAiAssistant.settings.form.type', {
+                    defaultMessage: 'Provider type',
+                  })}
+                />
+              }
             >
               <EuiSelect
                 options={PROVIDER_TYPES.map(type => ({
@@ -442,6 +517,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                   text: PROVIDER_TYPE_FORM_LABELS[type],
                 }))}
                 value={form.type}
+                aria-required='true'
                 onChange={event =>
                   setForm({
                     ...form,
@@ -452,9 +528,16 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
             </EuiFormRow>
             <EuiFormRow
               id='wz-ai-provider-base-url'
-              label={i18n.translate('wazuhAiAssistant.settings.form.baseUrl', {
-                defaultMessage: 'Endpoint URL',
-              })}
+              label={
+                <RequiredLabel
+                  label={i18n.translate(
+                    'wazuhAiAssistant.settings.form.baseUrl',
+                    {
+                      defaultMessage: 'Endpoint URL',
+                    },
+                  )}
+                />
+              }
               isInvalid={Boolean(baseUrlError)}
               error={baseUrlError}
               helpText={
@@ -485,7 +568,9 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     )}
                     title={i18n.translate(
                       'wazuhAiAssistant.settings.form.baseUrlDocsTitle',
-                      { defaultMessage: 'API documentation' },
+                      {
+                        defaultMessage: 'API documentation',
+                      },
                     )}
                     docs={urlGuidance.docs}
                     note={urlGuidance.note}
@@ -497,6 +582,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                 value={form.baseUrl}
                 placeholder={urlGuidance.placeholder}
                 isInvalid={Boolean(baseUrlError)}
+                aria-required='true'
                 onChange={event => {
                   setForm({ ...form, baseUrl: event.target.value });
                   if (baseUrlError) {
@@ -507,9 +593,16 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
             </EuiFormRow>
             <EuiFormRow
               id='wz-ai-provider-model'
-              label={i18n.translate('wazuhAiAssistant.settings.form.model', {
-                defaultMessage: 'Model',
-              })}
+              label={
+                <RequiredLabel
+                  label={i18n.translate(
+                    'wazuhAiAssistant.settings.form.model',
+                    {
+                      defaultMessage: 'Model',
+                    },
+                  )}
+                />
+              }
               helpText={
                 <>
                   {i18n.translate('wazuhAiAssistant.settings.form.modelHelp', {
@@ -542,11 +635,15 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                   <DocsPopover
                     triggerLabel={i18n.translate(
                       'wazuhAiAssistant.settings.form.modelDocsButton',
-                      { defaultMessage: 'See available models' },
+                      {
+                        defaultMessage: 'See available models',
+                      },
                     )}
                     title={i18n.translate(
                       'wazuhAiAssistant.settings.form.modelDocsTitle',
-                      { defaultMessage: 'Model documentation' },
+                      {
+                        defaultMessage: 'Model documentation',
+                      },
                     )}
                     docs={modelGuidance.docs}
                     note={modelGuidance.note}
@@ -556,6 +653,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
             >
               <EuiFieldText
                 value={form.model}
+                aria-required='true'
                 onChange={event =>
                   setForm({ ...form, model: event.target.value })
                 }
@@ -566,27 +664,50 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               label={i18n.translate('wazuhAiAssistant.settings.form.apiKey', {
                 defaultMessage: 'API key',
               })}
-              helpText={
-                editingProvider
-                  ? i18n.translate(
-                      'wazuhAiAssistant.settings.form.apiKeyHelpEditing',
+              // Issue #8854, point 4: the field itself is always blank on edit (the key is never
+              // sent back to the browser — ProviderSummary redacts it to `hasApiKey`), which used
+              // to read as "the key got deleted." The providers TABLE already shows "Configured"
+              // for this same provider; this badge is that same fact, moved to where an admin who
+              // opened the edit form would actually see it. Neutral (not success/warning) per the
+              // linked Kibana precedent (elastic/kibana#80657) choosing plain text over an alarm
+              // color after design review — this is informational, not a state to react to.
+              labelAppend={
+                editingProvider?.hasApiKey ? (
+                  <EuiBadge color='hollow'>
+                    {i18n.translate(
+                      'wazuhAiAssistant.settings.form.apiKeyStoredBadge',
                       {
-                        defaultMessage:
-                          'Leave empty to keep the current key. Optional for endpoints that ' +
-                          "don't require authentication (e.g. a local Ollama server without " +
-                          'auth) — stored encrypted at rest when an encryption key is ' +
-                          'configured.',
+                        defaultMessage: 'Key stored',
                       },
-                    )
-                  : i18n.translate(
-                      'wazuhAiAssistant.settings.form.apiKeyHelpCreate',
+                    )}
+                  </EuiBadge>
+                ) : undefined
+              }
+              helpText={
+                <>
+                  {editingProvider && (
+                    <p>
+                      {i18n.translate(
+                        'wazuhAiAssistant.settings.form.apiKeyHelpLeaveBlank',
+                        {
+                          defaultMessage:
+                            'Leave empty to keep the current key.',
+                        },
+                      )}
+                    </p>
+                  )}
+                  <p>
+                    {i18n.translate(
+                      'wazuhAiAssistant.settings.form.apiKeyHelpOptional',
                       {
                         defaultMessage:
                           "Optional for endpoints that don't require authentication (e.g. a " +
                           'local Ollama server without auth) — stored encrypted at rest when ' +
                           'an encryption key is configured.',
                       },
-                    )
+                    )}
+                  </p>
+                </>
               }
             >
               <EuiFieldPassword
@@ -597,45 +718,54 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                 }
               />
             </EuiFormRow>
-            <EuiSpacer size='m' />
-            <EuiFlexGroup gutterSize='s'>
-              <EuiFlexItem grow={false}>
-                <EuiToolTip
-                  content={
-                    !canSave
-                      ? accessMessage
-                      : apiKeyBlockedByEncryption
-                      ? i18n.translate(
-                          'wazuhAiAssistant.settings.form.encryptionRequiredTooltip',
-                          {
-                            defaultMessage:
-                              'An encryption key must be configured before an API key can be saved.',
-                          },
-                        )
-                      : undefined
-                  }
-                >
-                  <EuiButton
-                    onClick={handleSave}
-                    isDisabled={!canSave || apiKeyBlockedByEncryption}
-                    fill
-                  >
-                    {i18n.translate('wazuhAiAssistant.settings.form.save', {
-                      defaultMessage: 'Save',
-                    })}
-                  </EuiButton>
-                </EuiToolTip>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty onClick={requestClose}>
-                  {i18n.translate('wazuhAiAssistant.settings.form.cancel', {
-                    defaultMessage: 'Cancel',
-                  })}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            </EuiFlexGroup>
           </EuiForm>
         </EuiFlyoutBody>
+        <EuiFlyoutFooter>
+          {/* Cancel-left/Save-right (issue #8854, "Also noticed": the two were reversed before)
+              plus a dedicated EuiFlyoutFooter — previously Save/Cancel sat inline at the end of
+              the form's own scrolling area, so on a tall form (the encryption callout, five
+              fields, three doc popovers) both could scroll out of view entirely; the footer is
+              pinned outside that scroll region. */}
+          <EuiFlexGroup justifyContent='spaceBetween'>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={requestClose} flush='left'>
+                {i18n.translate('wazuhAiAssistant.settings.form.cancel', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={
+                  !canSave
+                    ? accessMessage
+                    : apiKeyBlockedByEncryption
+                    ? i18n.translate(
+                        'wazuhAiAssistant.settings.form.encryptionRequiredTooltip',
+                        {
+                          defaultMessage:
+                            'An encryption key must be configured before an API key can be saved.',
+                        },
+                      )
+                    : undefined
+                }
+              >
+                <EuiButton
+                  onClick={handleSave}
+                  isDisabled={!canSave || apiKeyBlockedByEncryption}
+                  fill
+                >
+                  {i18n.translate(
+                    'wazuhAiAssistant.settings.form.saveAndTest',
+                    {
+                      defaultMessage: 'Save & test',
+                    },
+                  )}
+                </EuiButton>
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
       </EuiFlyout>
       {showCloseConfirm && (
         <EuiConfirmModal

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-status.test.ts
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-status.test.ts
@@ -5,14 +5,6 @@ import {
   outcomeFromTestResult,
 } from './provider-status';
 
-/**
- * Issue #8854, point 3: "One Failed badge covers four different situations, including one that
- * is not the provider's fault." These tests pin the split this fix introduces: a completed test
- * (`outcomeFromTestResult`) is `ok`/`failed`, while a test that never ran at all
- * (`outcomeFromTestError`, e.g. the admin-gate check itself failing) is the distinct
- * `could-not-verify` status — never rendered as the same red "Failed" badge.
- */
-
 test('outcomeFromTestResult: a successful test maps to ok with the measured latency', () => {
   const outcome = outcomeFromTestResult({ success: true, latencyMs: 237 });
   assert.deepEqual(outcome, { status: 'ok', latencyMs: 237 });

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-status.test.ts
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-status.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import {
+  describeHttpError,
+  outcomeFromTestError,
+  outcomeFromTestResult,
+} from './provider-status';
+
+/**
+ * Issue #8854, point 3: "One Failed badge covers four different situations, including one that
+ * is not the provider's fault." These tests pin the split this fix introduces: a completed test
+ * (`outcomeFromTestResult`) is `ok`/`failed`, while a test that never ran at all
+ * (`outcomeFromTestError`, e.g. the admin-gate check itself failing) is the distinct
+ * `could-not-verify` status — never rendered as the same red "Failed" badge.
+ */
+
+test('outcomeFromTestResult: a successful test maps to ok with the measured latency', () => {
+  const outcome = outcomeFromTestResult({ success: true, latencyMs: 237 });
+  assert.deepEqual(outcome, { status: 'ok', latencyMs: 237 });
+});
+
+test('outcomeFromTestResult: a completed-but-unsuccessful test maps to failed with the server message', () => {
+  const outcome = outcomeFromTestResult({
+    success: false,
+    latencyMs: 15002,
+    message: 'The model gpt-5 does not exist or you do not have access to it.',
+  });
+  assert.deepEqual(outcome, {
+    status: 'failed',
+    message: 'The model gpt-5 does not exist or you do not have access to it.',
+  });
+});
+
+test('outcomeFromTestResult: a failed test with no message falls back to a generic one', () => {
+  const outcome = outcomeFromTestResult({ success: false, latencyMs: 0 });
+  assert.equal(outcome.status, 'failed');
+  assert.equal((outcome as { message: string }).message, 'Connection failed.');
+});
+
+test('outcomeFromTestError: an admin-gate rejection (thrown, never reached the provider) maps to could-not-verify', () => {
+  const adminGateError = {
+    body: {
+      message:
+        'Your Wazuh Manager API session is missing or expired. Open any page of the main ' +
+        'Wazuh app to establish it, then retry saving.',
+    },
+  };
+  const outcome = outcomeFromTestError(adminGateError);
+  assert.equal(outcome.status, 'could-not-verify');
+  assert.equal(
+    (outcome as { message: string }).message,
+    adminGateError.body.message,
+  );
+});
+
+test('outcomeFromTestError: a thrown error is NEVER classified as failed — only ok/failed come from a completed result', () => {
+  const outcome = outcomeFromTestError(new Error('network error'));
+  assert.notEqual(outcome.status, 'failed');
+  assert.equal(outcome.status, 'could-not-verify');
+});
+
+test('outcomeFromTestError: an error with no extractable message falls back to a generic could-not-verify copy', () => {
+  const outcome = outcomeFromTestError('a plain string, not an Error');
+  assert.deepEqual(outcome, {
+    status: 'could-not-verify',
+    message: 'Could not verify the provider status.',
+  });
+});
+
+test('describeHttpError: prefers body.message over error.message', () => {
+  const error = new Error('generic Forbidden');
+  (error as { body?: unknown }).body = { message: 'the real server reason' };
+  assert.equal(describeHttpError(error, 'fallback'), 'the real server reason');
+});
+
+test('describeHttpError: falls back to error.message when body.message is absent', () => {
+  assert.equal(
+    describeHttpError(new Error('plain error message'), 'fallback'),
+    'plain error message',
+  );
+});
+
+test('describeHttpError: falls back to the caller-supplied fallback for a non-Error, non-body value', () => {
+  assert.equal(describeHttpError(null, 'fallback'), 'fallback');
+  assert.equal(describeHttpError(42, 'fallback'), 'fallback');
+});

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-status.ts
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-status.ts
@@ -1,17 +1,5 @@
 import { ProviderTestResult } from '../../../common/types';
 
-/**
- * Client-side status a provider row can be in (issue #8854). Not part of `ProviderSummary` —
- * `handleTest` derives it fresh every time a test runs and keeps it in `settings-page.tsx`'s own
- * React state, so no saved-object schema change is needed.
- *
- *  - `ok` / `failed` come from a completed test: the server's `/providers/{id}/test` route ran
- *    the real provider round-trip and returned a `ProviderTestResult`.
- *  - `could-not-verify` is different in kind, not just in severity: the test route never reached
- *    the provider at all (e.g. the admin-gate check failed, or the request itself errored) — see
- *    `outcomeFromTestError` below. Badging that the same red "Failed" as a real connectivity
- *    failure blames the provider for something that was never actually tested.
- */
 export type ProviderTestOutcome =
   | { status: 'ok'; latencyMs: number }
   | { status: 'failed'; message: string }
@@ -21,10 +9,6 @@ const DEFAULT_FAILURE_MESSAGE = 'Connection failed.';
 const DEFAULT_COULD_NOT_VERIFY_MESSAGE =
   'Could not verify the provider status.';
 
-/**
- * A completed `ProviderTestResult` (the test route ran to completion, HTTP 200) maps 1:1 to
- * `ok`/`failed` — there is no ambiguity to resolve here, unlike `outcomeFromTestError` below.
- */
 export function outcomeFromTestResult(
   result: ProviderTestResult,
 ): ProviderTestOutcome {
@@ -37,18 +21,6 @@ export function outcomeFromTestResult(
   };
 }
 
-/**
- * `service.test()` throwing (rather than resolving with `{success:false}`) means the test route
- * itself never completed — the admin-gate check rejected the request (HTTP 403, e.g. the Wazuh
- * Manager session used to check "is this user an administrator" was missing/expired), or some
- * other transport-level failure happened. Either way, the PROVIDER was never actually contacted,
- * so this is "could not verify", not "failed": the row's own configuration may be perfectly fine.
- *
- * `describeHttpError` extracts the server's own explanation the same way every other mutation on
- * this page already does (`error.body.message` first, then `error.message`, then the fallback) —
- * duplicated here rather than imported from `settings-page.tsx` so this stays a standalone,
- * dependency-free module other call sites can use without pulling in the whole page component.
- */
 export function outcomeFromTestError(error: unknown): ProviderTestOutcome {
   return {
     status: 'could-not-verify',
@@ -56,13 +28,6 @@ export function outcomeFromTestError(error: unknown): ProviderTestOutcome {
   };
 }
 
-/**
- * Extracts a human-readable message from an OSD `http` client rejection. OSD's `HttpFetchError`
- * carries the real server explanation in `error.body.message`, while `error.message` is a generic
- * "Internal Server Error"/"Forbidden" restated from the HTTP status text — preferring `body`
- * first is what surfaces the actual reason (e.g. "Administrator privileges are required...")
- * instead of a useless generic phrase.
- */
 export function describeHttpError(error: unknown, fallback: string): string {
   if (error && typeof error === 'object') {
     const body = (error as { body?: unknown }).body;

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-status.ts
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-status.ts
@@ -1,0 +1,80 @@
+import { ProviderTestResult } from '../../../common/types';
+
+/**
+ * Client-side status a provider row can be in (issue #8854). Not part of `ProviderSummary` —
+ * `handleTest` derives it fresh every time a test runs and keeps it in `settings-page.tsx`'s own
+ * React state, so no saved-object schema change is needed.
+ *
+ *  - `ok` / `failed` come from a completed test: the server's `/providers/{id}/test` route ran
+ *    the real provider round-trip and returned a `ProviderTestResult`.
+ *  - `could-not-verify` is different in kind, not just in severity: the test route never reached
+ *    the provider at all (e.g. the admin-gate check failed, or the request itself errored) — see
+ *    `outcomeFromTestError` below. Badging that the same red "Failed" as a real connectivity
+ *    failure blames the provider for something that was never actually tested.
+ */
+export type ProviderTestOutcome =
+  | { status: 'ok'; latencyMs: number }
+  | { status: 'failed'; message: string }
+  | { status: 'could-not-verify'; message: string };
+
+const DEFAULT_FAILURE_MESSAGE = 'Connection failed.';
+const DEFAULT_COULD_NOT_VERIFY_MESSAGE =
+  'Could not verify the provider status.';
+
+/**
+ * A completed `ProviderTestResult` (the test route ran to completion, HTTP 200) maps 1:1 to
+ * `ok`/`failed` — there is no ambiguity to resolve here, unlike `outcomeFromTestError` below.
+ */
+export function outcomeFromTestResult(
+  result: ProviderTestResult,
+): ProviderTestOutcome {
+  if (result.success) {
+    return { status: 'ok', latencyMs: result.latencyMs };
+  }
+  return {
+    status: 'failed',
+    message: result.message ?? DEFAULT_FAILURE_MESSAGE,
+  };
+}
+
+/**
+ * `service.test()` throwing (rather than resolving with `{success:false}`) means the test route
+ * itself never completed — the admin-gate check rejected the request (HTTP 403, e.g. the Wazuh
+ * Manager session used to check "is this user an administrator" was missing/expired), or some
+ * other transport-level failure happened. Either way, the PROVIDER was never actually contacted,
+ * so this is "could not verify", not "failed": the row's own configuration may be perfectly fine.
+ *
+ * `describeHttpError` extracts the server's own explanation the same way every other mutation on
+ * this page already does (`error.body.message` first, then `error.message`, then the fallback) —
+ * duplicated here rather than imported from `settings-page.tsx` so this stays a standalone,
+ * dependency-free module other call sites can use without pulling in the whole page component.
+ */
+export function outcomeFromTestError(error: unknown): ProviderTestOutcome {
+  return {
+    status: 'could-not-verify',
+    message: describeHttpError(error, DEFAULT_COULD_NOT_VERIFY_MESSAGE),
+  };
+}
+
+/**
+ * Extracts a human-readable message from an OSD `http` client rejection. OSD's `HttpFetchError`
+ * carries the real server explanation in `error.body.message`, while `error.message` is a generic
+ * "Internal Server Error"/"Forbidden" restated from the HTTP status text — preferring `body`
+ * first is what surfaces the actual reason (e.g. "Administrator privileges are required...")
+ * instead of a useless generic phrase.
+ */
+export function describeHttpError(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object') {
+    const body = (error as { body?: unknown }).body;
+    if (body && typeof body === 'object') {
+      const message = (body as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim().length > 0) {
+        return message;
+      }
+    }
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
@@ -77,7 +77,7 @@ describe('SettingsPage — wazuh_brain hidden from provider type dropdown', () =
     fireEvent.click(addButton);
 
     // Wait for the form to be visible (Name field is present)
-    await screen.findByLabelText(/^name$/i);
+    await screen.findByLabelText(/^name/i);
 
     const optionValues = screen
       .getAllByRole('option')

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
@@ -180,9 +180,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   const [deleteTarget, setDeleteTarget] = useState<ProviderSummary | null>(
     null,
   );
-  // Distinguishes "still loading the initial list" from "loaded and genuinely empty" — without
-  // this, the first-run empty state below would flash open for a frame on every page load, before
-  // `providers` gets its first real value.
   const [providersLoaded, setProvidersLoaded] = useState(false);
 
   // Privacy settings: loaded once on mount; edited locally and only written back on an explicit
@@ -465,14 +462,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   // for; the per-provider map stays editable only by ensuring the global
   // Privacy section below never overwrites it (see `handleSavePrivacySettings`'s
   // `privacyDefaultPerProvider: loadedAssistantSettings.privacyDefaultPerProvider` passthrough).
-  // "Save & test" (issue #8854, points 1-3): saving a provider — whether creating it or editing
-  // an already-verified one — used to leave its Status column at "Not tested" until someone
-  // manually pressed the row's Test action. Save itself must still succeed even when the
-  // immediately-following test fails (a local Ollama that isn't running yet, a rate-limited key,
-  // etc. are still valid saved configurations) — `handleTest` below already reports its own
-  // failure into `testResults` rather than throwing, so firing it here (without awaiting or
-  // wrapping it in this function's own try/catch) can never turn a successful save into a
-  // reported error.
   const handleSubmit = async (input: ProviderInput) => {
     setError(null);
     try {
@@ -567,12 +556,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
     }
   };
 
-  // A THROWN error (service.test() rejecting) and a RESOLVED `{success:false}` are different in
-  // kind, not just in outcome — see provider-status.ts's doc comment. Resolving means the test
-  // route ran the real provider round-trip and it failed (`outcomeFromTestResult` -> `failed`);
-  // throwing means the route never got that far at all (most commonly the admin-gate check
-  // itself rejecting the request), so the provider's own configuration was never actually
-  // exercised (`outcomeFromTestError` -> `could-not-verify`).
   const handleTest = async (provider: ProviderSummary) => {
     setTestingIds(current => new Set(current).add(provider.id));
     try {
@@ -724,10 +707,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
             </EuiBadge>
           );
         }
-        // `failed` and `could-not-verify` share this layout (a badge plus the message it
-        // couldn't fit) but never the same badge color/text — attaching the message here, on the
-        // row itself, is what replaces the old page-level callout stack: the reason is right next
-        // to the row it is about instead of in a list the admin has to match back up by name.
         const isCouldNotVerify = result.status === 'could-not-verify';
         return (
           <EuiFlexGroup gutterSize='xs' alignItems='center' responsive={false}>
@@ -916,10 +895,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
               )}
 
               {providersLoaded && providers.length === 0 ? (
-                // First-run state (issue #8854, point 6): mirrors chat-page.tsx's own
-                // "No AI provider configured" EuiEmptyPrompt exactly (same icon, same title, same
-                // CTA copy) so the two surfaces agree instead of this table falling back to
-                // EuiBasicTable's generic "No items found".
                 <EuiEmptyPrompt
                   iconType='machineLearningApp'
                   title={

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
@@ -30,6 +30,7 @@ import {
   EuiHorizontalRule,
   EuiFieldSearch,
   EuiAccordion,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { CoreStart } from '../../../../../src/core/public';
@@ -43,6 +44,12 @@ import { ensureManagerSession } from '../../services/session-heal';
 import { ProviderInput, ProviderSummary } from '../../../common/types';
 import { useDirtyFormState } from '../../hooks/use-dirty-form-state';
 import { ProviderFormFlyout } from './provider-form-flyout';
+import {
+  ProviderTestOutcome,
+  describeHttpError,
+  outcomeFromTestError,
+  outcomeFromTestResult,
+} from './provider-status';
 
 const FIELD_POLICY_ACTIONS: FieldPolicyAction[] = [
   'allow',
@@ -93,30 +100,6 @@ type PrivacyDraft = Pick<
 > & {
   fieldPolicy: Array<FieldPolicyEntry & { _isNew?: true }>;
 };
-
-/**
- * OSD's HttpFetchError puts the server's JSON body on `error.body` (the raw fetch Response is
- * otherwise opaque to callers) — an admin-gated rejection lands here as a bare "Forbidden"
- * `error.message` with no explanation, while the actual reason the server rejected the request is
- * `error.body.message`. Preferring that first (falling back to `error.message`, then to a
- * caller-supplied i18n fallback) is what makes the real server explanation reach the admin instead
- * of a generic callout.
- */
-function describeHttpError(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object') {
-    const body = (error as { body?: unknown }).body;
-    if (body && typeof body === 'object') {
-      const message = (body as { message?: unknown }).message;
-      if (typeof message === 'string' && message.trim().length > 0) {
-        return message;
-      }
-    }
-  }
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  return fallback;
-}
 
 /**
  * Full PUT /settings payload from the last successful load plus the one slice a section's Save
@@ -191,15 +174,16 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<
-    Record<string, { success: boolean; latencyMs: number; message?: string }>
+    Record<string, ProviderTestOutcome>
   >({});
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
-  const [dismissedErrorIds, setDismissedErrorIds] = useState<Set<string>>(
-    new Set(),
-  );
   const [deleteTarget, setDeleteTarget] = useState<ProviderSummary | null>(
     null,
   );
+  // Distinguishes "still loading the initial list" from "loaded and genuinely empty" — without
+  // this, the first-run empty state below would flash open for a frame on every page load, before
+  // `providers` gets its first real value.
+  const [providersLoaded, setProvidersLoaded] = useState(false);
 
   // Privacy settings: loaded once on mount; edited locally and only written back on an explicit
   // "Save privacy settings" click, mirroring the provider form's own edit-then-save pattern
@@ -233,12 +217,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   );
   const [isSavingRetention, setIsSavingRetention] = useState(false);
   const [fieldPolicyFilter, setFieldPolicyFilter] = useState('');
-  const failedProviders = providers.filter(
-    p =>
-      testResults[p.id] &&
-      !testResults[p.id].success &&
-      !dismissedErrorIds.has(p.id),
-  );
   const hasEmptyFieldPolicyRow = fieldPolicyDraft.some(
     entry => entry.field.trim() === '',
   );
@@ -451,7 +429,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
             defaultMessage: 'Could not load providers.',
           }),
         ),
-      );
+      )
+      .finally(() => setProvidersLoaded(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -486,18 +465,35 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   // for; the per-provider map stays editable only by ensuring the global
   // Privacy section below never overwrites it (see `handleSavePrivacySettings`'s
   // `privacyDefaultPerProvider: loadedAssistantSettings.privacyDefaultPerProvider` passthrough).
+  // "Save & test" (issue #8854, points 1-3): saving a provider — whether creating it or editing
+  // an already-verified one — used to leave its Status column at "Not tested" until someone
+  // manually pressed the row's Test action. Save itself must still succeed even when the
+  // immediately-following test fails (a local Ollama that isn't running yet, a rate-limited key,
+  // etc. are still valid saved configurations) — `handleTest` below already reports its own
+  // failure into `testResults` rather than throwing, so firing it here (without awaiting or
+  // wrapping it in this function's own try/catch) can never turn a successful save into a
+  // reported error.
   const handleSubmit = async (input: ProviderInput) => {
     setError(null);
     try {
-      if (editingProvider) {
-        await service.update(editingProvider.id, input);
-        clearTestResult(editingProvider.id);
-      } else {
-        await service.create(input);
-      }
+      const saved = editingProvider
+        ? await service.update(editingProvider.id, input)
+        : await service.create(input);
       setIsFormOpen(false);
       reload();
       onProvidersChanged();
+      handleTest(saved);
+      core.notifications.toasts.addSuccess(
+        editingProvider
+          ? i18n.translate('wazuhAiAssistant.settings.updateSuccess', {
+              defaultMessage: 'Provider "{name}" updated.',
+              values: { name: saved.name },
+            })
+          : i18n.translate('wazuhAiAssistant.settings.createSuccess', {
+              defaultMessage: 'Provider "{name}" added.',
+              values: { name: saved.name },
+            }),
+      );
     } catch (submitError) {
       setError(
         describeHttpError(
@@ -553,6 +549,12 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
       await service.setDefault(provider.id);
       reload();
       onProvidersChanged();
+      core.notifications.toasts.addSuccess(
+        i18n.translate('wazuhAiAssistant.settings.setDefaultSuccess', {
+          defaultMessage: '"{name}" is now the default provider.',
+          values: { name: provider.name },
+        }),
+      );
     } catch (setDefaultError) {
       setError(
         describeHttpError(
@@ -565,24 +567,24 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
     }
   };
 
+  // A THROWN error (service.test() rejecting) and a RESOLVED `{success:false}` are different in
+  // kind, not just in outcome — see provider-status.ts's doc comment. Resolving means the test
+  // route ran the real provider round-trip and it failed (`outcomeFromTestResult` -> `failed`);
+  // throwing means the route never got that far at all (most commonly the admin-gate check
+  // itself rejecting the request), so the provider's own configuration was never actually
+  // exercised (`outcomeFromTestError` -> `could-not-verify`).
   const handleTest = async (provider: ProviderSummary) => {
     setTestingIds(current => new Set(current).add(provider.id));
-    setDismissedErrorIds(current => {
-      const next = new Set(current);
-      next.delete(provider.id);
-      return next;
-    });
     try {
       const result = await service.test(provider.id);
-      setTestResults(current => ({ ...current, [provider.id]: result }));
+      setTestResults(current => ({
+        ...current,
+        [provider.id]: outcomeFromTestResult(result),
+      }));
     } catch (testError) {
       setTestResults(current => ({
         ...current,
-        [provider.id]: {
-          success: false,
-          latencyMs: 0,
-          message: describeHttpError(testError, String(testError)),
-        },
+        [provider.id]: outcomeFromTestError(testError),
       }));
     } finally {
       setTestingIds(current => {
@@ -712,7 +714,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
             </EuiText>
           );
         }
-        if (result.success) {
+        if (result.status === 'ok') {
           return (
             <EuiBadge color='success'>
               {i18n.translate('wazuhAiAssistant.settings.testSuccessBadge', {
@@ -722,12 +724,39 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
             </EuiBadge>
           );
         }
+        // `failed` and `could-not-verify` share this layout (a badge plus the message it
+        // couldn't fit) but never the same badge color/text — attaching the message here, on the
+        // row itself, is what replaces the old page-level callout stack: the reason is right next
+        // to the row it is about instead of in a list the admin has to match back up by name.
+        const isCouldNotVerify = result.status === 'could-not-verify';
         return (
-          <EuiBadge color='danger'>
-            {i18n.translate('wazuhAiAssistant.settings.testFailureBadge', {
-              defaultMessage: 'Failed',
-            })}
-          </EuiBadge>
+          <EuiFlexGroup gutterSize='xs' alignItems='center' responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={isCouldNotVerify ? 'hollow' : 'danger'}>
+                {isCouldNotVerify
+                  ? i18n.translate(
+                      'wazuhAiAssistant.settings.testCouldNotVerifyBadge',
+                      {
+                        defaultMessage: 'Could not verify',
+                      },
+                    )
+                  : i18n.translate(
+                      'wazuhAiAssistant.settings.testFailureBadge',
+                      {
+                        defaultMessage: 'Failed',
+                      },
+                    )}
+              </EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiIconTip
+                type={isCouldNotVerify ? 'questionInCircle' : 'alert'}
+                color={isCouldNotVerify ? 'subdued' : 'danger'}
+                content={result.message}
+                aria-label={result.message}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         );
       },
     },
@@ -886,35 +915,54 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
                 </>
               )}
 
-              <EuiBasicTable items={providers} columns={columns} itemId='id' />
-              {failedProviders.map(p => (
-                <React.Fragment key={p.id}>
-                  <EuiSpacer size='s' />
-                  <EuiCallOut
-                    color='danger'
-                    iconType='alert'
-                    size='s'
-                    title={i18n.translate(
-                      'wazuhAiAssistant.settings.testFailureCallout',
-                      {
-                        defaultMessage: '{name}: {message}',
-                        values: {
-                          name: p.name,
-                          message:
-                            testResults[p.id].message ??
-                            i18n.translate(
-                              'wazuhAiAssistant.settings.testFailureUnknown',
-                              { defaultMessage: 'Connection failed.' },
-                            ),
+              {providersLoaded && providers.length === 0 ? (
+                // First-run state (issue #8854, point 6): mirrors chat-page.tsx's own
+                // "No AI provider configured" EuiEmptyPrompt exactly (same icon, same title, same
+                // CTA copy) so the two surfaces agree instead of this table falling back to
+                // EuiBasicTable's generic "No items found".
+                <EuiEmptyPrompt
+                  iconType='machineLearningApp'
+                  title={
+                    <h2>
+                      {i18n.translate(
+                        'wazuhAiAssistant.settings.providers.emptyTitle',
+                        {
+                          defaultMessage: 'No AI provider configured',
                         },
-                      },
-                    )}
-                    onDismiss={() =>
-                      setDismissedErrorIds(prev => new Set([...prev, p.id]))
-                    }
-                  />
-                </React.Fragment>
-              ))}
+                      )}
+                    </h2>
+                  }
+                  body={
+                    <p>
+                      {i18n.translate(
+                        'wazuhAiAssistant.settings.providers.emptyBody',
+                        {
+                          defaultMessage:
+                            'The AI Assistant needs at least one connected provider ' +
+                            '(OpenAI-compatible or Anthropic) before it can answer questions. ' +
+                            'Add one to get started.',
+                        },
+                      )}
+                    </p>
+                  }
+                  actions={
+                    <EuiButton color='primary' fill onClick={openCreateForm}>
+                      {i18n.translate(
+                        'wazuhAiAssistant.settings.providers.emptyAction',
+                        {
+                          defaultMessage: 'Add a provider',
+                        },
+                      )}
+                    </EuiButton>
+                  }
+                />
+              ) : (
+                <EuiBasicTable
+                  items={providers}
+                  columns={columns}
+                  itemId='id'
+                />
+              )}
             </EuiPanel>
 
             <EuiSpacer size='xl' />
@@ -1085,7 +1133,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
                           <strong>
                             {i18n.translate(
                               'wazuhAiAssistant.settings.privacy.fieldColumnHeader',
-                              { defaultMessage: 'Field' },
+                              {
+                                defaultMessage: 'Field',
+                              },
                             )}
                           </strong>
                         </EuiText>
@@ -1185,7 +1235,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
                     >
                       {i18n.translate(
                         'wazuhAiAssistant.settings.privacy.addField',
-                        { defaultMessage: 'Add field' },
+                        {
+                          defaultMessage: 'Add field',
+                        },
                       )}
                     </EuiButton>
                   </EuiAccordion>
@@ -1201,7 +1253,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
                     >
                       {i18n.translate(
                         'wazuhAiAssistant.settings.privacy.addField',
-                        { defaultMessage: 'Add field' },
+                        {
+                          defaultMessage: 'Add field',
+                        },
                       )}
                     </EuiButton>
                   </>


### PR DESCRIPTION
## Description

The AI provider configuration screen never told the administrator what state a provider was actually in. Testing the flow end to end (Groq, OpenAI-compatible) surfaced several places where the product knew something and didn't say it, or said something misleading:

- Saving a provider never verified it, so a brand-new (or freshly edited) provider sat at "Not tested" until someone manually pressed Test.
- Editing a working provider into a broken one saved silently — no warning, and the Status column reset to "Not tested" instead of re-checking.
- A single red "Failed" badge covered both a genuinely broken provider and a test that never ran at all (e.g. the admin-gate check itself failing) — misattributing blame to a provider that was never actually contacted.
- A stored API key showed as an empty field on edit, with no indication it was still saved.
- The reason a disabled Save button was disabled lived only in a hover tooltip.
- An empty providers table fell back to a generic "No items found" instead of guiding the admin to add one.

Closes #8854

## Proposed Changes

- **"Save & test"**: the flyout's primary action now saves the provider and immediately runs the existing test route against it — the record still saves even if the test fails. Re-triggered on every save, including edits, so an edited provider never sits in a stale, unverified state.
- **New `could-not-verify` status** (`provider-status.ts`), distinct from `failed`: derived from *how* the test call resolved — a completed test (`{success, latencyMs, message}`) maps to `ok`/`failed`, while `service.test()` throwing (the request never completed, most commonly the admin-gate check rejecting it) maps to `could-not-verify`. No schema change: this is pure client-side React state in `settings-page.tsx`.
- **Status column**: renders three states now (`OK (Xms)`, `Failed`, `Could not verify`), each failure/could-not-verify badge carrying its message via an inline `EuiIconTip` on the row itself — replacing the old page-level callout stack keyed by provider name.
- **API key "Key stored" badge**: a neutral `labelAppend` badge next to the API key label when editing a provider that already has one configured; split the help text so "Leave empty to keep the current key" stands on its own sentence.
- **Admin-gate message inside the flyout body**: the same explanation the disabled Save button's tooltip already carried is now also a visible `EuiCallOut` in the form itself.
- **First-run empty state**: the providers table now shows the same `EuiEmptyPrompt` ("No AI provider configured" / "Add a provider") the chat page already uses when no providers exist, instead of EUI's generic empty-table text.
- Smaller items noticed while testing: required-field asterisks + `aria-required` on Name/Provider type/Endpoint URL/Model; a bare `https://` now fails client-side validation instead of only after a round trip; success toasts on create/update/set-default; the flyout got a proper `EuiFlyoutFooter` (previously Save/Cancel could scroll out of view on a tall form) with Cancel/Save in the conventional left/right order.

### Results and Evidence

<details>
<summary>1. Save & test — new provider verifies automatically on save</summary>

<img width="474" height="970" alt="Screenshot 2026-08-10 at 2 27 37 PM" src="https://github.com/user-attachments/assets/fa778de3-91df-42e0-a2c9-cf95e2518e0d" />
<img width="1755" height="918" alt="Screenshot 2026-08-10 at 2 28 08 PM" src="https://github.com/user-attachments/assets/3886a7be-21fa-405d-977e-5c92a712b3fb" />


</details>

<details>
<summary>2. Editing a working provider into a broken one re-tests and shows Failed</summary>

<img width="1760" height="1026" alt="Screenshot 2026-08-10 at 2 30 18 PM" src="https://github.com/user-attachments/assets/4aa45c76-4629-4b2e-ab91-567d7a8128a5" />


</details>

<details>
<summary>3. Distinct "Could not verify" badge (admin-gate/session failure, not a provider failure)</summary>

<img width="1712" height="430" alt="Screenshot 2026-08-10 at 2 40 08 PM" src="https://github.com/user-attachments/assets/0ad4f12f-5121-4ab3-9874-ba735633be3e" />


</details>

<details>
<summary>4. "Key stored" badge on edit, API key field</summary>

<img width="533" height="1002" alt="Screenshot 2026-08-10 at 2 44 39 PM" src="https://github.com/user-attachments/assets/8d17c37e-4b24-4eff-813a-749d3d2d97d7" />


</details>

<details>
<summary>5. Admin-gate reason visible inside the flyout body (not only on hover)</summary>

<img width="561" height="992" alt="Screenshot 2026-08-10 at 2 49 46 PM" src="https://github.com/user-attachments/assets/5ccae217-74ef-41b4-b5cb-20385363858a" />


</details>

<details>
<summary>6. First-run empty state on the providers table</summary>

<img width="1760" height="496" alt="Screenshot 2026-08-10 at 4 10 28 PM" src="https://github.com/user-attachments/assets/9f1640fb-77f7-4630-926d-017e96bf0e1d" />


</details>

<details>
<summary>7. Per-row error message (icon tip) instead of a page-level callout</summary>

<img width="1757" height="280" alt="Screenshot 2026-08-10 at 3 05 51 PM" src="https://github.com/user-attachments/assets/7736cc04-4032-473a-b8b0-1ce1b733c1da" />


</details>

### Artifacts Affected

- `plugins/wazuh-ai-assistant` (`public/components/settings/`): `settings-page.tsx`, `provider-form-flyout.tsx`, new `provider-status.ts`.

### Configuration Changes

None. No saved-object schema change — `ProviderTestOutcome` is client-side React state only.

### Documentation Updates

None required.

### Tests Introduced

- `provider-status.test.ts` (new): unit tests for `outcomeFromTestResult`, `outcomeFromTestError`, and `describeHttpError` — the ok/failed/could-not-verify classification in isolation.
- `settings-page.test.tsx` / `provider-form-flyout.test.tsx`: existing suites updated for the new label/button copy ("Name *", "Save & test"); no coverage removed.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A — none)
- [x] Developer documentation reflects the changes (N/A — none)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...