### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -177,11 +177,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -205,6 +208,17 @@ jobs:
             git commit -m "feat: revert ${{ github.ref_name }} references"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: 'Result: original bump pull request not found'
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: 'Result: no changes to commit'
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Push changes
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')


### PR DESCRIPTION
## Description

Closes #8940

The release orchestration in `wazuh-qa-automation` now distinguishes a repository bump that **failed** from one that **had nothing to do** (see [wazuh-qa-automation#8027](https://github.com/wazuh/wazuh-qa-automation/issues/8027)), so a release is no longer blocked by a repository where the bump was a no-op. Before this change, `.github/workflows/5_bumper_repository.yml` ended with a `failure` conclusion in two harmless situations, and the orchestrator had no way to tell those apart from a real failure:

- On a revert run (`revert: true`), when the original bump pull request doesn't exist because that bump introduced no changes.
- On a bump run, when the bump script produces no changes (nothing to commit).

## Proposed Changes

- `Revert references (Revert)` step: replaced the `exit 1` when the original bump PR is not found with `pr_found=false` / `has_changes=false` outputs and `exit 0`, so the run no longer fails and the rest of the revert logic is skipped for that run.
- Added `pr_found=true` output when the original PR is found, so downstream steps can tell the two skip scenarios apart.
- Added two steps whose names are matched exactly (trimmed, case-insensitive) by the orchestrator to report which no-op scenario happened:
  - `Result: original bump pull request not found`
  - `Result: no changes to commit`
- `Push changes` / `Create pull request` / `Merge pull request` remain skipped in both no-op scenarios (conditions already covered this).
- The bump path already had a `Check for changes` step guarding the commit, so no changes were needed there.

Behavior for a normal bump and a normal revert (where changes exist) is unchanged.

### Results and Evidence

<!-- Manual validation runs are still pending — see "How to Test" below. Attach the four run links here once executed on the 5.0.0 branch. -->

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (CI workflow only, no dashboard artifacts affected).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (GitHub Actions workflow; validated via manual workflow runs, see below).

## How to Test

Trigger the **Repository bumper** workflow (`workflow_dispatch`) on the `5.0.0` branch for each of these four cases and check the run conclusion and each step's conclusion (`gh run view <run-id> --json jobs --jq '.jobs[].steps[] | {name, conclusion}'`):

1. **Revert with no original bump PR** (`revert: true` with a `bump-issue-link` that has no merged bump PR): run ends as **success**, `Result: original bump pull request not found` executes, `Push changes` / `Create pull request` / `Merge pull request` are **skipped**, no branch/PR created.
2. **Bump with no changes** (run the same bump twice; the second is a no-op): run ends as **success**, `Result: no changes to commit` executes, no PR created.
3. **Normal bump**: bump PR is created and merged, neither `Result:` step executes.
4. **Normal revert**: revert PR is created and merged, neither `Result:` step executes.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
