### PR TITLE
Fix duplicate provider names and stale settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
+| [#1512](https://github.com/wazuh/wazuh-dashboard/issues/1512)         | Fixed AI assistant accepting duplicate provider names, and the admin privacy policy and provider list not reaching an open chat until a page reload                                           |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,6 @@
 | [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)   | Fixed Home KPI's visualization persistent filters                                                                                                                                             |
 | [#8766](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8766) | Fixed Server Management Settings crashing or showing a blank page for users without permission to read the manager configuration                                                              |
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                |
-| [#1512](https://github.com/wazuh/wazuh-dashboard/issues/1512)         | Fixed AI assistant accepting duplicate provider names, and the admin privacy policy and provider list not reaching an open chat until a page reload                                           |
 
 ### Removed
 

--- a/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
@@ -2975,11 +2975,28 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
    * long per render, which tipped these over. Explicit headroom instead of a global bump, so a
    * genuinely hung test still fails rather than stalling the gate. */
   const PRIVACY_POLICY_TEST_TIMEOUT_MS = 30_000;
-  // Scoped through jest.setTimeout rather than a per-test third argument, which Prettier expands
-  // into a far noisier shape; the afterEach restores Jest's own default so no later file-level
-  // test inherits the longer budget.
-  beforeEach(() => jest.setTimeout(PRIVACY_POLICY_TEST_TIMEOUT_MS));
-  afterEach(() => jest.setTimeout(5_000));
+  /**
+   * Scoped through jest.setTimeout rather than a per-test third argument, which Prettier expands
+   * into a far noisier shape.
+   *
+   * Jest exposes no public getter for the configured test timeout, so the previous budget is read
+   * off the jasmine global (present under the jasmine2 runner, which is what the platform's Jest
+   * config uses) and restored afterwards. Nothing is hardcoded: if that global is ever absent the
+   * raised budget simply stays in effect, which is harmless because this is the LAST describe in
+   * the file — keep it last, or capture and restore explicitly.
+   */
+  const jasmineGlobal = () =>
+    (globalThis as { jasmine?: { DEFAULT_TIMEOUT_INTERVAL?: number } }).jasmine;
+  let previousTimeout: number | undefined;
+  beforeEach(() => {
+    previousTimeout = jasmineGlobal()?.DEFAULT_TIMEOUT_INTERVAL;
+    jest.setTimeout(PRIVACY_POLICY_TEST_TIMEOUT_MS);
+  });
+  afterEach(() => {
+    if (typeof previousTimeout === 'number') {
+      jest.setTimeout(previousTimeout);
+    }
+  });
 
   const settings = (overrides: Record<string, unknown>) => ({
     privacyDefaultOn: false,
@@ -2989,10 +3006,50 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     ...overrides,
   });
 
+  /** A save announced WITHOUT a payload, so the listener has to fall back to its own GET. */
   const announceSettingsSaved = () =>
     act(() => {
       window.dispatchEvent(new Event(ASSISTANT_SETTINGS_CHANGED_EVENT));
     });
+
+  /** A save announced the way settings-page.tsx really does it: the document the PUT returned
+   * travels as `detail`, so no GET is needed (and a GET could still see the pre-save doc). */
+  const announceSettingsSavedWith = (detail: unknown) =>
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ASSISTANT_SETTINGS_CHANGED_EVENT, { detail }),
+      );
+    });
+
+  /** Drives `document.visibilityState`, which jsdom exposes as a read-only getter, then fires the
+   * event the component listens for. Restored to 'visible' after each case below. */
+  const setDocumentVisibility = (state: 'visible' | 'hidden') => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+  });
+
+  /** A stream that opens and stays open, so a turn reaches `streamChat` and parks there — enough
+   * for the send-path assertions below, which only care about the request body. */
+  const mockOpenStream = () => {
+    const stream = createControllableStream();
+    mockStreamChat.mockImplementation(
+      (_providerId: unknown, _messages: unknown, signal: AbortSignal) =>
+        stream.generate(signal),
+    );
+    return stream;
+  };
 
   it('locks the chip — and overrides the user own toggle — when the admin revokes overrides', async () => {
     mockSettingsService.getAssistantSettings.mockResolvedValue(
@@ -3133,5 +3190,157 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     );
     const chipAfter = await findPrivacyChipWithModifier('on');
     expect(chipAfter.tagName).not.toBe('BUTTON');
+  });
+  it('applies the event payload directly, without re-reading the settings', async () => {
+    // M4 read-after-write: a GET issued microseconds after the PUT can still return the PRE-save
+    // document, which would silently reinstate the policy the admin just changed. The payload the
+    // Settings page attaches is authoritative, so no second GET may happen at all.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toBeEnabled());
+
+    // Deliberately leave the GET returning the STALE document: if the listener re-read, the chip
+    // would stay unlocked and this test would fail.
+    announceSettingsSavedWith(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+
+    await waitFor(() => expect(privacyChip()).toBeDisabled());
+    expect(privacyChip()).toHaveTextContent(/on/i);
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a GET when the event payload is missing or malformed', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toBeEnabled());
+
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    // A shape that must NOT be trusted as a settings document.
+    announceSettingsSavedWith({ nonsense: true });
+
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() => expect(privacyChip()).toBeDisabled());
+  });
+
+  it('refetches when the document becomes visible again', async () => {
+    // H1(b): an admin saving in a DIFFERENT browser reaches no window event here, so an idle chat
+    // left open would keep honouring a stale policy. Coming back to the tab has to correct it.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toBeEnabled());
+
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    setDocumentVisibility('hidden');
+    setDocumentVisibility('visible');
+
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() => expect(privacyChip()).toBeDisabled());
+    expect(privacyChip()).toHaveTextContent(/on/i);
+  });
+
+  it('does not refetch when the document merely becomes hidden', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true }),
+    );
+    renderChatPage();
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1),
+    );
+
+    setDocumentVisibility('hidden');
+
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops listening to visibility changes once unmounted', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true }),
+    );
+    const { unmount } = renderChatPage();
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1),
+    );
+
+    unmount();
+    setDocumentVisibility('hidden');
+    setDocumentVisibility('visible');
+
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads the policy before sending, and sends what the server will enforce', async () => {
+    // H1(a) — the headline gap. A user on a different machine sees no window event at all, so at
+    // the moment it actually matters (pressing Send) the policy is re-read and the request body is
+    // built from THAT, not from a chip that may be minutes stale.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    mockOpenStream();
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toHaveTextContent(/off/i));
+
+    // An admin elsewhere locks privacy ON. Nothing in this browser knows yet.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+
+    await sendMessage('what happened last night?');
+
+    // The privacy payload is the 4th argument of streamChat.
+    expect(mockStreamChat.mock.calls[0][3]).toEqual({ enabled: true, map: [] });
+    // ...and the chip now tells the truth too.
+    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
+    expect(privacyChip()).toBeDisabled();
+  });
+
+  it('still sends when the pre-send policy re-read fails', async () => {
+    // Fail-soft is load-bearing: a failing settings GET must never block the user from sending.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: true }),
+    );
+    mockOpenStream();
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
+
+    mockSettingsService.getAssistantSettings.mockRejectedValue(httpError(503));
+
+    await sendMessage('still works?');
+
+    expect(mockStreamChat).toHaveBeenCalled();
+    // The policy already in state is kept — never silently downgraded to "off", which is the
+    // direction that would leak.
+    expect(mockStreamChat.mock.calls[0][3]).toEqual({ enabled: true, map: [] });
+  });
+
+  it('keeps a user-chosen privacy value through the pre-send re-read', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    mockOpenStream();
+    renderChatPage();
+    await waitFor(() => expect(privacyChip()).toBeEnabled());
+
+    // The user turns privacy on for this conversation; overrides stay allowed server-side.
+    fireEvent.click(privacyChip());
+    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
+
+    await sendMessage('respect my choice');
+
+    expect(mockStreamChat.mock.calls[0][3]).toEqual({ enabled: true, map: [] });
   });
 });

--- a/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
@@ -3104,8 +3104,17 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     );
     announceSettingsSaved();
 
-    const chip = await findPrivacyChipWithModifier('on');
-    expect(chip.tagName).toBe('BUTTON');
+    // The modifier class stays `--on` through this transition (only clickability changes), so a
+    // plain class-selector wait can resolve on the stale, still-`--on` SPAN from before the
+    // refetch — wait for the tag itself to actually flip to BUTTON.
+    const chip = await waitFor(() => {
+      const el = document.querySelector(
+        '[data-test-subj="wzPrivacyChip"].wzPrivacyChip--on',
+      ) as HTMLElement;
+      expect(el).not.toBeNull();
+      expect(el.tagName).toBe('BUTTON');
+      return el;
+    });
     // And it is genuinely interactive again, not just visually enabled.
     fireEvent.click(chip);
     await findPrivacyChipWithModifier('off');
@@ -3199,7 +3208,8 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
       settings({ userCanOverride: true, privacyDefaultOn: false }),
     );
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toBeEnabled());
+    const offChip = await findPrivacyChipWithModifier('off');
+    expect(offChip.tagName).toBe('BUTTON');
 
     // Deliberately leave the GET returning the STALE document: if the listener re-read, the chip
     // would stay unlocked and this test would fail.
@@ -3207,8 +3217,8 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
       settings({ userCanOverride: false, privacyDefaultOn: true }),
     );
 
-    await waitFor(() => expect(privacyChip()).toBeDisabled());
-    expect(privacyChip()).toHaveTextContent(/on/i);
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
     expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
   });
 
@@ -3217,7 +3227,7 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
       settings({ userCanOverride: true, privacyDefaultOn: false }),
     );
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toBeEnabled());
+    await findPrivacyChipWithModifier('off');
 
     mockSettingsService.getAssistantSettings.mockResolvedValue(
       settings({ userCanOverride: false, privacyDefaultOn: true }),
@@ -3228,7 +3238,8 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     await waitFor(() =>
       expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
     );
-    await waitFor(() => expect(privacyChip()).toBeDisabled());
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
   });
 
   it('refetches when the document becomes visible again', async () => {
@@ -3238,7 +3249,7 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
       settings({ userCanOverride: true, privacyDefaultOn: false }),
     );
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toBeEnabled());
+    await findPrivacyChipWithModifier('off');
 
     mockSettingsService.getAssistantSettings.mockResolvedValue(
       settings({ userCanOverride: false, privacyDefaultOn: true }),
@@ -3249,8 +3260,8 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     await waitFor(() =>
       expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
     );
-    await waitFor(() => expect(privacyChip()).toBeDisabled());
-    expect(privacyChip()).toHaveTextContent(/on/i);
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
   });
 
   it('does not refetch when the document merely becomes hidden', async () => {
@@ -3292,7 +3303,7 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     );
     mockOpenStream();
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toHaveTextContent(/off/i));
+    await findPrivacyChipWithModifier('off');
 
     // An admin elsewhere locks privacy ON. Nothing in this browser knows yet.
     mockSettingsService.getAssistantSettings.mockResolvedValue(
@@ -3304,8 +3315,8 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     // The privacy payload is the 4th argument of streamChat.
     expect(mockStreamChat.mock.calls[0][3]).toEqual({ enabled: true, map: [] });
     // ...and the chip now tells the truth too.
-    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
-    expect(privacyChip()).toBeDisabled();
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
   });
 
   it('still sends when the pre-send policy re-read fails', async () => {
@@ -3315,7 +3326,7 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     );
     mockOpenStream();
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
+    await findPrivacyChipWithModifier('on');
 
     mockSettingsService.getAssistantSettings.mockRejectedValue(httpError(503));
 
@@ -3333,11 +3344,11 @@ describe('ChatPage — admin privacy policy applies without a reload', () => {
     );
     mockOpenStream();
     renderChatPage();
-    await waitFor(() => expect(privacyChip()).toBeEnabled());
+    const offChip = await findPrivacyChipWithModifier('off');
 
     // The user turns privacy on for this conversation; overrides stay allowed server-side.
-    fireEvent.click(privacyChip());
-    await waitFor(() => expect(privacyChip()).toHaveTextContent(/on/i));
+    fireEvent.click(offChip);
+    await findPrivacyChipWithModifier('on');
 
     await sendMessage('respect my choice');
 

--- a/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/chat-page.test.tsx
@@ -11,6 +11,7 @@ import {
 import '@testing-library/jest-dom';
 import { createBrowserHistory } from 'history';
 import { ChatPage, CONVERSATIONS_CHANGED_EVENT } from './chat-page';
+import { ASSISTANT_SETTINGS_CHANGED_EVENT } from '../../services/settings-service';
 import {
   ConversationRecord,
   PersistedChatMessage,
@@ -64,6 +65,10 @@ jest.mock('../../services/conversations-service', () => ({
 }));
 
 jest.mock('../../services/settings-service', () => ({
+  // Keeps the module's real constants — notably `ASSISTANT_SETTINGS_CHANGED_EVENT`, which the
+  // component subscribes to and the tests below dispatch. Stubbing them out would make both sides
+  // agree on `undefined` and prove nothing.
+  ...jest.requireActual('../../services/settings-service'),
   SettingsService: jest.fn().mockImplementation(() => ({
     getAssistantSettings: () => mockSettingsService.getAssistantSettings(),
     getSettingsAccess: () => mockSettingsService.getSettingsAccess(),
@@ -2953,5 +2958,180 @@ describe('ChatPage — privacy explainer moved off the pill onto a discrete ⓘ 
     const infoTip = screen.getByLabelText(/about privacy mode/i);
     expect(infoTip).toBeInTheDocument();
     expect(infoTip).not.toBe(chip);
+  });
+});
+
+/**
+ * Admin privacy policy changes have to reach an ALREADY-MOUNTED chat. Both views stay mounted
+ * behind `display: none` (application.tsx), so the mount-only settings load held a stale policy
+ * until a full page reload. The Settings page now dispatches
+ * `ASSISTANT_SETTINGS_CHANGED_EVENT` after every successful save, and the chat also refetches when
+ * it becomes visible again.
+ */
+describe('ChatPage — admin privacy policy applies without a reload', () => {
+  /** Every case here mounts the full ChatPage and then drives two or three settings round-trips
+   * through it. That is comfortably under Jest's 5s default in isolation, but the whole suite runs
+   * `--runInBand` alongside 99 others and the slowest observed full-gate run took roughly twice as
+   * long per render, which tipped these over. Explicit headroom instead of a global bump, so a
+   * genuinely hung test still fails rather than stalling the gate. */
+  const PRIVACY_POLICY_TEST_TIMEOUT_MS = 30_000;
+  // Scoped through jest.setTimeout rather than a per-test third argument, which Prettier expands
+  // into a far noisier shape; the afterEach restores Jest's own default so no later file-level
+  // test inherits the longer budget.
+  beforeEach(() => jest.setTimeout(PRIVACY_POLICY_TEST_TIMEOUT_MS));
+  afterEach(() => jest.setTimeout(5_000));
+
+  const settings = (overrides: Record<string, unknown>) => ({
+    privacyDefaultOn: false,
+    privacyDefaultPerProvider: {},
+    userCanOverride: true,
+    conversationRetentionDays: 0,
+    ...overrides,
+  });
+
+  const announceSettingsSaved = () =>
+    act(() => {
+      window.dispatchEvent(new Event(ASSISTANT_SETTINGS_CHANGED_EVENT));
+    });
+
+  it('locks the chip — and overrides the user own toggle — when the admin revokes overrides', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    const offChip = await findPrivacyChipWithModifier('off');
+    expect(offChip.tagName).toBe('BUTTON');
+
+    // The user makes their own choice, which normally freezes the default resolution.
+    fireEvent.click(offChip);
+    await findPrivacyChipWithModifier('on');
+
+    // The admin now revokes overrides with the global default OFF. The lock has to bind the
+    // CURRENT conversation too, so the user's manual "On" must not survive it.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: false }),
+    );
+    announceSettingsSaved();
+
+    const lockedChip = await findPrivacyChipWithModifier('off');
+    expect(lockedChip.tagName).not.toBe('BUTTON');
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies a newly locked-ON policy to the live conversation', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    await findPrivacyChipWithModifier('off');
+
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    announceSettingsSaved();
+
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
+  });
+
+  it('re-enables the chip when the admin gives overrides back (the unlock case)', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    renderChatPage();
+    const lockedChip = await findPrivacyChipWithModifier('on');
+    expect(lockedChip.tagName).not.toBe('BUTTON');
+
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: true }),
+    );
+    announceSettingsSaved();
+
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).toBe('BUTTON');
+    // And it is genuinely interactive again, not just visually enabled.
+    fireEvent.click(chip);
+    await findPrivacyChipWithModifier('off');
+  });
+
+  it('leaves a user-chosen value alone while overrides stay allowed', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    renderChatPage();
+    const offChip = await findPrivacyChipWithModifier('off');
+
+    fireEvent.click(offChip);
+    await findPrivacyChipWithModifier('on');
+
+    // An unrelated admin save (still allowing overrides) must not undo the user's own choice.
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true, privacyDefaultOn: false }),
+    );
+    announceSettingsSaved();
+
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
+    );
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).toBe('BUTTON');
+  });
+
+  it('refetches when the Chat view becomes visible again, and not on the first render', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true }),
+    );
+    const view = renderChatPage({ isActive: true });
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1),
+    );
+
+    // Switching to Settings and back: only the false -> true transition refetches.
+    view.rerenderWith({ isActive: false });
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
+
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    view.rerenderWith({ isActive: true });
+
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
+    );
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
+  });
+
+  it('stops listening once unmounted', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: true }),
+    );
+    const { unmount } = renderChatPage();
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1),
+    );
+
+    unmount();
+    window.dispatchEvent(new Event(ASSISTANT_SETTINGS_CHANGED_EVENT));
+
+    expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the applied policy when the refetch fails', async () => {
+    mockSettingsService.getAssistantSettings.mockResolvedValue(
+      settings({ userCanOverride: false, privacyDefaultOn: true }),
+    );
+    renderChatPage();
+    const chip = await findPrivacyChipWithModifier('on');
+    expect(chip.tagName).not.toBe('BUTTON');
+
+    mockSettingsService.getAssistantSettings.mockRejectedValue(httpError(503));
+    announceSettingsSaved();
+
+    await waitFor(() =>
+      expect(mockSettingsService.getAssistantSettings).toHaveBeenCalledTimes(2),
+    );
+    const chipAfter = await findPrivacyChipWithModifier('on');
+    expect(chipAfter.tagName).not.toBe('BUTTON');
   });
 });

--- a/plugins/wazuh-ai-assistant/public/components/chat/chat-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/chat-page.tsx
@@ -33,6 +33,7 @@ import {
   ASSISTANT_SETTINGS_CHANGED_EVENT,
   AssistantSettings,
   SettingsService,
+  isAssistantSettingsPayload,
 } from '../../services/settings-service';
 import { ensureManagerSession } from '../../services/session-heal';
 import { confirmInterruption } from '../../services/interrupt-confirm';
@@ -281,6 +282,50 @@ const SCROLL_UNPIN_SLACK_PX = 40;
 export const CONVERSATIONS_CHANGED_EVENT =
   'wazuhAiAssistant:conversationsChanged';
 
+/** Deadline for the pre-send policy refresh in `startTurn`. Short on purpose: its only job is to
+ * catch a policy changed elsewhere, and a user pressing Send must never wait on a slow settings
+ * GET — past this point the turn proceeds with the policy already in state. */
+const PRE_SEND_SETTINGS_TIMEOUT_MS = 1500;
+
+/**
+ * Resolves with `work`'s value, or `null` if it has not settled within `timeoutMs`.
+ *
+ * The timer is ALWAYS cleared, including on the fast path — a bare
+ * `Promise.race([work, new Promise(r => setTimeout(r, ms))])` leaves a live timer behind on every
+ * call, which keeps the event loop busy for the full deadline even though the answer already
+ * arrived. Harmless-looking in production, but it made every send in the test suite hold a 1.5s
+ * timer and turned a 39s suite into a 306s one.
+ */
+async function resolveWithinDeadline<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<null>(resolve => {
+        timer = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** The privacy default a settings document resolves to for one provider: the provider's own
+ * override if the admin set one, otherwise the global default. Shared by the default-resolution
+ * effect and the pre-send refresh so the two can never drift apart — server/routes/chat.ts's
+ * `resolvePrivacyEnabled` applies the same rule authoritatively. */
+function resolvePrivacyDefault(
+  settings: AssistantSettings,
+  providerId: string,
+): boolean {
+  return (
+    settings.privacyDefaultPerProvider[providerId] ?? settings.privacyDefaultOn
+  );
+}
+
 /**
  * Welcome-state example questions, now rendered as EuiCards (not plain badge chips) so the empty
  * state reads as a real product surface: one short title + icon per card, the full question as
@@ -438,6 +483,16 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
     // Set on the user's first manual toggle so the settings-driven default effect below stops
     // recomputing it (e.g. if the top-level provider selector changes later in the same session).
     const privacyTouchedRef = useRef(false);
+    // Guards the settings refetch paths below (window event, tab activation, tab visibility,
+    // pre-send): all of them can resolve after this component has gone away — the header flyout's
+    // ChatPage in particular unmounts every time the flyout closes.
+    const isMountedRef = useRef(true);
+    useEffect(
+      () => () => {
+        isMountedRef.current = false;
+      },
+      [],
+    );
     // Per-turn tool_call/digest bookkeeping for history reconstruction. A ref, not
     // state: consulted only when building the NEXT request's body, never rendered.
     const turnHistoryRef = useRef<AssistantTurnRecord[]>([]);
@@ -950,7 +1005,7 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
     };
 
     /**
-     * (Re)loads the plugin-wide assistant settings and re-applies the resulting privacy policy.
+     * Applies a freshly-obtained settings document to this component's privacy state.
      *
      * The non-obvious part is `privacyTouchedRef`: when the admin has just turned OFF
      * `userCanOverride`, the policy has to bind the CURRENT conversation too, not only the next
@@ -963,23 +1018,63 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
      * the user picked themselves survives an unrelated admin save, and an untouched one is
      * re-resolved by that same effect anyway.
      */
-    const refreshAssistantSettings = () =>
+    const applyAssistantSettings = (next: AssistantSettings) => {
+      // Nothing to apply to an unmounted component; setState would warn and the ref write would
+      // outlive the instance that owned it.
+      if (!isMountedRef.current) {
+        return;
+      }
+      if (!next.userCanOverride) {
+        privacyTouchedRef.current = false;
+      }
+      setAssistantSettings(next);
+    };
+
+    /** (Re)loads the plugin-wide assistant settings and re-applies the resulting privacy policy,
+     * resolving with the document that was applied (or `null` if the load failed).
+     * Fail-soft: a failed GET keeps whatever policy is already applied rather than degrading to a
+     * default, and never rejects — callers may safely ignore the returned promise. */
+    const refreshAssistantSettings = (): Promise<AssistantSettings | null> =>
       settingsService
         .getAssistantSettings()
         .then(next => {
-          if (!next.userCanOverride) {
-            privacyTouchedRef.current = false;
-          }
-          setAssistantSettings(next);
+          applyAssistantSettings(next);
+          return next;
         })
         .catch(() => {
           // Same fail-soft as the initial load below: keep whatever policy is already applied.
+          return null;
         });
+
+    /**
+     * The policy the server itself would resolve for this turn, used to make the chip and the
+     * outgoing request agree with the server at the one moment it matters — send time.
+     *
+     * `settings` is the just-refreshed document, or `null` when the refresh failed. A locked policy
+     * (`userCanOverride === false`) always wins; otherwise an untouched conversation follows the
+     * default and a conversation the user has toggled themselves keeps their choice. Falls back to
+     * the current state whenever there is nothing fresher to go on, so a failed GET can never flip
+     * privacy OFF — the direction that would leak.
+     */
+    const resolveEffectivePrivacy = (
+      settings: AssistantSettings | null,
+    ): boolean => {
+      if (!settings) {
+        return privacyEnabled;
+      }
+      if (!settings.userCanOverride || !privacyTouchedRef.current) {
+        return resolvePrivacyDefault(settings, selectedProviderId);
+      }
+      return privacyEnabled;
+    };
 
     useEffect(() => {
       settingsService
         .getAssistantSettings()
-        .then(setAssistantSettings)
+        // Routed through `applyAssistantSettings` like every later refresh, so the mount path picks
+        // up the same unmounted guard rather than setting state on a component the user has already
+        // navigated away from.
+        .then(applyAssistantSettings)
         .catch(() => {
           // Non-fatal: privacy mode simply stays off (mirrors server/routes/chat.ts's own
           // resolvePrivacyEnabled default when nothing overrides it) and the chip below stays
@@ -1028,21 +1123,32 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
       ) {
         return;
       }
-      const perProviderDefault =
-        assistantSettings.privacyDefaultPerProvider[selectedProviderId];
       setPrivacyEnabled(
-        perProviderDefault ?? assistantSettings.privacyDefaultOn,
+        resolvePrivacyDefault(assistantSettings, selectedProviderId),
       );
     }, [assistantSettings, selectedProviderId]);
 
-    // Admin privacy policy changes have to land in the chat without a page reload: this view stays
-    // MOUNTED behind `display: none` when the Settings tab is showing (application.tsx), so the
-    // mount-only load above would otherwise hold a stale policy forever. Event-driven (the Settings
-    // page dispatches ASSISTANT_SETTINGS_CHANGED_EVENT after every successful save) plus one
-    // refetch when this view becomes visible again, which also covers a save made in another tab.
-    // Deliberately no polling/interval — there is nothing to poll for between those two triggers.
+    /**
+     * Admin privacy policy changes have to land in the chat without a page reload: this view stays
+     * MOUNTED behind `display: none` when the Settings tab is showing (application.tsx), so the
+     * mount-only load above would otherwise hold a stale policy forever.
+     *
+     * Same-document saves arrive on ASSISTANT_SETTINGS_CHANGED_EVENT and carry the saved document
+     * as `detail`, which is applied DIRECTLY — a re-GET issued this soon after the write can still
+     * return the pre-save document and silently reinstate the old policy. A dispatch without a
+     * usable payload falls back to the GET.
+     *
+     * This event cannot cross a browser or a machine, so it is only one of three triggers; see the
+     * visibility effect below and the pre-send refresh in `handleSend` for the cases it misses.
+     * Deliberately no polling/interval anywhere.
+     */
     useEffect(() => {
-      const onSettingsChanged = () => {
+      const onSettingsChanged = (event: Event) => {
+        const payload = (event as CustomEvent<unknown>).detail;
+        if (isAssistantSettingsPayload(payload)) {
+          applyAssistantSettings(payload);
+          return;
+        }
         void refreshAssistantSettings();
       };
       window.addEventListener(
@@ -1057,8 +1163,10 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Skips its own first run: the mount effect above already issued that exact GET, and this only
-    // has to cover a LATER false -> true transition (a Settings -> Chat tab switch).
+    // Cheap freshness on a Settings -> Chat tab switch. Skips its own first run: the mount effect
+    // above already issued that exact GET, so this only has to cover a LATER false -> true
+    // transition. This is an IN-APP tab toggle only — it says nothing about saves made elsewhere,
+    // which the visibility effect and the pre-send refresh below are what actually cover.
     const assistantSettingsActiveSyncedRef = useRef(false);
     useEffect(() => {
       if (!assistantSettingsActiveSyncedRef.current) {
@@ -1070,6 +1178,22 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isActive]);
+
+    // A policy saved by an admin in a DIFFERENT browser or on a different machine reaches no window
+    // event here, so an idle chat left open would keep showing (and honouring) a stale chip
+    // indefinitely. Refetching when the document becomes visible again corrects it the moment the
+    // user comes back to the tab — still event-driven, no timer.
+    useEffect(() => {
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          void refreshAssistantSettings();
+        }
+      };
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      return () =>
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleTogglePrivacy = () => {
       if (!assistantSettings?.userCanOverride) {
@@ -2105,9 +2229,9 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
     // conversation that has never enabled privacy mode and never minted a pseudonym. The route
     // treats an absent key and a disabled one identically, so sending nothing keeps the request
     // body minimal for the common case.
-    const privacyPayload =
-      privacyEnabled || pseudonymMap.length > 0
-        ? { enabled: privacyEnabled, map: pseudonymMap }
+    const buildPrivacyPayload = (enabled: boolean): ChatRequest['privacy'] =>
+      enabled || pseudonymMap.length > 0
+        ? { enabled, map: pseudonymMap }
         : undefined;
 
     /**
@@ -2121,6 +2245,21 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
       // expired) so this turn's Manager-path tool calls see a fresh token. The 60s memo makes it free
       // during rapid back-and-forth; `detectManagerAuthError` below stays the mid-turn backstop.
       await ensureManagerSession(core.http, { maxAgeMs: 60_000 });
+
+      // Pre-send policy refresh — the one trigger that does not depend on this browser having seen
+      // the admin's save. Neither the window event nor the visibility/tab refreshes can cross a
+      // browser or a machine, so without this a user on another workstation could hold a chip
+      // reading "Off"/"On" that disagrees with the policy the server will actually enforce, and
+      // (worse) believe unmasked data was masked. Bounded and fail-soft: a slow or failing GET must
+      // never be able to block sending, so it is raced against a short deadline and a `null` result
+      // simply keeps the current state. The server re-resolves the policy authoritatively either
+      // way (server/routes/chat.ts) — this is what keeps the UI honest about it.
+      const freshSettings = await resolveWithinDeadline(
+        refreshAssistantSettings(),
+        PRE_SEND_SETTINGS_TIMEOUT_MS,
+      );
+      const effectivePrivacyEnabled = resolveEffectivePrivacy(freshSettings);
+      const privacyPayload = buildPrivacyPayload(effectivePrivacyEnabled);
 
       const assistantMessageId = nextMessageId();
       const assistantMessage: UiChatMessage = {

--- a/plugins/wazuh-ai-assistant/public/components/chat/chat-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/chat-page.tsx
@@ -30,6 +30,7 @@ import { i18n } from '@osd/i18n';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
 import { ChatService } from '../../services/chat-service';
 import {
+  ASSISTANT_SETTINGS_CHANGED_EVENT,
   AssistantSettings,
   SettingsService,
 } from '../../services/settings-service';
@@ -948,6 +949,33 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
       setRailDisplayMode('expanded');
     };
 
+    /**
+     * (Re)loads the plugin-wide assistant settings and re-applies the resulting privacy policy.
+     *
+     * The non-obvious part is `privacyTouchedRef`: when the admin has just turned OFF
+     * `userCanOverride`, the policy has to bind the CURRENT conversation too, not only the next
+     * one — a lock a user's earlier manual toggle could sit above would not be a lock at all. So
+     * the "user already chose" flag is cleared, which re-arms the default-resolution effect below;
+     * that effect then recomputes `privacyEnabled` from the per-provider default (falling back to
+     * `privacyDefaultOn`) as soon as this new settings object lands.
+     *
+     * When `userCanOverride` is (still, or newly) true the flag is left exactly as it is: a value
+     * the user picked themselves survives an unrelated admin save, and an untouched one is
+     * re-resolved by that same effect anyway.
+     */
+    const refreshAssistantSettings = () =>
+      settingsService
+        .getAssistantSettings()
+        .then(next => {
+          if (!next.userCanOverride) {
+            privacyTouchedRef.current = false;
+          }
+          setAssistantSettings(next);
+        })
+        .catch(() => {
+          // Same fail-soft as the initial load below: keep whatever policy is already applied.
+        });
+
     useEffect(() => {
       settingsService
         .getAssistantSettings()
@@ -1006,6 +1034,42 @@ export const ChatPage = React.forwardRef<ChatPageHandle, ChatPageProps>(
         perProviderDefault ?? assistantSettings.privacyDefaultOn,
       );
     }, [assistantSettings, selectedProviderId]);
+
+    // Admin privacy policy changes have to land in the chat without a page reload: this view stays
+    // MOUNTED behind `display: none` when the Settings tab is showing (application.tsx), so the
+    // mount-only load above would otherwise hold a stale policy forever. Event-driven (the Settings
+    // page dispatches ASSISTANT_SETTINGS_CHANGED_EVENT after every successful save) plus one
+    // refetch when this view becomes visible again, which also covers a save made in another tab.
+    // Deliberately no polling/interval — there is nothing to poll for between those two triggers.
+    useEffect(() => {
+      const onSettingsChanged = () => {
+        void refreshAssistantSettings();
+      };
+      window.addEventListener(
+        ASSISTANT_SETTINGS_CHANGED_EVENT,
+        onSettingsChanged,
+      );
+      return () =>
+        window.removeEventListener(
+          ASSISTANT_SETTINGS_CHANGED_EVENT,
+          onSettingsChanged,
+        );
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Skips its own first run: the mount effect above already issued that exact GET, and this only
+    // has to cover a LATER false -> true transition (a Settings -> Chat tab switch).
+    const assistantSettingsActiveSyncedRef = useRef(false);
+    useEffect(() => {
+      if (!assistantSettingsActiveSyncedRef.current) {
+        assistantSettingsActiveSyncedRef.current = true;
+        return;
+      }
+      if (isActive) {
+        void refreshAssistantSettings();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isActive]);
 
     const handleTogglePrivacy = () => {
       if (!assistantSettings?.userCanOverride) {

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -1240,3 +1240,166 @@ describe('ProviderFormFlyout — one tight column (audit §5)', () => {
     );
   });
 });
+
+describe('ProviderFormFlyout — duplicate provider names', () => {
+  const existingProviders: ProviderSummary[] = [
+    editingProvider,
+    {
+      id: 'p2',
+      name: 'Claude staging',
+      type: 'anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-opus-4-8',
+      hasApiKey: true,
+      isDefault: true,
+    },
+  ];
+
+  /** Fills the three required fields with a valid endpoint and model, so the ONLY thing that can
+   * block Save in these cases is the name check under test. */
+  const fillValidForm = (name: string) => {
+    fireEvent.change(screen.getByLabelText(/^name/i), {
+      target: { value: name },
+    });
+    fireEvent.change(screen.getByLabelText(/endpoint url/i), {
+      target: { value: 'https://api.openai.com/v1' },
+    });
+    const modelField = screen.getByLabelText(/^model/i);
+    fireEvent.change(modelField, { target: { value: 'gpt-4o' } });
+    fireEvent.keyDown(modelField, { key: 'Enter', code: 'Enter' });
+  };
+
+  it('blocks submit and shows an inline error for a name another provider already uses', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fillValidForm('Claude staging');
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    expect(await screen.findByText(/already exists/i)).toBeInTheDocument();
+    expect(baseProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('matches the taken name regardless of casing and surrounding whitespace', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fillValidForm('  claude STAGING  ');
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    expect(await screen.findByText(/already exists/i)).toBeInTheDocument();
+    expect(baseProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('clears the duplicate-name error as soon as the name is edited', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fillValidForm('Claude staging');
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+    expect(await screen.findByText(/already exists/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^name/i), {
+      target: { value: 'Claude staging 2' },
+    });
+
+    expect(screen.queryByText(/already exists/i)).toBeNull();
+  });
+
+  it('accepts a name no other provider uses', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fillValidForm('Gemini lab');
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    await waitFor(() => {
+      expect(baseProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Gemini lab' }),
+      );
+    });
+  });
+
+  it('lets an edited provider keep its OWN name — no self-collision', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        editingProvider={editingProvider}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    await waitFor(() => {
+      expect(baseProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'My OpenAI' }),
+      );
+    });
+    expect(screen.queryByText(/already exists/i)).toBeNull();
+  });
+
+  it('still blocks an edited provider renamed onto ANOTHER provider name', async () => {
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        editingProvider={editingProvider}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/^name/i), {
+      target: { value: 'Claude staging' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    expect(await screen.findByText(/already exists/i)).toBeInTheDocument();
+    expect(baseProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('performs no duplicate check when no provider list is supplied', async () => {
+    // Absent `existingProviders` must behave exactly as before the prop existed.
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    fillValidForm('Claude staging');
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    await waitFor(() => {
+      expect(baseProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Claude staging' }),
+      );
+    });
+  });
+
+  it('surfaces a server-side 409 through the existing error callout', () => {
+    // A race (another admin created the same name while this flyout was open) comes back as the
+    // 409 message on the `error` prop; the flyout must show it, not swallow it.
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+        error='A provider named "Claude staging" already exists.'
+      />,
+    );
+
+    expect(
+      screen.getByText('A provider named "Claude staging" already exists.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -1387,6 +1387,31 @@ describe('ProviderFormFlyout — duplicate provider names', () => {
     });
   });
 
+  it('surfaces a duplicate name AND a bad URL on the same click', async () => {
+    // L10: validating sequentially made a form with both problems take two clicks to reveal two
+    // errors, which reads as though fixing the first broke something new.
+    render(
+      <ProviderFormFlyout
+        {...baseProps}
+        existingProviders={existingProviders}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/^name/i), {
+      target: { value: 'Claude staging' },
+    });
+    fireEvent.change(screen.getByLabelText(/endpoint url/i), {
+      target: { value: 'not-a-url' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+    expect(await screen.findByText(/already exists/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/valid URL starting with http/i),
+    ).toBeInTheDocument();
+    expect(baseProps.onSubmit).not.toHaveBeenCalled();
+  });
+
   it('surfaces a server-side 409 through the existing error callout', () => {
     // A race (another admin created the same name while this flyout was open) comes back as the
     // 409 message on the `error` prop; the flyout must show it, not swallow it.

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -580,9 +580,16 @@ interface ProviderFormFlyoutProps {
   editingProvider: ProviderSummary | null;
   error: string | null;
   /** Every provider already configured, so this form can refuse a name that is already taken
-   * before the round-trip (the server enforces the same rule with a 409 — see
-   * `rejectDuplicateProviderName` in server/routes/settings.ts — which still covers the race of a
-   * second admin creating the same name while this flyout is open).
+   * before the round-trip. The server enforces the same rule with a 409
+   * (`rejectDuplicateProviderName` in server/routes/settings.ts), which is what covers a STALE
+   * list here — a provider created by someone else since this page last loaded.
+   *
+   * What neither check closes is a true concurrent-create TOCTOU: the server does a read and then
+   * a separate write, and the indexer endpoint behind providers has no unique constraint on `name`,
+   * so two admins submitting the same name in the same instant can both succeed. That residual race
+   * is ACCEPTED — the window is milliseconds and the worst outcome is two same-named providers,
+   * which an admin fixes by renaming one. Closing it properly needs a storage-level constraint that
+   * does not exist.
    *
    * Optional/absent means "no list available", which behaves exactly as before this prop existed:
    * no client-side duplicate check at all. */
@@ -754,6 +761,10 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
       apiKey: form.apiKey?.trim() ?? '',
     };
 
+    // Both field checks are evaluated BEFORE either returns, so one click surfaces everything that
+    // is wrong. Validating sequentially made a form with a duplicate name and a bad URL take two
+    // clicks to reveal two problems, which reads like the first fix broke something new.
+    //
     // Duplicate name check, mirroring the server's own 409 (`rejectDuplicateProviderName`): same
     // trim + lowercase comparison, and the provider being edited is excluded so re-saving it
     // unchanged is never a collision with itself.
@@ -763,27 +774,25 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
         provider.id !== editingProvider?.id &&
         provider.name.trim().toLowerCase() === normalizedName,
     );
-    if (nameTaken) {
-      setNameError(
-        i18n.translate('wazuhAiAssistant.settings.form.nameDuplicate', {
+    const nextNameError = nameTaken
+      ? i18n.translate('wazuhAiAssistant.settings.form.nameDuplicate', {
           defaultMessage:
             'A provider named "{name}" already exists. Pick a different name.',
           values: { name: trimmedForm.name },
-        }),
-      );
-      return;
-    }
-    setNameError(null);
-
-    if (!isValidEndpointUrl(trimmedForm.baseUrl)) {
-      setBaseUrlError(
-        i18n.translate('wazuhAiAssistant.settings.form.baseUrlInvalid', {
+        })
+      : null;
+    const nextBaseUrlError = isValidEndpointUrl(trimmedForm.baseUrl)
+      ? null
+      : i18n.translate('wazuhAiAssistant.settings.form.baseUrlInvalid', {
           defaultMessage: 'Enter a valid URL starting with http:// or https://',
-        }),
-      );
+        });
+
+    setNameError(nextNameError);
+    setBaseUrlError(nextBaseUrlError);
+    if (nextNameError || nextBaseUrlError) {
       return;
     }
-    setBaseUrlError(null);
+
     await onSubmit(trimmedForm);
   };
 

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -579,6 +579,14 @@ const DocsPopover: React.FC<{
 interface ProviderFormFlyoutProps {
   editingProvider: ProviderSummary | null;
   error: string | null;
+  /** Every provider already configured, so this form can refuse a name that is already taken
+   * before the round-trip (the server enforces the same rule with a 409 — see
+   * `rejectDuplicateProviderName` in server/routes/settings.ts — which still covers the race of a
+   * second admin creating the same name while this flyout is open).
+   *
+   * Optional/absent means "no list available", which behaves exactly as before this prop existed:
+   * no client-side duplicate check at all. */
+  existingProviders?: ProviderSummary[];
   apiKeyEncryptionEnabled: boolean | null;
   /** True while a save (+ the connection test it triggers) is in flight. Optional/absent behaves
    * exactly as before this prop existed: the Save button is never shown as loading. */
@@ -594,6 +602,7 @@ interface ProviderFormFlyoutProps {
 export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
   editingProvider,
   error,
+  existingProviders = [],
   apiKeyEncryptionEnabled,
   isSaving = false,
   testOutcome = null,
@@ -616,6 +625,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
       : emptyForm,
   );
   const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   // Tracks whether the admin has typed into the endpoint URL field themselves (see the field's own
   // `onChange` below), so a provider-type switch (`handleTypeChange` above) only ever resets the
@@ -743,6 +753,27 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
       model: form.model.trim(),
       apiKey: form.apiKey?.trim() ?? '',
     };
+
+    // Duplicate name check, mirroring the server's own 409 (`rejectDuplicateProviderName`): same
+    // trim + lowercase comparison, and the provider being edited is excluded so re-saving it
+    // unchanged is never a collision with itself.
+    const normalizedName = trimmedForm.name.toLowerCase();
+    const nameTaken = existingProviders.some(
+      provider =>
+        provider.id !== editingProvider?.id &&
+        provider.name.trim().toLowerCase() === normalizedName,
+    );
+    if (nameTaken) {
+      setNameError(
+        i18n.translate('wazuhAiAssistant.settings.form.nameDuplicate', {
+          defaultMessage:
+            'A provider named "{name}" already exists. Pick a different name.',
+          values: { name: trimmedForm.name },
+        }),
+      );
+      return;
+    }
+    setNameError(null);
 
     if (!isValidEndpointUrl(trimmedForm.baseUrl)) {
       setBaseUrlError(
@@ -988,13 +1019,21 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                         )}
                       />
                     }
+                    isInvalid={Boolean(nameError)}
+                    error={nameError}
                   >
                     <EuiFieldText
                       value={form.name}
                       aria-required='true'
-                      onChange={event =>
-                        setForm({ ...form, name: event.target.value })
-                      }
+                      isInvalid={Boolean(nameError)}
+                      onChange={event => {
+                        setForm({ ...form, name: event.target.value });
+                        // Clear the duplicate-name error as soon as the admin starts fixing it,
+                        // same as `fillBaseUrl` does for `baseUrlError`.
+                        if (nameError) {
+                          setNameError(null);
+                        }
+                      }}
                     />
                   </EuiFormRow>
                 </EuiFlexItem>

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
@@ -1603,4 +1603,155 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
       heard.stop();
     }
   });
+  it('dispatches the settings event with the SAVED document as its payload', async () => {
+    // M4: listeners must be able to skip their own GET, which can still return the pre-save
+    // document. The dispatch therefore has to carry what the PUT returned, not just a bare Event.
+    mockService.list.mockResolvedValue([PROVIDER]);
+    const saved = {
+      privacyDefaultOn: true,
+      privacyDefaultPerProvider: {},
+      userCanOverride: false,
+      fieldPolicy: [],
+      conversationRetentionDays: 0,
+    };
+    mockService.updateAssistantSettings.mockResolvedValue(saved);
+    const payloads: unknown[] = [];
+    const handler = (event: Event) => {
+      payloads.push((event as CustomEvent<unknown>).detail);
+    };
+    window.addEventListener(ASSISTANT_SETTINGS_CHANGED_EVENT, handler);
+
+    try {
+      render(
+        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+      );
+      fireEvent.click(
+        await screen.findByText(/allow users to override privacy mode/i),
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: /save privacy settings/i }),
+      );
+
+      await waitFor(() => expect(payloads).toHaveLength(1));
+      expect(payloads[0]).toEqual(saved);
+    } finally {
+      window.removeEventListener(ASSISTANT_SETTINGS_CHANGED_EVENT, handler);
+    }
+  });
+
+  it('dispatches the settings event after a conversation-history save too', async () => {
+    // L12: the retention section writes the same settings document, so it must announce it as well
+    // — otherwise a retention save would leave every mounted chat holding a stale document.
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.updateAssistantSettings.mockResolvedValue({
+      privacyDefaultOn: false,
+      privacyDefaultPerProvider: {},
+      userCanOverride: true,
+      fieldPolicy: [],
+      conversationRetentionDays: 30,
+    });
+    const heard = listenFor(ASSISTANT_SETTINGS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+      );
+      // Queried by role, not by label: this jest environment stubs EUI's htmlIdGenerator so every
+      // generated id is the literal "generated-id", which makes the field's own <label for=...>
+      // resolve to whichever element carries that id first (a button). The retention days field is
+      // the page's only number input, so `spinbutton` identifies it unambiguously.
+      const days = await screen.findByRole('spinbutton');
+      fireEvent.change(days, { target: { value: '30' } });
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /save conversation history settings/i,
+        }),
+      );
+
+      await waitFor(() =>
+        expect(mockService.updateAssistantSettings).toHaveBeenCalled(),
+      );
+      await waitFor(() => expect(heard.count()).toBe(1));
+    } finally {
+      heard.stop();
+    }
+  });
+
+  it('dispatches PROVIDERS_CHANGED_EVENT when a provider is created', async () => {
+    mockService.list.mockResolvedValue([]);
+    mockService.create.mockResolvedValue({ ...PROVIDER, name: 'Gemini lab' });
+    const heard = listenFor(PROVIDERS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPage
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+          autoOpenCreateForm={true}
+        />,
+      );
+      fireEvent.change(await screen.findByLabelText(/^name/i), {
+        target: { value: 'Gemini lab' },
+      });
+      fireEvent.change(screen.getByLabelText(/endpoint url/i), {
+        target: { value: 'https://api.openai.com/v1' },
+      });
+      const modelField = screen.getByLabelText(/^model/i);
+      fireEvent.change(modelField, { target: { value: 'gpt-4o' } });
+      fireEvent.keyDown(modelField, { key: 'Enter', code: 'Enter' });
+      fireEvent.click(screen.getByRole('button', { name: /save & test/i }));
+
+      await waitFor(() => expect(mockService.create).toHaveBeenCalled());
+      await waitFor(() => expect(heard.count()).toBe(1));
+    } finally {
+      heard.stop();
+    }
+  });
+
+  it('dispatches PROVIDERS_CHANGED_EVENT when a provider is deleted', async () => {
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.remove.mockResolvedValue(undefined);
+    const heard = listenFor(PROVIDERS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+      );
+      // Delete lives behind the row's actions popover.
+      fireEvent.click(
+        await screen.findByRole('button', { name: /actions for my openai/i }),
+      );
+      fireEvent.click(await screen.findByText(/^delete$/i));
+      fireEvent.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() =>
+        expect(mockService.remove).toHaveBeenCalledWith('p1'),
+      );
+      await waitFor(() => expect(heard.count()).toBe(1));
+    } finally {
+      heard.stop();
+    }
+  });
+
+  it('does not announce a provider change when the delete fails', async () => {
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.remove.mockRejectedValue(new Error('403'));
+    const heard = listenFor(PROVIDERS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+      );
+      fireEvent.click(
+        await screen.findByRole('button', { name: /actions for my openai/i }),
+      );
+      fireEvent.click(await screen.findByText(/^delete$/i));
+      fireEvent.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => expect(mockService.remove).toHaveBeenCalled());
+      expect(heard.count()).toBe(0);
+    } finally {
+      heard.stop();
+    }
+  });
 });

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
@@ -46,10 +46,18 @@ const mockService = {
 };
 
 jest.mock('../../services/settings-service', () => ({
+  // Keeps the module's real constants — `ASSISTANT_SETTINGS_CHANGED_EVENT` and
+  // `PROVIDERS_CHANGED_EVENT`, which this page dispatches and the tests below listen for. Stubbing
+  // them out would make both sides agree on `undefined` and prove nothing.
+  ...jest.requireActual('../../services/settings-service'),
   SettingsService: jest.fn(() => mockService),
 }));
 
 import { SettingsPage } from './settings-page';
+import {
+  ASSISTANT_SETTINGS_CHANGED_EVENT,
+  PROVIDERS_CHANGED_EVENT,
+} from '../../services/settings-service';
 import { CoreStart } from '../../../../../src/core/public';
 
 const coreMock = { http: {} } as unknown as CoreStart;
@@ -1455,5 +1463,144 @@ describe('SettingsPage — in-card layout and hierarchy (audit §4)', () => {
     expect(resultTableScss).toMatch(
       /\.wzResultsCard \.euiTableHeaderCell \{\s*@include wzMicroLabel/,
     );
+  });
+});
+
+/**
+ * Cross-view propagation (wazuh-dashboard#1512). Chat and Settings both stay mounted behind
+ * `display: none` (application.tsx), and the header flyout holds a SECOND, independent ChatPage and
+ * `useProviders` instance — so neither a saved privacy policy nor a provider CRUD action used to
+ * reach them until a reload. Both are announced with a window event now; these cases prove the
+ * dispatch side.
+ */
+describe('SettingsPage — announcing saved changes to the mounted chat', () => {
+  const coreWithToasts = {
+    http: {},
+    notifications: {
+      toasts: { addSuccess: jest.fn(), addDanger: jest.fn() },
+    },
+  } as unknown as CoreStart;
+
+  /** Records every dispatch of `eventName` for the duration of one test. */
+  function listenFor(eventName: string): {
+    count: () => number;
+    stop: () => void;
+  } {
+    let seen = 0;
+    const handler = () => {
+      seen += 1;
+    };
+    window.addEventListener(eventName, handler);
+    return {
+      count: () => seen,
+      stop: () => window.removeEventListener(eventName, handler),
+    };
+  }
+
+  const PROVIDER = {
+    id: 'p1',
+    name: 'My OpenAI',
+    type: 'openai_compatible',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    isDefault: false,
+  };
+
+  it('dispatches ASSISTANT_SETTINGS_CHANGED_EVENT after a successful privacy save', async () => {
+    // With no providers the page renders the "No AI provider configured" empty prompt instead of
+    // the Privacy section, so every privacy case here needs at least one provider loaded.
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.updateAssistantSettings.mockResolvedValue({
+      privacyDefaultOn: true,
+      privacyDefaultPerProvider: {},
+      userCanOverride: false,
+      fieldPolicy: [],
+      conversationRetentionDays: 0,
+    });
+    const heard = listenFor(ASSISTANT_SETTINGS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+        />,
+      );
+
+      // The Save button is disabled until the section is dirty, so change something first.
+      // The switch is reached through its label text, not by role+name: this jest environment
+      // stubs EUI's htmlIdGenerator so EVERY generated id is the literal string "generated-id",
+      // which makes the switch's own `aria-labelledby` resolve to the wrong node and leaves it
+      // with no accessible name. EUI puts a click handler on the label <span> precisely so it
+      // behaves like a real <label>, so clicking the text toggles the switch.
+      fireEvent.click(
+        await screen.findByText(/allow users to override privacy mode/i),
+      );
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(mockService.updateAssistantSettings).toHaveBeenCalled(),
+      );
+      await waitFor(() => expect(heard.count()).toBe(1));
+    } finally {
+      heard.stop();
+    }
+  });
+
+  it('does not announce anything when the privacy save fails', async () => {
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.updateAssistantSettings.mockRejectedValue(new Error('boom'));
+    const heard = listenFor(ASSISTANT_SETTINGS_CHANGED_EVENT);
+
+    try {
+      render(
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+        />,
+      );
+
+      fireEvent.click(
+        await screen.findByText(/allow users to override privacy mode/i),
+      );
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(mockService.updateAssistantSettings).toHaveBeenCalled(),
+      );
+      expect(heard.count()).toBe(0);
+    } finally {
+      heard.stop();
+    }
+  });
+
+  it('dispatches PROVIDERS_CHANGED_EVENT when a provider becomes the default', async () => {
+    mockService.list.mockResolvedValue([PROVIDER]);
+    mockService.setDefault.mockResolvedValue({ ...PROVIDER, isDefault: true });
+    const heard = listenFor(PROVIDERS_CHANGED_EVENT);
+    const onProvidersChanged = jest.fn();
+
+    try {
+      render(
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={onProvidersChanged}
+        />,
+      );
+      await waitFor(() => expect(mockService.list).toHaveBeenCalled());
+
+      fireEvent.click(
+        await screen.findByRole('button', { name: /set as default/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockService.setDefault).toHaveBeenCalledWith('p1'),
+      );
+      await waitFor(() => expect(heard.count()).toBe(1));
+      // The pre-existing prop path stays intact — the event only ADDS the reach the prop lacks.
+      expect(onProvidersChanged).toHaveBeenCalled();
+    } finally {
+      heard.stop();
+    }
   });
 });

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.test.tsx
@@ -1524,6 +1524,7 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
         <SettingsPageWithRouter
           core={coreWithToasts}
           onProvidersChanged={jest.fn()}
+          initialEntries={['/settings?tab=privacy']}
         />,
       );
 
@@ -1557,6 +1558,7 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
         <SettingsPageWithRouter
           core={coreWithToasts}
           onProvidersChanged={jest.fn()}
+          initialEntries={['/settings?tab=privacy']}
         />,
       );
 
@@ -1623,14 +1625,16 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
 
     try {
       render(
-        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+          initialEntries={['/settings?tab=privacy']}
+        />,
       );
       fireEvent.click(
         await screen.findByText(/allow users to override privacy mode/i),
       );
-      fireEvent.click(
-        screen.getByRole('button', { name: /save privacy settings/i }),
-      );
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
       await waitFor(() => expect(payloads).toHaveLength(1));
       expect(payloads[0]).toEqual(saved);
@@ -1654,7 +1658,11 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
 
     try {
       render(
-        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+          initialEntries={['/settings?tab=retention']}
+        />,
       );
       // Queried by role, not by label: this jest environment stubs EUI's htmlIdGenerator so every
       // generated id is the literal "generated-id", which makes the field's own <label for=...>
@@ -1684,7 +1692,7 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
 
     try {
       render(
-        <SettingsPage
+        <SettingsPageWithRouter
           core={coreWithToasts}
           onProvidersChanged={jest.fn()}
           autoOpenCreateForm={true}
@@ -1715,7 +1723,10 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
 
     try {
       render(
-        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+        />,
       );
       // Delete lives behind the row's actions popover.
       fireEvent.click(
@@ -1740,7 +1751,10 @@ describe('SettingsPage — announcing saved changes to the mounted chat', () => 
 
     try {
       render(
-        <SettingsPage core={coreWithToasts} onProvidersChanged={jest.fn()} />,
+        <SettingsPageWithRouter
+          core={coreWithToasts}
+          onProvidersChanged={jest.fn()}
+        />,
       );
       fireEvent.click(
         await screen.findByRole('button', { name: /actions for my openai/i }),

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
@@ -121,9 +121,15 @@ interface SettingsPageProps {
 
 /** Announces a saved assistant-settings document to every mounted ChatPage (including the header
  * flyout's independent one), so an admin's privacy policy change applies without a page reload.
- * See `ASSISTANT_SETTINGS_CHANGED_EVENT` for why this is a window event, not a prop callback. */
-function notifyAssistantSettingsChanged(): void {
-  window.dispatchEvent(new Event(ASSISTANT_SETTINGS_CHANGED_EVENT));
+ * See `ASSISTANT_SETTINGS_CHANGED_EVENT` for why this is a window event, not a prop callback.
+ *
+ * The document the PUT returned rides along as `detail` so listeners never have to re-GET it: a
+ * read issued right after the write can still see the PRE-save document (the indexer write is not
+ * synchronously visible), which would silently reinstate the policy just changed. */
+function notifyAssistantSettingsChanged(saved: AssistantSettings): void {
+  window.dispatchEvent(
+    new CustomEvent(ASSISTANT_SETTINGS_CHANGED_EVENT, { detail: saved }),
+  );
 }
 
 /** Announces a provider create/update/delete/default change to every `useProviders` consumer.
@@ -635,7 +641,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
         }),
       );
       setLoadedAssistantSettings(saved);
-      notifyAssistantSettingsChanged();
+      notifyAssistantSettingsChanged(saved);
       retention.commit(saved.conversationRetentionDays);
       core.notifications.toasts.addSuccess(
         i18n.translate('wazuhAiAssistant.settings.retention.saveSuccess', {
@@ -738,7 +744,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
         }),
       );
       setLoadedAssistantSettings(saved);
-      notifyAssistantSettingsChanged();
+      notifyAssistantSettingsChanged(saved);
       privacy.commit({
         privacyDefaultOn: saved.privacyDefaultOn,
         userCanOverride: saved.userCanOverride,

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
@@ -40,9 +40,11 @@ import {
 import { i18n } from '@osd/i18n';
 import { CoreStart } from '../../../../../src/core/public';
 import {
+  ASSISTANT_SETTINGS_CHANGED_EVENT,
   AssistantSettings,
   FieldPolicyAction,
   FieldPolicyEntry,
+  PROVIDERS_CHANGED_EVENT,
   SettingsService,
 } from '../../services/settings-service';
 import { ProviderInput, ProviderSummary } from '../../../common/types';
@@ -115,6 +117,19 @@ interface SettingsPageProps {
   /** True while the URL carries `?addProvider=true`: opens the create-provider flyout. */
   autoOpenCreateForm?: boolean;
   onCreateFormOpenChange?: (open: boolean) => void;
+}
+
+/** Announces a saved assistant-settings document to every mounted ChatPage (including the header
+ * flyout's independent one), so an admin's privacy policy change applies without a page reload.
+ * See `ASSISTANT_SETTINGS_CHANGED_EVENT` for why this is a window event, not a prop callback. */
+function notifyAssistantSettingsChanged(): void {
+  window.dispatchEvent(new Event(ASSISTANT_SETTINGS_CHANGED_EVENT));
+}
+
+/** Announces a provider create/update/delete/default change to every `useProviders` consumer.
+ * Complements the `onProvidersChanged` prop, which only reaches the in-app chat view. */
+function notifyProvidersChanged(): void {
+  window.dispatchEvent(new Event(PROVIDERS_CHANGED_EVENT));
 }
 
 // Short labels shown in the providers table; the add/edit flyout uses its own long labels
@@ -620,6 +635,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
         }),
       );
       setLoadedAssistantSettings(saved);
+      notifyAssistantSettingsChanged();
       retention.commit(saved.conversationRetentionDays);
       core.notifications.toasts.addSuccess(
         i18n.translate('wazuhAiAssistant.settings.retention.saveSuccess', {
@@ -722,6 +738,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
         }),
       );
       setLoadedAssistantSettings(saved);
+      notifyAssistantSettingsChanged();
       privacy.commit({
         privacyDefaultOn: saved.privacyDefaultOn,
         userCanOverride: saved.userCanOverride,
@@ -912,6 +929,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
       setEditingProvider(saved);
       reload();
       onProvidersChanged();
+      notifyProvidersChanged();
       core.notifications.toasts.addSuccess(
         editingProvider
           ? i18n.translate('wazuhAiAssistant.settings.updateSuccess', {
@@ -1007,6 +1025,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
     }
     reload();
     onProvidersChanged();
+    notifyProvidersChanged();
   };
 
   const handleSetDefault = async (provider: ProviderSummary) => {
@@ -1015,6 +1034,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
       await service.setDefault(provider.id);
       reload();
       onProvidersChanged();
+      notifyProvidersChanged();
       core.notifications.toasts.addSuccess(
         i18n.translate('wazuhAiAssistant.settings.setDefaultSuccess', {
           defaultMessage: '"{name}" is now the default provider.',
@@ -2244,6 +2264,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
         <ProviderFormFlyout
           editingProvider={editingProvider}
           error={error}
+          existingProviders={providers}
           apiKeyEncryptionEnabled={apiKeyEncryptionEnabled}
           isSaving={isSubmittingProvider}
           testOutcome={flyoutTestOutcome}

--- a/plugins/wazuh-ai-assistant/public/hooks/use-providers.test.ts
+++ b/plugins/wazuh-ai-assistant/public/hooks/use-providers.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { HttpSetup } from '../../../../src/core/public';
+import { PROVIDERS_CHANGED_EVENT } from '../services/settings-service';
 import { useProviders } from './use-providers';
 
 /**
@@ -11,6 +12,9 @@ import { useProviders } from './use-providers';
 const mockList = jest.fn();
 
 jest.mock('../services/settings-service', () => ({
+  // Keeps the module's real `PROVIDERS_CHANGED_EVENT`, which the hook subscribes to and the tests
+  // below dispatch. Stubbing it out would make both sides agree on `undefined`.
+  ...jest.requireActual('../services/settings-service'),
   SettingsService: jest.fn().mockImplementation(() => ({
     list: () => mockList(),
   })),
@@ -103,5 +107,59 @@ describe('useProviders', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  /**
+   * Provider CRUD done on the Settings page has to reach EVERY mounted consumer, including the
+   * header flyout's own independent instance, which no prop callback from the Settings page can
+   * reach (both views stay mounted side by side). The Settings page announces it with
+   * `PROVIDERS_CHANGED_EVENT`; the hook refreshes on it.
+   */
+  describe('cross-instance refresh (wazuh-dashboard#1512)', () => {
+    it('refetches when a provider change is announced', async () => {
+      mockList.mockResolvedValue([provider('a', true)]);
+
+      const { result } = renderHook(() => useProviders(http));
+      await waitFor(() => expect(result.current.providersLoaded).toBe(true));
+      expect(mockList).toHaveBeenCalledTimes(1);
+
+      // A provider was added elsewhere (the Settings page, in the other mounted view).
+      mockList.mockResolvedValue([provider('a', true), provider('b')]);
+      act(() => {
+        window.dispatchEvent(new Event(PROVIDERS_CHANGED_EVENT));
+      });
+
+      await waitFor(() => expect(result.current.providers).toHaveLength(2));
+      expect(mockList).toHaveBeenCalledTimes(2);
+      // The existing selection survives, same as any other refresh.
+      expect(result.current.selectedProviderId).toBe('a');
+    });
+
+    it('re-selects a default when the previously selected provider was deleted', async () => {
+      mockList.mockResolvedValue([provider('a'), provider('b', true)]);
+
+      const { result } = renderHook(() => useProviders(http));
+      await waitFor(() => expect(result.current.selectedProviderId).toBe('b'));
+
+      mockList.mockResolvedValue([provider('a', true)]);
+      act(() => {
+        window.dispatchEvent(new Event(PROVIDERS_CHANGED_EVENT));
+      });
+
+      await waitFor(() => expect(result.current.selectedProviderId).toBe('a'));
+    });
+
+    it('stops listening once the consumer unmounts', async () => {
+      mockList.mockResolvedValue([provider('a', true)]);
+
+      const { result, unmount } = renderHook(() => useProviders(http));
+      await waitFor(() => expect(result.current.providersLoaded).toBe(true));
+      expect(mockList).toHaveBeenCalledTimes(1);
+
+      unmount();
+      window.dispatchEvent(new Event(PROVIDERS_CHANGED_EVENT));
+
+      expect(mockList).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/plugins/wazuh-ai-assistant/public/hooks/use-providers.ts
+++ b/plugins/wazuh-ai-assistant/public/hooks/use-providers.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { HttpSetup } from '../../../../src/core/public';
 import { ProviderSummary } from '../../common/types';
-import { SettingsService } from '../services/settings-service';
+import {
+  PROVIDERS_CHANGED_EVENT,
+  SettingsService,
+} from '../services/settings-service';
 
 const PROVIDERS_LOAD_TIMEOUT_MS = 20_000;
 
@@ -67,9 +70,17 @@ export function useProviders(http: HttpSetup): ProvidersState {
       .finally(() => setProvidersLoaded(true));
   }, [settingsService]);
 
+  // Load once per mount, then again on every PROVIDERS_CHANGED_EVENT. Every consumer of this hook
+  // is fixed at once by subscribing here — notably the header flyout's own independent instance
+  // (public/components/header/assistant-chat-panel.tsx), which no prop callback from the Settings
+  // page can reach because both views stay mounted side by side. Event-driven only: no polling.
   useEffect(() => {
     refreshProviders();
-    return () => clearTimeout(deadlineRef.current);
+    window.addEventListener(PROVIDERS_CHANGED_EVENT, refreshProviders);
+    return () => {
+      window.removeEventListener(PROVIDERS_CHANGED_EVENT, refreshProviders);
+      clearTimeout(deadlineRef.current);
+    };
   }, [refreshProviders]);
 
   return {

--- a/plugins/wazuh-ai-assistant/public/hooks/use-providers.ts
+++ b/plugins/wazuh-ai-assistant/public/hooks/use-providers.ts
@@ -30,6 +30,17 @@ export function useProviders(http: HttpSetup): ProvidersState {
     undefined,
   );
 
+  // Every resolution below is gated on this: the flyout mount unmounts on every close, so a
+  // refresh triggered right before that (or by a PROVIDERS_CHANGED_EVENT it saw on the way out)
+  // would otherwise set state on a dead hook.
+  const isMountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
   const refreshProviders = useCallback(() => {
     clearTimeout(deadlineRef.current);
     const deadline = setTimeout(() => {
@@ -47,6 +58,9 @@ export function useProviders(http: HttpSetup): ProvidersState {
       .list()
       .then(list => {
         clearTimeout(deadline);
+        if (!isMountedRef.current) {
+          return;
+        }
         setProviders(list);
         setProvidersError(null);
         setSelectedProviderId(current => {
@@ -60,6 +74,9 @@ export function useProviders(http: HttpSetup): ProvidersState {
       })
       .catch(() => {
         clearTimeout(deadline);
+        if (!isMountedRef.current) {
+          return;
+        }
         setProvidersError(
           i18n.translate('wazuhAiAssistant.chat.providersLoadError', {
             defaultMessage:
@@ -67,7 +84,11 @@ export function useProviders(http: HttpSetup): ProvidersState {
           }),
         );
       })
-      .finally(() => setProvidersLoaded(true));
+      .finally(() => {
+        if (isMountedRef.current) {
+          setProvidersLoaded(true);
+        }
+      });
   }, [settingsService]);
 
   // Load once per mount, then again on every PROVIDERS_CHANGED_EVENT. Every consumer of this hook

--- a/plugins/wazuh-ai-assistant/public/services/settings-service.ts
+++ b/plugins/wazuh-ai-assistant/public/services/settings-service.ts
@@ -8,6 +8,29 @@ import {
 import { fetchAllPages } from './fetch-all-pages';
 import { SettingsAccess } from './session-heal';
 
+/**
+ * Window event announcing that the plugin-wide assistant settings document was just saved
+ * (`updateAssistantSettings`). Every mounted ChatPage listens and refetches, so an admin's privacy
+ * policy change lands in the chat immediately instead of only after a full page reload.
+ *
+ * A window event rather than a prop callback on purpose: the Chat and Settings views stay mounted
+ * side by side behind `display: none` (public/application.tsx), and there is a SECOND, independent
+ * ChatPage mount in the header flyout (public/components/header/assistant-chat-panel.tsx) that no
+ * prop from the Settings page could ever reach. Lives here — the module that owns the settings
+ * GET/PUT — so neither view has to import the other.
+ */
+export const ASSISTANT_SETTINGS_CHANGED_EVENT =
+  'wazuhAiAssistant:assistantSettingsChanged';
+
+/**
+ * Window event announcing that the provider list changed (created/updated/deleted, or a new
+ * default). Consumed by `useProviders` (public/hooks/use-providers.ts), so every mounted consumer
+ * refreshes — including the header flyout's own independent `useProviders` instance, which the
+ * Settings page's `onProvidersChanged` prop callback can never reach for the same reason described
+ * above. That prop path stays in place; a duplicate refresh is harmless.
+ */
+export const PROVIDERS_CHANGED_EVENT = 'wazuhAiAssistant:providersChanged';
+
 /** Mirrors server/tools/privacy.ts's `FieldPolicyAction` — that file lives under server/ (out of
  * scope to import from public/), so this is a hand-kept public-side copy of the same wire values
  * (server/routes/settings.ts's `fieldPolicyActionSchema` is the source of truth). */

--- a/plugins/wazuh-ai-assistant/public/services/settings-service.ts
+++ b/plugins/wazuh-ai-assistant/public/services/settings-service.ts
@@ -18,9 +18,35 @@ import { SettingsAccess } from './session-heal';
  * ChatPage mount in the header flyout (public/components/header/assistant-chat-panel.tsx) that no
  * prop from the Settings page could ever reach. Lives here — the module that owns the settings
  * GET/PUT — so neither view has to import the other.
+ *
+ * Dispatched as a `CustomEvent` whose `detail` carries the settings object the PUT just returned.
+ * Listeners must PREFER that payload over issuing their own GET: the indexer write may not be
+ * visible to a read that happens microseconds later, so a re-GET can hand back the PRE-save
+ * document and silently reinstate the policy the admin just changed. The GET stays as the fallback
+ * for any dispatch without a usable payload (see `isAssistantSettingsPayload`).
  */
 export const ASSISTANT_SETTINGS_CHANGED_EVENT =
   'wazuhAiAssistant:assistantSettingsChanged';
+
+/**
+ * Narrows an untrusted `CustomEvent.detail` to `AssistantSettings`. Deliberately minimal — it
+ * checks only the fields consumers actually branch on, so a server that grows the shape does not
+ * make every payload fall back to a GET. Anything failing this check is treated as "no payload".
+ */
+export function isAssistantSettingsPayload(
+  detail: unknown,
+): detail is AssistantSettings {
+  if (!detail || typeof detail !== 'object') {
+    return false;
+  }
+  const candidate = detail as Partial<AssistantSettings>;
+  return (
+    typeof candidate.privacyDefaultOn === 'boolean' &&
+    typeof candidate.userCanOverride === 'boolean' &&
+    Boolean(candidate.privacyDefaultPerProvider) &&
+    typeof candidate.privacyDefaultPerProvider === 'object'
+  );
+}
 
 /**
  * Window event announcing that the provider list changed (created/updated/deleted, or a new
@@ -28,6 +54,13 @@ export const ASSISTANT_SETTINGS_CHANGED_EVENT =
  * refreshes — including the header flyout's own independent `useProviders` instance, which the
  * Settings page's `onProvidersChanged` prop callback can never reach for the same reason described
  * above. That prop path stays in place; a duplicate refresh is harmless.
+ *
+ * Carries NO payload, unlike `ASSISTANT_SETTINGS_CHANGED_EVENT`: the mutation sites only ever hold
+ * the single provider they just wrote, never the full post-write list this event's consumers
+ * (`useProviders`) actually need, so there is nothing useful to attach. The read-after-write window
+ * is tolerable here in a way it is not for privacy: a list that is one refresh stale shows a
+ * missing or extra row until the next refresh, whereas a stale privacy policy silently sends
+ * unmasked data.
  */
 export const PROVIDERS_CHANGED_EVENT = 'wazuhAiAssistant:providersChanged';
 

--- a/plugins/wazuh-ai-assistant/server/routes/provider-name-route-wiring.test.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/provider-name-route-wiring.test.ts
@@ -1,0 +1,301 @@
+import assert from 'node:assert/strict';
+
+/**
+ * Proves the duplicate-name gate is actually WIRED INTO the provider routes, not merely exported.
+ * `provider-name-uniqueness.test.ts` next to this file covers the gate's own comparison logic; the
+ * gap this file closes is that deleting the two `if (duplicateName) { return duplicateName; }`
+ * blocks in server/routes/settings.ts left that suite entirely green.
+ *
+ * So this drives the REAL handlers: `registerSettingsRoutes` is called with a fake `IRouter` that
+ * captures every registered handler by method+path, and the POST/PUT handlers are then invoked
+ * directly. Beyond the 409 status, the load-bearing assertion is the ORDERING invariant — on a
+ * duplicate, `aiProviders.create`/`update` must never be called at all, so a rejected request
+ * leaves nothing half-written.
+ *
+ * Runs under the platform Jest runner only: server/routes/settings.ts imports `@osd/config-schema`
+ * as a runtime value (`schema.object(...)`, not just types), which resolves only inside a full
+ * wazuh-dashboard checkout.
+ *
+ * The URL guard is mocked because `assertProviderUrlAllowed` performs a real DNS lookup for the
+ * baseUrl (server/providers/url-guard.ts) — irrelevant to name uniqueness, and a test that needs
+ * working DNS is a flaky test. Its own behavior is covered by server/providers/url-guard.test.ts.
+ */
+jest.mock('../providers/url-guard', () => ({
+  assertProviderUrlAllowed: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { registerSettingsRoutes } from './settings';
+import { API_PATHS } from '../../common/constants';
+
+type CapturedHandler = (
+  context: unknown,
+  request: unknown,
+  response: unknown,
+) => Promise<unknown>;
+
+interface RecordedResponse {
+  kind: 'ok' | 'customError' | 'badRequest' | 'notFound';
+  statusCode?: number;
+  body?: { message?: string };
+}
+
+/** Collects the handlers `registerSettingsRoutes` registers, keyed `METHOD path`. */
+function captureRoutes(): {
+  handlers: Map<string, CapturedHandler>;
+} {
+  const handlers = new Map<string, CapturedHandler>();
+  const record =
+    (method: string) =>
+    (config: { path: string }, handler: CapturedHandler) => {
+      handlers.set(`${method} ${config.path}`, handler);
+    };
+  const router = {
+    get: record('GET'),
+    post: record('POST'),
+    put: record('PUT'),
+    delete: record('DELETE'),
+  };
+  const logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+  registerSettingsRoutes(
+    router as unknown as Parameters<typeof registerSettingsRoutes>[0],
+    logger as unknown as Parameters<typeof registerSettingsRoutes>[1],
+  );
+  return { handlers };
+}
+
+/** Records what the handler answered with, so the test can assert on status AND body. */
+function fakeResponse(): {
+  calls: RecordedResponse[];
+  factory: unknown;
+} {
+  const calls: RecordedResponse[] = [];
+  const factory = {
+    ok(options?: { body?: unknown }) {
+      calls.push({ kind: 'ok', statusCode: 200, body: options?.body as never });
+      return { status: 200 };
+    },
+    customError(options: { statusCode: number; body?: { message?: string } }) {
+      calls.push({
+        kind: 'customError',
+        statusCode: options.statusCode,
+        body: options.body,
+      });
+      return { status: options.statusCode };
+    },
+    badRequest(options?: { body?: { message?: string } }) {
+      calls.push({ kind: 'badRequest', statusCode: 400, body: options?.body });
+      return { status: 400 };
+    },
+    notFound() {
+      calls.push({ kind: 'notFound', statusCode: 404 });
+      return { status: 404 };
+    },
+  };
+  return { calls, factory };
+}
+
+interface StoredProvider {
+  id: string;
+  name: string;
+}
+
+/** A provider store with the three methods these two handlers reach for. `create`/`update` are
+ * jest mocks so the "no write on rejection" invariant is directly observable. */
+function fakeProviderStore(existing: StoredProvider[]) {
+  const create = jest.fn().mockResolvedValue(undefined);
+  const update = jest.fn().mockResolvedValue(undefined);
+  const listCalls: Array<{ page: number; perPage: number }> = [];
+  const aiProviders = {
+    list: (_context: unknown, page: number, perPage: number) => {
+      listCalls.push({ page, perPage });
+      return Promise.resolve({
+        providers: existing
+          .slice((page - 1) * perPage, (page - 1) * perPage + perPage)
+          .map(({ id, name }) => ({ id, attributes: { name } })),
+        total: existing.length,
+      });
+    },
+    count: () => Promise.resolve(existing.length),
+    get: (_context: unknown, id: string) => {
+      const found = existing.find(provider => provider.id === id);
+      return Promise.resolve(
+        found ? { id: found.id, attributes: { name: found.name } } : undefined,
+      );
+    },
+    create,
+    update,
+  };
+  return { aiProviders, create, update, listCalls };
+}
+
+const VALID_BODY = {
+  type: 'openai_compatible' as const,
+  baseUrl: 'https://api.openai.com/v1',
+  model: 'gpt-4o',
+};
+
+const EXISTING = [
+  { id: 'p1', name: 'OpenAI production' },
+  { id: 'p2', name: 'Claude staging' },
+];
+
+test('POST /providers: a duplicate name is refused with 409 and nothing is created', async () => {
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post, 'POST /providers must be registered');
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: 'Claude staging' } },
+    factory,
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].statusCode, 409);
+  assert.match(String(calls[0].body?.message), /already exists/);
+  // The ordering invariant: rejection happens BEFORE any document write.
+  assert.equal(store.create.mock.calls.length, 0, 'no provider may be created');
+});
+
+test('POST /providers: the same name in another casing/spacing is also refused', async () => {
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post);
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: '  claude STAGING ' } },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 409);
+  assert.equal(store.create.mock.calls.length, 0);
+});
+
+test('POST /providers: an unused name is created, with the name stored trimmed', async () => {
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post);
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: '  Gemini lab  ' } },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 200, 'the create must succeed');
+  assert.equal(store.create.mock.calls.length, 1);
+  // L9: what is STORED matches what the uniqueness check compared.
+  assert.equal(store.create.mock.calls[0][2].name, 'Gemini lab');
+});
+
+test('POST /providers: a whitespace-only name is a 400 and creates nothing', async () => {
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post);
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: '   ' } },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 400);
+  assert.equal(store.create.mock.calls.length, 0);
+});
+
+test('POST /providers: every provider is compared, not just the first page of 200', async () => {
+  // M3: the client pre-check compares against the FULL list (fetchAllPages), so a server that only
+  // scanned the first page would disagree with it and let provider #201's name through.
+  const many = Array.from({ length: 250 }, (_value, index) => ({
+    id: `p${index}`,
+    name: `provider-${index}`,
+  }));
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post);
+  const store = fakeProviderStore(many);
+  const { calls, factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: 'provider-240' } },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 409, 'provider #241 must still collide');
+  assert.equal(store.create.mock.calls.length, 0);
+  // Proof of the mechanism: a capped first read, then a full re-read once `total` exceeded it.
+  assert.deepEqual(store.listCalls, [
+    { page: 1, perPage: 200 },
+    { page: 1, perPage: 250 },
+  ]);
+});
+
+test('POST /providers: a store within the first page is read exactly once', async () => {
+  const { handlers } = captureRoutes();
+  const post = handlers.get(`POST ${API_PATHS.PROVIDERS}`);
+  assert.ok(post);
+  const store = fakeProviderStore(EXISTING);
+  const { factory } = fakeResponse();
+
+  await post(
+    { wazuh_ai_assistant: store },
+    { body: { ...VALID_BODY, name: 'Gemini lab' } },
+    factory,
+  );
+
+  assert.deepEqual(store.listCalls, [{ page: 1, perPage: 200 }]);
+});
+
+test('PUT /providers/{id}: renaming onto another provider name is 409 with no write', async () => {
+  const { handlers } = captureRoutes();
+  const put = handlers.get(`PUT ${API_PATHS.PROVIDER_BY_ID('{id}')}`);
+  assert.ok(put, 'PUT /providers/{id} must be registered');
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await put(
+    { wazuh_ai_assistant: store },
+    { params: { id: 'p1' }, body: { ...VALID_BODY, name: 'Claude staging' } },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 409);
+  assert.match(String(calls[0].body?.message), /already exists/);
+  assert.equal(store.update.mock.calls.length, 0, 'no provider may be updated');
+});
+
+test('PUT /providers/{id}: keeping the provider own name writes normally', async () => {
+  const { handlers } = captureRoutes();
+  const put = handlers.get(`PUT ${API_PATHS.PROVIDER_BY_ID('{id}')}`);
+  assert.ok(put);
+  const store = fakeProviderStore(EXISTING);
+  const { calls, factory } = fakeResponse();
+
+  await put(
+    { wazuh_ai_assistant: store },
+    {
+      params: { id: 'p1' },
+      body: { ...VALID_BODY, name: '  OpenAI production  ' },
+    },
+    factory,
+  );
+
+  assert.equal(calls[0].statusCode, 200);
+  assert.equal(store.update.mock.calls.length, 1);
+  assert.equal(store.update.mock.calls[0][2].name, 'OpenAI production');
+});

--- a/plugins/wazuh-ai-assistant/server/routes/provider-name-uniqueness.test.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/provider-name-uniqueness.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import {
+  duplicateProviderNameMessage,
+  rejectDuplicateProviderName,
+} from './settings';
+
+/**
+ * `rejectDuplicateProviderName` is the uniqueness gate POST /providers and PUT /providers/{id}
+ * (server/routes/settings.ts) run before any document write: a name already taken by ANOTHER
+ * provider is refused with HTTP 409, so two providers can never end up indistinguishable in the
+ * chat's provider selector. Comparison is trim + lowercase, and the provider being updated is
+ * excluded so re-saving it never collides with itself.
+ *
+ * Runs under the platform Jest runner only: server/routes/settings.ts imports `@osd/config-schema`
+ * as a runtime value (`schema.object(...)`, not just types), which resolves only inside a full
+ * wazuh-dashboard checkout.
+ *
+ * Same convention as provider-encryption-gate.test.ts and manager-session-check.test.ts: there is
+ * no request/response-mocking harness for OpenSearch Dashboards routes in this plugin, so this
+ * exercises the gate directly, mocking only what it touches
+ * (`context.wazuh_ai_assistant.aiProviders.list` and `response.customError`) and using
+ * `Parameters<typeof rejectDuplicateProviderName>` to pick up the real OSD parameter types without
+ * importing them from the (here, unavailable) `../../../../src/core/server` tree.
+ */
+
+type Context = Parameters<typeof rejectDuplicateProviderName>[0];
+type ResponseFactory = Parameters<typeof rejectDuplicateProviderName>[3];
+
+/** Mirrors the `{ providers, total }` shape `AiProvidersClient.list` resolves with — only `id` and
+ * `attributes.name` are read by the gate. */
+function fakeContext(names: Array<{ id: string; name: string }>): Context {
+  return {
+    wazuh_ai_assistant: {
+      aiProviders: {
+        list: () =>
+          Promise.resolve({
+            providers: names.map(({ id, name }) => ({
+              id,
+              attributes: { name },
+            })),
+            total: names.length,
+          }),
+      },
+    },
+  } as unknown as Context;
+}
+
+function fakeResponse(): {
+  calls: Array<{ statusCode: number; body: { message: string } }>;
+  factory: ResponseFactory;
+} {
+  const calls: Array<{ statusCode: number; body: { message: string } }> = [];
+  const factory = {
+    customError(options: { statusCode: number; body: { message: string } }) {
+      calls.push(options);
+      return { status: options.statusCode, ...options };
+    },
+  } as unknown as ResponseFactory;
+  return { calls, factory };
+}
+
+const EXISTING = [
+  { id: 'p1', name: 'OpenAI production' },
+  { id: 'p2', name: 'Claude staging' },
+];
+
+test('create: a name already taken by another provider is refused with 409', async () => {
+  const { calls, factory } = fakeResponse();
+
+  const result = await rejectDuplicateProviderName(
+    fakeContext(EXISTING),
+    'OpenAI production',
+    undefined,
+    factory,
+  );
+
+  assert.ok(result, 'the gate must return a response, not null');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].statusCode, 409);
+  assert.equal(
+    calls[0].body.message,
+    duplicateProviderNameMessage('OpenAI production'),
+  );
+});
+
+test('create: an unused name passes with no response built', async () => {
+  const { calls, factory } = fakeResponse();
+
+  assert.equal(
+    await rejectDuplicateProviderName(
+      fakeContext(EXISTING),
+      'Gemini lab',
+      undefined,
+      factory,
+    ),
+    null,
+  );
+  assert.equal(calls.length, 0, 'no error response may be built');
+});
+
+test('create: the match ignores casing and surrounding whitespace', async () => {
+  const candidates = [
+    'openai production',
+    'OPENAI PRODUCTION',
+    '  OpenAI production  ',
+    ' openai PRODUCTION ',
+  ];
+
+  const outcomes = await Promise.all(
+    candidates.map(async candidate => {
+      const { calls, factory } = fakeResponse();
+      const result = await rejectDuplicateProviderName(
+        fakeContext(EXISTING),
+        candidate,
+        undefined,
+        factory,
+      );
+      return { candidate, calls, result };
+    }),
+  );
+
+  for (const { candidate, calls, result } of outcomes) {
+    assert.ok(result, `"${candidate}" must be refused`);
+    assert.equal(calls[0].statusCode, 409);
+    // The message echoes the TRIMMED name the caller sent, not the stored one.
+    assert.equal(
+      calls[0].body.message,
+      duplicateProviderNameMessage(candidate.trim()),
+    );
+  }
+});
+
+test('create: a stored name with stray whitespace still collides', async () => {
+  const { factory } = fakeResponse();
+
+  const result = await rejectDuplicateProviderName(
+    fakeContext([{ id: 'p1', name: '  Padded name ' }]),
+    'padded name',
+    undefined,
+    factory,
+  );
+
+  assert.ok(result, 'stored-side whitespace must be normalized too');
+});
+
+test('update: renaming onto another provider name is refused with 409', async () => {
+  const { calls, factory } = fakeResponse();
+
+  const result = await rejectDuplicateProviderName(
+    fakeContext(EXISTING),
+    'Claude staging',
+    'p1',
+    factory,
+  );
+
+  assert.ok(result, 'the gate must return a response, not null');
+  assert.equal(calls[0].statusCode, 409);
+  assert.equal(
+    calls[0].body.message,
+    duplicateProviderNameMessage('Claude staging'),
+  );
+});
+
+test('update: keeping the provider own name is allowed — no self-collision', async () => {
+  const { calls, factory } = fakeResponse();
+
+  assert.equal(
+    await rejectDuplicateProviderName(
+      fakeContext(EXISTING),
+      'OpenAI production',
+      'p1',
+      factory,
+    ),
+    null,
+  );
+  assert.equal(calls.length, 0, 'no error response may be built');
+});
+
+test('update: re-casing the provider own name is allowed', async () => {
+  const { factory } = fakeResponse();
+
+  assert.equal(
+    await rejectDuplicateProviderName(
+      fakeContext(EXISTING),
+      'openai PRODUCTION',
+      'p1',
+      factory,
+    ),
+    null,
+  );
+});
+
+test('the very first provider (empty store) is never a duplicate', async () => {
+  const { factory } = fakeResponse();
+
+  assert.equal(
+    await rejectDuplicateProviderName(
+      fakeContext([]),
+      'Anything',
+      undefined,
+      factory,
+    ),
+    null,
+  );
+});
+
+test('the 409 message names the offending provider and stays actionable', () => {
+  const message = duplicateProviderNameMessage('OpenAI production');
+  assert.match(message, /OpenAI production/);
+  assert.match(message, /already exists/);
+  // Never reference repo files in operator-facing copy (same rule as ENCRYPTION_REQUIRED_MESSAGE).
+  assert.doesNotMatch(message, /server\/|public\/|\.ts\b/);
+});

--- a/plugins/wazuh-ai-assistant/server/routes/provider-name-uniqueness.test.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/provider-name-uniqueness.test.ts
@@ -27,19 +27,28 @@ type Context = Parameters<typeof rejectDuplicateProviderName>[0];
 type ResponseFactory = Parameters<typeof rejectDuplicateProviderName>[3];
 
 /** Mirrors the `{ providers, total }` shape `AiProvidersClient.list` resolves with — only `id` and
- * `attributes.name` are read by the gate. */
-function fakeContext(names: Array<{ id: string; name: string }>): Context {
+ * `attributes.name` are read by the gate. Pages honestly, so a store larger than the gate's
+ * first-page size exercises its re-read branch rather than silently returning everything. */
+function fakeContext(
+  names: Array<{ id: string; name: string }>,
+  listCalls: Array<{ page: number; perPage: number }> = [],
+): Context {
   return {
     wazuh_ai_assistant: {
       aiProviders: {
-        list: () =>
-          Promise.resolve({
-            providers: names.map(({ id, name }) => ({
-              id,
-              attributes: { name },
-            })),
+        list: (_context: unknown, page: number, perPage: number) => {
+          listCalls.push({ page, perPage });
+          const start = (page - 1) * perPage;
+          return Promise.resolve({
+            providers: names
+              .slice(start, start + perPage)
+              .map(({ id, name }) => ({
+                id,
+                attributes: { name },
+              })),
             total: names.length,
-          }),
+          });
+        },
       },
     },
   } as unknown as Context;
@@ -202,6 +211,46 @@ test('the very first provider (empty store) is never a duplicate', async () => {
     ),
     null,
   );
+});
+
+test('a name held by provider #201+ still collides: the whole store is scanned', async () => {
+  // M3: the first read is capped at 200 (matching `clearOtherDefaults`), but `total` says there are
+  // more, so the gate re-reads everything. Without that, provider #201's name was never compared —
+  // and the client-side pre-check DOES compare it (fetchAllPages), so the two disagreed.
+  const many = Array.from({ length: 260 }, (_value, index) => ({
+    id: `p${index}`,
+    name: `provider-${index}`,
+  }));
+  const listCalls: Array<{ page: number; perPage: number }> = [];
+  const { calls, factory } = fakeResponse();
+
+  const result = await rejectDuplicateProviderName(
+    fakeContext(many, listCalls),
+    'PROVIDER-255',
+    undefined,
+    factory,
+  );
+
+  assert.ok(result, 'a name beyond the first page must still be refused');
+  assert.equal(calls[0].statusCode, 409);
+  assert.deepEqual(listCalls, [
+    { page: 1, perPage: 200 },
+    { page: 1, perPage: 260 },
+  ]);
+});
+
+test('a store that fits the first page is read exactly once', async () => {
+  const listCalls: Array<{ page: number; perPage: number }> = [];
+  const { factory } = fakeResponse();
+
+  await rejectDuplicateProviderName(
+    fakeContext(EXISTING, listCalls),
+    'Gemini lab',
+    undefined,
+    factory,
+  );
+
+  assert.deepEqual(listCalls, [{ page: 1, perPage: 200 }]);
 });
 
 test('the 409 message names the offending provider and stays actionable', () => {

--- a/plugins/wazuh-ai-assistant/server/routes/settings.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/settings.ts
@@ -172,6 +172,10 @@ export const ENCRYPTION_REQUIRED_MESSAGE =
   'add wazuh_ai_assistant.encryptionKey` (recommended) or in `opensearch_dashboards.yml` — then ' +
   'restart dashboard service and try again.';
 
+/** First-page size for the provider-name scan below, matching `clearOtherDefaults`'s own `perPage`.
+ * A store larger than this is re-read in full — see `rejectDuplicateProviderName`. */
+const PROVIDER_SCAN_PAGE_SIZE = 200;
+
 /** Message for a name already taken by another provider. Kept as a builder so the route and its
  * test agree on the exact wording the admin sees. */
 export function duplicateProviderNameMessage(name: string): string {
@@ -188,9 +192,22 @@ export function duplicateProviderNameMessage(name: string): string {
  * would defeat the point.
  *
  * `excludeId` is the provider being updated (PUT /providers/{id}) so re-saving a provider without
- * renaming it never collides with itself; it is `undefined` on create. Providers are capped at ~200
- * (the same `perPage` `clearOtherDefaults` above uses) and every read of this store is a full
- * in-memory list anyway (server/settings/ai-providers-client.ts), so a plain list+scan is fine.
+ * renaming it never collides with itself; it is `undefined` on create.
+ *
+ * The scan must cover EVERY provider, not just the first page: the client-side pre-check in the
+ * add/edit flyout compares against the full list (public/services/settings-service.ts's `list()`
+ * loops pages via `fetchAllPages`), so a server that only compared the first page would disagree
+ * with it and let provider #201's name through. The first read therefore uses the same `perPage` as
+ * `clearOtherDefaults` above and then re-lists with `perPage: total` if the store turned out to
+ * hold more — cheap, because every read of this store materializes the whole thing in memory
+ * anyway (server/settings/ai-providers-client.ts).
+ *
+ * Residual race (accepted): this is a read followed by a separate write, and the indexer endpoint
+ * backing providers has no unique constraint on `name`, so two admins creating the same name at the
+ * same instant can both pass this check. Closing that would need a constraint the storage layer
+ * does not offer. The window is milliseconds, the outcome is cosmetic (two same-named providers,
+ * fixable by renaming one), and the check still catches every realistic case: a stale flyout list,
+ * a second browser tab, and a direct API caller.
  *
  * Exported for unit testing only — the routes below call it directly.
  */
@@ -201,11 +218,12 @@ export async function rejectDuplicateProviderName(
   response: OpenSearchDashboardsResponseFactory,
 ): Promise<IOpenSearchDashboardsResponse | null> {
   const normalized = name.trim().toLowerCase();
-  const { providers } = await context.wazuh_ai_assistant.aiProviders.list(
-    context,
-    1,
-    200,
-  );
+  const { aiProviders } = context.wazuh_ai_assistant;
+  const firstPage = await aiProviders.list(context, 1, PROVIDER_SCAN_PAGE_SIZE);
+  let { providers } = firstPage;
+  if (providers.length < firstPage.total) {
+    ({ providers } = await aiProviders.list(context, 1, firstPage.total));
+  }
   const taken = providers.some(
     provider =>
       provider.id !== excludeId &&
@@ -217,6 +235,21 @@ export async function rejectDuplicateProviderName(
   return response.customError({
     statusCode: 409,
     body: { message: duplicateProviderNameMessage(name.trim()) },
+  });
+}
+
+/** Rejects a name that is empty once trimmed. The body schema's `minLength: 1` only rejects the
+ * empty string, so `"   "` reaches here; since both the uniqueness comparison and the persisted
+ * value are trimmed (L9), a whitespace-only name would otherwise be stored as `""`. */
+export function rejectBlankProviderName(
+  name: string,
+  response: OpenSearchDashboardsResponseFactory,
+): IOpenSearchDashboardsResponse | null {
+  if (name.trim().length > 0) {
+    return null;
+  }
+  return response.badRequest({
+    body: { message: 'Provider name cannot be empty.' },
   });
 }
 
@@ -298,6 +331,10 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       if (encryptionGate) {
         return encryptionGate;
       }
+      const blankName = rejectBlankProviderName(request.body.name, response);
+      if (blankName) {
+        return blankName;
+      }
       // Name uniqueness, before any document write: `crypto.randomUUID()` below would otherwise
       // happily mint a second provider indistinguishable from an existing one in every UI surface.
       const duplicateName = await rejectDuplicateProviderName(
@@ -333,6 +370,10 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       const providerId = crypto.randomUUID();
       const attributes: StoredProviderAttributes = {
         ...request.body,
+        // Persist the trimmed name so what is STORED matches what the uniqueness check above
+        // compared: otherwise " OpenAI " could be saved and then collide with itself on the next
+        // edit, and the two would render as visually identical rows.
+        name: request.body.name.trim(),
         apiKey: request.body.apiKey
           ? getApiKeyCipher().encrypt(request.body.apiKey, providerId)
           : request.body.apiKey,
@@ -393,6 +434,10 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       if (!existing) {
         return response.notFound();
       }
+      const blankName = rejectBlankProviderName(request.body.name, response);
+      if (blankName) {
+        return blankName;
+      }
       // Same uniqueness rule as POST /providers, excluding this provider so re-saving it (or
       // renaming it to a different casing/spacing of its own name) never collides with itself.
       const duplicateName = await rejectDuplicateProviderName(
@@ -443,6 +488,8 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       const nextAttributes: StoredProviderAttributes = {
         ...existing.attributes,
         ...request.body,
+        // Same trim-at-the-write rule as POST /providers above.
+        name: request.body.name.trim(),
         apiKey: nextApiKey,
         isDefault: nextIsDefault,
       };

--- a/plugins/wazuh-ai-assistant/server/routes/settings.ts
+++ b/plugins/wazuh-ai-assistant/server/routes/settings.ts
@@ -172,6 +172,54 @@ export const ENCRYPTION_REQUIRED_MESSAGE =
   'add wazuh_ai_assistant.encryptionKey` (recommended) or in `opensearch_dashboards.yml` — then ' +
   'restart dashboard service and try again.';
 
+/** Message for a name already taken by another provider. Kept as a builder so the route and its
+ * test agree on the exact wording the admin sees. */
+export function duplicateProviderNameMessage(name: string): string {
+  return `A provider named "${name}" already exists.`;
+}
+
+/**
+ * Rejects a provider name that is already taken by ANOTHER provider with HTTP 409.
+ *
+ * Provider names are the only way an admin tells two providers apart in the chat's provider
+ * selector and in every toast/error this plugin emits, so two providers sharing one name is
+ * indistinguishable in the UI even though the ids differ. The comparison is `trim()` +
+ * `toLowerCase()`: " OpenAI " and "openai" read as the same provider to a human, so accepting both
+ * would defeat the point.
+ *
+ * `excludeId` is the provider being updated (PUT /providers/{id}) so re-saving a provider without
+ * renaming it never collides with itself; it is `undefined` on create. Providers are capped at ~200
+ * (the same `perPage` `clearOtherDefaults` above uses) and every read of this store is a full
+ * in-memory list anyway (server/settings/ai-providers-client.ts), so a plain list+scan is fine.
+ *
+ * Exported for unit testing only — the routes below call it directly.
+ */
+export async function rejectDuplicateProviderName(
+  context: RequestHandlerContext,
+  name: string,
+  excludeId: string | undefined,
+  response: OpenSearchDashboardsResponseFactory,
+): Promise<IOpenSearchDashboardsResponse | null> {
+  const normalized = name.trim().toLowerCase();
+  const { providers } = await context.wazuh_ai_assistant.aiProviders.list(
+    context,
+    1,
+    200,
+  );
+  const taken = providers.some(
+    provider =>
+      provider.id !== excludeId &&
+      (provider.attributes.name ?? '').trim().toLowerCase() === normalized,
+  );
+  if (!taken) {
+    return null;
+  }
+  return response.customError({
+    statusCode: 409,
+    body: { message: duplicateProviderNameMessage(name.trim()) },
+  });
+}
+
 /** Refuses a non-empty `apiKey` when no encryption key is configured. See docs/ENCRYPTION.md. */
 export function requireApiKeyEncryption(
   apiKey: string | undefined,
@@ -249,6 +297,17 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       );
       if (encryptionGate) {
         return encryptionGate;
+      }
+      // Name uniqueness, before any document write: `crypto.randomUUID()` below would otherwise
+      // happily mint a second provider indistinguishable from an existing one in every UI surface.
+      const duplicateName = await rejectDuplicateProviderName(
+        context,
+        request.body.name,
+        undefined,
+        response,
+      );
+      if (duplicateName) {
+        return duplicateName;
       }
       const isFirstProvider =
         (await context.wazuh_ai_assistant.aiProviders.count(context)) === 0;
@@ -333,6 +392,17 @@ export function registerSettingsRoutes(router: IRouter, logger: Logger): void {
       );
       if (!existing) {
         return response.notFound();
+      }
+      // Same uniqueness rule as POST /providers, excluding this provider so re-saving it (or
+      // renaming it to a different casing/spacing of its own name) never collides with itself.
+      const duplicateName = await rejectDuplicateProviderName(
+        context,
+        request.body.name,
+        request.params.id,
+        response,
+      );
+      if (duplicateName) {
+        return duplicateName;
       }
       const cipher = getApiKeyCipher();
       let nextApiKey: string | undefined;


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh-dashboard/issues/1512

Two independent problems with the AI Assistant's provider/privacy settings:

1. Two AI providers could share the same name, making them indistinguishable
   in the chat's provider selector and in every toast the plugin emits.
2. The Chat and Settings views stay mounted side by side behind
   `display: none` (and the header flyout holds its own, separate `ChatPage`
   / `useProviders` instance), so a privacy policy saved in Settings — or a
   provider created, edited, deleted, or made default — never reached an
   already-open chat until a full page reload.

## Proposed Changes

- **Reject duplicate provider names.** `POST /providers` and
  `PUT /providers/{id}` now list existing providers and refuse a name another
  provider already holds (HTTP 409), comparing on `trim()` +
  `toLowerCase()`. `PUT` excludes the provider being updated. The add/edit
  flyout mirrors this client-side against the loaded provider list before the
  round-trip, and surfaces a genuine race's 409 through its existing error
  callout.
- **Harden the uniqueness gate.** The gate now re-lists with the store's real
  `total` instead of one page of 200 (matching the flyout's own
  `fetchAllPages` pre-check), trims the name at write time so storage matches
  what was compared, rejects a name that trims to empty, and is now covered
  by a test that drives the real routes end-to-end and asserts no
  create/update happens on a 409. The residual read-then-write race (no
  unique constraint at the indexer) is accepted and documented.
- **Surface all provider form errors on one click.** The name and
  endpoint-URL checks ran sequentially; both are now evaluated before either
  returns, so a form with two problems doesn't need two submit attempts to
  see both.
- **Apply saved AI settings to an open chat.** Two window events, dispatched
  after a successful save and consumed by every mounted consumer:
  - `assistantSettingsChanged` — every `ChatPage` refetches (and also
    refetches when it becomes the visible tab). When `userCanOverride`
    arrives `false`, the "user already toggled" flag is cleared so the lock
    binds the current conversation, not only the next.
  - `providersChanged` — `useProviders` refreshes, fixing every consumer at
    once, including the header flyout's own instance that no prop callback
    can reach.
- **Make the chat privacy chip tell the truth.** The events above only reach
  the browser that did the saving. Two more triggers close that gap without
  polling: `handleSend` re-reads the policy before building the request body
  (bounded by a 1.5s deadline, fail-soft — never blocks sending, never
  silently flips privacy off), and a `visibilitychange` refetch corrects an
  idle chat when the user returns to the tab. Also: the settings event now
  carries the saved document as `CustomEvent` detail (applied directly,
  closing a read-after-write gap where a re-GET could still see the pre-save
  document), every refetch path is guarded against resolving after unmount,
  and a stale comment claiming tab-switch alone covered other-tab saves was
  corrected.

### Results and Evidence

Covered by the automated test suite below (1641 tests passing), plus a
manual click-through against a running dev instance (`docker/osd-dev`,
`5.0.0` base). Screenshots below; some steps only have text evidence
(accessibility-tree snapshots / network payloads) where noted.

**Duplicate name + malformed URL, one click.** Submitted the Add-provider
form with `Name: test` (already used by an existing provider) and
`Endpoint URL: not-a-valid-url` together. Both inline errors appeared from
the single submit, no second attempt needed:
- Name field: `A provider named "test" already exists. Pick a different name.`
- Endpoint URL field: `Enter a valid URL starting with http:// or https://`

<img width="1280" height="577" alt="invalid-url-error" src="https://github.com/user-attachments/assets/df526fe9-c19d-4d42-9688-ca470e4decb7" />

**Privacy policy reaches an already-open chat, live.** With a Chat tab
already open showing the composer chip as `Privacy · Off` (clickable
`<button>`), saved `Enable privacy mode by default: On` +
`Allow users to override privacy mode: Off` on the Settings tab. Switching
back to the same (never-reloaded) Chat tab, the chip had flipped to a
locked `Privacy · On`. Confirmed in the DOM the element is no longer
clickable:
```
tagName: "SPAN"
className: "euiBadge euiBadge--hollow euiBadge--iconLeft wzPrivacyChip wzPrivacyChip--on"
```
The header flyout's independent `ChatPage`/`useProviders` instance,
opened fresh afterwards, showed the same locked `Privacy · On` and the
same selected provider — consistent with the tab that was live-updated.

<img width="1280" height="577" alt="chat-privacy-off-before" src="https://github.com/user-attachments/assets/9aa92a67-6b7d-4ee4-8df9-d46787116cc1" />
<img width="1280" height="577" alt="chat-privacy-on-live-after-save" src="https://github.com/user-attachments/assets/1b6d8d37-a8ac-4a7d-80b7-34c58de3c97f" />
<img width="1280" height="577" alt="header-flyout-consistent" src="https://github.com/user-attachments/assets/6bb29fa0-2030-4d52-93cc-a5106052f83c" />

**`providersChanged` reaches every mounted consumer.** With the header
flyout open and untouched, created a provider (`e2e-test-provider`) from
the main Settings tab. Re-opened the main Chat tab's provider picker
(mounted the whole time, never remounted) and it already listed the new
provider alongside the two pre-existing ones:
```
menuitemradio "test Default gemma4:12b" [checked=true]
menuitemradio "nvidia nvidia/nemotron-3.5-lightning:free" [checked=false]
menuitemradio "e2e-test-provider llama3" [checked=false]
```
The header flyout's own picker (still the same open instance) showed the
identical list. Deleted `e2e-test-provider` from Settings and re-opened the
Chat tab's picker again without any reload — the deleted provider was gone
immediately:
```
menuitemradio "test Default gemma4:12b" [checked=true]
menuitemradio "nvidia nvidia/nemotron-3.5-lightning:free" [checked=false]
menuitemradio "e2e-crud-check llama3" [checked=false]
```

<img width="1280" height="577" alt="provider-created-toast" src="https://github.com/user-attachments/assets/ebc3b730-855e-438d-b8bd-fc0765d1e04a" />

**Pre-send re-read sends what the server will enforce.** Sent a real
message while privacy was locked on (`privacyDefaultOn: true`,
`userCanOverride: false`). Captured the outgoing request body via the
browser's network log:
```json
POST /api/wazuh_ai_assistant/chat
{"providerId":"...","messages":[{"role":"user","content":"hola, probando pre-send privacy re-read"}],"privacy":{"enabled":true,"map":[]}}
```
`privacy.enabled` matches the just-saved policy at send time, not a stale
in-memory value. (The provider itself failed to respond — no reachable
LLM endpoint in this local dev environment — which is unrelated to this
PR; the request payload is the thing under test.)

<img width="1280" height="577" alt="real-message-sent" src="https://github.com/user-attachments/assets/6faafe32-cc45-43b3-b3ea-b43fc8a4d890" />

Test providers were deleted and the privacy settings reverted to their
original values after this pass, leaving the dev instance as found.

Not yet run: the existing Cypress suite under
`plugins/wazuh-ai-assistant/test/cypress`.

### Artifacts Affected

- `plugins/wazuh-ai-assistant` (public, server, common)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- Server: route-wiring test proving the 409 gate is actually wired into
  `POST`/`PUT` (not just unit-tested in isolation), and a uniqueness test
  covering the `total`-aware re-list, trim-at-write, and empty-after-trim
  rejection.
- Public: coverage for cross-view propagation of `assistantSettingsChanged`
  and `providersChanged` (chat page and settings page), the pre-send policy
  re-read, the visibility-change refetch, and the provider form's combined
  name/URL validation.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...

