### PR TITLE
Keep the conversation rail action buttons off the title and timestamp

### DIFF
--- a/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.scss
+++ b/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.scss
@@ -66,6 +66,19 @@
 /** The expanded rail is a full-height flex column so the collapse control above can be pinned and
   * the conversation list itself is the part that scrolls. */
 .wzConvoRail {
+  /**
+   * The ground the DOCKED rail paints, republished for `.wzConvoRowRenameOverlay`'s opaque pill.
+   *
+   * chat-page.tsx renders this rail as `<EuiPanel color='subdued'>`, and EUI maps `subdued` to
+   * `$euiPageBackgroundColor` (its `$ouiPanelBackgroundColorModifiers`) — the SAME value
+   * `_redesign.scss` already publishes as `--wz-chrome`, so this names an existing token rather
+   * than restating a hex or guessing at a shade. `--wz-surface` (the white card tone) is a
+   * different color in both themes: measured on the v9 light theme, the rail paints #F0F2F4 while
+   * `--wz-surface` is #FCFEFF, so a pill grounded in `--wz-surface` was a permanently lighter
+   * rectangle sitting in the docked rail — visible at rest and on focus-without-hover, where the
+   * row's own tint is transparent and the ground is all the pill has.
+   */
+  --wz-convo-rail-bg: var(--wz-chrome, #{$euiPageBackgroundColor});
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -96,6 +109,18 @@
  */
 .wzConvoRailFlyout {
   @include wzSurfaceTokens;
+  /**
+   * The flyout's ground is NOT the docked rail's. `EuiFlyout` paints `$euiColorEmptyShade` (the
+   * white card tone, `--wz-surface`), where the docked `EuiPanel color='subdued'` paints
+   * `$euiPageBackgroundColor` — measured on v9 light, #FCFEFF against #F0F2F4. The rename pill has
+   * to be grounded in whichever one it is actually sitting on, so each container publishes its own
+   * and the pill just reads `--wz-convo-rail-bg` without knowing which rail it is in.
+   *
+   * No specificity fight with `.wzConvoRail` above: chat-page.tsx renders the rail EITHER as that
+   * docked panel OR inside this flyout wrapper, never one nested in the other, so exactly one of
+   * these two declarations is ever an ancestor of a given row.
+   */
+  --wz-convo-rail-bg: var(--wz-surface, #{$euiColorEmptyShade});
 }
 
 .wzConvoRailCollapsed {
@@ -153,23 +178,134 @@
   list-style: none;
 }
 
+/** One `EuiButtonIcon`'s box (EUI's default `size='m'`), named once so the rename overlay's offset
+ * and the timestamp's reserved width below are derived from the same figure rather than from two
+ * hand-copied numbers that can drift apart. */
+$wzConvoRowActionSize: 32px;
+/** The row's own padding. Emitted as a custom property by `.wzConvoRowLayout` below and consumed
+ * from there by the row itself, so this SCSS value is the single definition (#9018 review nit) —
+ * it used to be restated as an inline `padding: '8px'` in conversation-list.tsx, where nothing
+ * stopped the two from drifting apart and silently invalidating the overlay geometry derived from
+ * it. */
+$wzConvoRowPadding: 8px;
+/** `EuiFlexGroup gutterSize='xs'`, the gap between the row's own flex items. */
+$wzConvoRowGutter: 4px;
+/**
+ * Width reserved for the relative timestamp — sized to the WIDEST value `formatRelativeTime`
+ * (conversation-list.tsx) can produce, which is its >7-day branch: a localized `{month: 'short',
+ * day: 'numeric'}` date, "Jul 26" / "26 jul" / "26.07.", around 40px at this type size. The other
+ * branches ("now", "59m", "23h", "Mon") are all far narrower.
+ *
+ * #9018 review G2: sizing this to the ICON instead (28px) left the wide branch's leading glyphs
+ * sticking out to the left of the pill that is supposed to mask them. A FIXED width, not a
+ * `min-width`, is what makes the pill's coverage provable rather than approximate — the slot cannot
+ * grow past what the pill spans — and anything wider than the branches above (an unusually verbose
+ * locale) ellipses inside it instead of pushing out.
+ */
+$wzConvoRowTimestampSlot: 48px;
+
+/**
+ * The row's own box. Split out from `.wzConvoRow` (chat-page.scss, which this component consumes
+ * but does not own) so the padding above and the geometry derived from it live together in one
+ * file.
+ */
+.wzConvoRowLayout {
+  --wz-convo-row-padding: #{$wzConvoRowPadding};
+  padding: var(--wz-convo-row-padding, #{$wzConvoRowPadding});
+}
+
 /**
  * The inline-rename pencil (M3 fix, #9010 review), anchored to `.wzConvoRow`'s own
  * `position: relative` (conversation-list.tsx) rather than living inside the row's flex group —
  * a zero-width flex item still cost the row a `gutterSize='xs'` margin at rest (EUI gutters are
- * margins, not padding), which this avoids entirely by never entering the flex flow. Positioned
- * over the timestamp/trash corner of the row: `right` clears the trash button's own box so the
- * two controls don't sit on top of each other when both are visible on hover, but a hovered
- * pencil is still expected to sit over part of the (glance-only) timestamp text — the background
- * below is the row's OWN hover tint, not a new color, so no text bleeds through it.
+ * margins, not padding), which this avoids entirely by never entering the flex flow. `right`
+ * clears the trash button's own box (the row's padding plus one icon) so the two controls never
+ * sit on top of each other when both are revealed.
+ *
+ * #9018 review: the pencil rendered ON TOP of the row's text and was, in the reviewer's words,
+ * "hard to see". The comment here used to claim the background stopped anything bleeding through,
+ * but `--wz-accent-hover` is `rgba($euiColorPrimary, 0.06)` — a 6% tint, i.e. 94% transparent — so
+ * the timestamp (and, on a row whose timestamp is short, the tail of the title) showed straight
+ * through the icon. The pill is now genuinely OPAQUE, in two layers:
+ *
+ *  - `background-color` is `--wz-convo-rail-bg`: THE GROUND THIS RAIL ACTUALLY SITS ON, which the
+ *    two rail containers publish for themselves below. It has to be opaque and it has to be the
+ *    right opaque, or the pill is a permanent lighter rectangle — see those two rules for why the
+ *    rail has two different grounds and why naming one of them here would be wrong.
+ *  - `background-image` re-applies THE ROW'S OWN computed background on top of that ground, read
+ *    from `--wz-convo-row-bg` — a custom property the row publishes alongside the background it
+ *    actually paints (conversation-list.tsx). Because both come from one expression, the pill
+ *    matches the row in every state by construction: hovered (`--wz-accent-hover`), SELECTED
+ *    (`--wz-accent-soft`, a 10% tint the pill used to under-paint at 6% and so showed as a lighter
+ *    patch), and focus-without-hover (`transparent`, where the pill correctly resolves to bare
+ *    surface — exactly what an unhighlighted row renders as over that same ground). #9018 review
+ *    G1: the previous version hardcoded the hover tint here, which matched only one of those three.
+ *
+ * Both layers are unconditional on the class, so they apply to every reveal path this branch
+ * ships — pointer hover AND keyboard focus (`isFocused`, F-3) — not only to hover.
+ *
+ * The pill spans the whole reserved timestamp slot plus its gutter, not just the icon's own box
+ * (#9018 review G2): masking only 32px of a 48px slot left the wide "Jul 26" branch's leading
+ * glyphs peeking out beside it. `justify-content: flex-end` keeps the icon itself exactly where it
+ * has always sat — flush against the trash button — while the backdrop extends left across
+ * everything it needs to cover.
+ *
+ * Every `var()` carries a fallback, for the same reason `_redesign.scss`'s own mixins do: an
+ * unresolved `var()` invalidates the WHOLE declaration, which here would silently restore the
+ * see-through pill this fixes. `--wz-convo-row-bg` falls back to `transparent`, which degrades to
+ * the plain ground rather than to nothing.
+ *
+ * `inset-inline-end` rather than `right`, and `text-align: end` on the slot below: the row is a
+ * plain flex row, so in an RTL locale its `[title][timestamp][trash]` order mirrors and the whole
+ * action corner moves to the left — a physical `right` would strand the pill on the side the
+ * controls just left. The logical property follows them.
  */
 .wzConvoRowRenameOverlay {
   position: absolute;
   top: 50%;
-  right: 40px;
+  inset-inline-end: $wzConvoRowPadding + $wzConvoRowActionSize;
+  width: $wzConvoRowGutter + $wzConvoRowTimestampSlot;
+  display: flex;
+  justify-content: flex-end;
   transform: translateY(-50%);
-  background: var(--wz-accent-hover);
   border-radius: 4px;
+  background-color: var(--wz-convo-rail-bg, #{$euiColorEmptyShade});
+  background-image: linear-gradient(
+    var(--wz-convo-row-bg, transparent),
+    var(--wz-convo-row-bg, transparent)
+  );
+}
+
+/**
+ * The relative timestamp beside the trash button — the ONE thing the revealed pencil is allowed to
+ * cover, since it is glance-only and the pill above masks it completely.
+ *
+ * The reserved width is what keeps that promise honest (#9018 review). The pill spans from
+ * `right: 40px` leftwards across this slot and its gutter; without a reservation, a timestamp
+ * narrower than that span — "2m", "5h" — left the pencil hanging past the timestamp and over the
+ * TITLE's last glyphs, and one WIDER than it (the "Jul 26" branch, G2) pushed its own leading
+ * glyphs out to the left of the pill. A fixed `$wzConvoRowTimestampSlot` pins both ends: the slot
+ * is exactly as wide as the pill covers, so the pencil never reaches title text and never leaves
+ * timestamp text showing beside it.
+ *
+ * Reserved UNCONDITIONALLY, not only while the icons are revealed: the whole point of the M3
+ * overlay is that hovering a row reflows nothing, and a width that appeared on hover would put the
+ * title reflow straight back. `text-align: right` keeps a short timestamp hugging the trash button,
+ * exactly where it sat before this reservation existed; the truncation is the backstop for a locale
+ * whose date form runs wider than the slot, which ellipses rather than escaping it.
+ */
+.wzConvoRowTimestamp {
+  width: $wzConvoRowTimestampSlot;
+  flex-shrink: 0;
+  /* `end`, not `right`: mirrors with the row in RTL, same reason as the overlay's
+     `inset-inline-end` above. */
+  text-align: end;
+  overflow: hidden;
+
+  .euiText {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 /** EUI's `.euiFlexGroup` carries `flex-grow: 1`. These two rows are direct children of

--- a/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.test.tsx
@@ -812,6 +812,130 @@ describe('ConversationList', () => {
       expect(flexGroup?.children).toHaveLength(3);
     });
 
+    // #9018 review (Ian, screenshot): "The edit button is located above some text, which makes it
+    // hard to see." The pencil overlay's background was `--wz-accent-hover` -- a 6% tint, i.e. 94%
+    // transparent -- so the text it sat on read straight through the icon. jsdom has no layout
+    // engine and does not compile the SCSS, so what is assertable here is the STRUCTURE the fix
+    // hangs off: the overlay still carries the class the opaque-pill rule targets, the timestamp
+    // now carries the class that reserves the width the overlay sits over, and that reservation is
+    // present at rest (a width that only appeared on hover would reflow the title on hover, which
+    // is exactly what the M3 overlay exists to avoid). The rendered colors themselves are a visual
+    // check -- see the PR's evidence pass.
+    it('#9018: the rename overlay and the width it reserves are both wired at rest', () => {
+      render(
+        <ConversationList
+          conversations={[conversation({ id: 'c1', title: 'Rename me' })]}
+          isLoading={false}
+          activeConversationId={null}
+          onSelect={noop}
+          onNewConversation={noop}
+          onDelete={noop}
+          onRename={noop}
+        />,
+      );
+
+      const row = screen.getByText('Rename me').closest('.wzConvoRow');
+      const pencil = screen.getByRole('button', {
+        name: 'Rename conversation',
+      });
+      // The opaque-pill rule (conversation-list.scss) is keyed on this class, and it is on the
+      // overlay unconditionally -- so it applies to BOTH reveal paths this branch ships, pointer
+      // hover and keyboard focus, not only to hover.
+      expect(pencil.closest('.wzConvoRowRenameOverlay')).not.toBeNull();
+
+      // The reserved timestamp slot: present before any hover, and inside the row's own flex group
+      // (so it is real reserved layout, not another overlay).
+      const flexGroup = row?.querySelector(':scope > .euiFlexGroup');
+      const timestampSlot = flexGroup?.querySelector('.wzConvoRowTimestamp');
+      expect(timestampSlot).not.toBeNull();
+
+      // Hovering reveals the pencil without adding, removing or re-classing a single flex item --
+      // the reservation is the same one it was at rest.
+      fireEvent.mouseEnter(row as HTMLElement);
+      expect(flexGroup?.children).toHaveLength(3);
+      expect(flexGroup?.querySelectorAll('.wzConvoRowTimestamp')).toHaveLength(
+        1,
+      );
+    });
+
+    // #9018 review G1: the pill used to hardcode the hover tint, so it matched the row only while
+    // hovered-and-unselected -- on a SELECTED row it under-painted a 10% tint at 6% and read as a
+    // lighter patch. The row now PUBLISHES the background it paints and the pill re-paints that same
+    // value over its own opaque ground, so the two match in every state by construction.
+    //
+    // Only the PUBLISHED value is asserted here. The painted one is not readable in this
+    // environment: jsdom's `background` shorthand parser drops a `var()` value outright, so
+    // `style.background` reports whatever last parsed rather than what React set -- asserting it
+    // would test jsdom's CSS parser, not this component. That the two agree is structural (one
+    // `const` feeds both), and the rendered colors are a visual check for the evidence pass.
+    it('#9018: the row publishes the background it paints, in every state', () => {
+      const { rerender } = render(
+        <ConversationList
+          conversations={[conversation({ id: 'c1', title: 'Publish me' })]}
+          isLoading={false}
+          activeConversationId={null}
+          onSelect={noop}
+          onNewConversation={noop}
+          onDelete={noop}
+          onRename={noop}
+        />,
+      );
+
+      const rowOf = () =>
+        screen.getByText('Publish me').closest('.wzConvoRow') as HTMLElement;
+      const publishedBg = (element: HTMLElement) =>
+        element.style.getPropertyValue('--wz-convo-row-bg');
+
+      // At rest: transparent, and published as such -- the pill then resolves to bare surface,
+      // which is exactly what an unhighlighted row renders as over that same ground.
+      const atRest = publishedBg(rowOf());
+      expect(atRest).toBe('transparent');
+
+      // Hovered: the hover tint, published.
+      fireEvent.mouseEnter(rowOf());
+      const hovered = publishedBg(rowOf());
+      expect(hovered).toBe('var(--wz-accent-hover)');
+
+      // SELECTED: the 10% tint the pill used to under-paint at 6%. This is the state G1 is about.
+      rerender(
+        <ConversationList
+          conversations={[conversation({ id: 'c1', title: 'Publish me' })]}
+          isLoading={false}
+          activeConversationId='c1'
+          onSelect={noop}
+          onNewConversation={noop}
+          onDelete={noop}
+          onRename={noop}
+        />,
+      );
+      const selected = publishedBg(rowOf());
+      expect(selected).toBe('var(--wz-accent-soft)');
+
+      // Three states, three DIFFERENT published values -- so a pill following this property tracks
+      // all of them, where the hardcoded tint could only ever match one.
+      expect(new Set([atRest, hovered, selected]).size).toBe(3);
+    });
+
+    // #9018 review nit: the row's padding is the figure the overlay's geometry is derived from, so
+    // it lives in the stylesheet as one SCSS constant rather than as an inline literal here.
+    it('#9018: the row takes its padding from the stylesheet, not an inline literal', () => {
+      render(
+        <ConversationList
+          conversations={[conversation({ id: 'c1', title: 'Pad me' })]}
+          isLoading={false}
+          activeConversationId={null}
+          onSelect={noop}
+          onNewConversation={noop}
+          onDelete={noop}
+          onRename={noop}
+        />,
+      );
+
+      const row = screen.getByText('Pad me').closest('.wzConvoRow');
+      expect(row).toHaveClass('wzConvoRowLayout');
+      expect((row as HTMLElement).style.padding).toBe('');
+    });
+
     it('M3 REGRESSION: the pencil is NOT permanently shown on the active/selected row -- hover or focus only', () => {
       render(
         <ConversationList

--- a/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/chat/conversation-list.tsx
@@ -960,6 +960,30 @@ export const ConversationList: React.FC<ConversationListProps> = ({
                   const isFocused = conversation.id === focusedId;
                   const isRenaming = conversation.id === renamingId;
                   const isChecked = selectedIds.has(conversation.id);
+                  // "Soft-tinted pill on the active row" (design language, "Navigation"): a filled,
+                  // well-rounded highlight rather than the old left-border indicator — font-weight
+                  // 600 plus `aria-current` below are what carry the non-color-reliant signal now.
+                  const rowBackground =
+                    !selectMode && isSelected
+                      ? 'var(--wz-accent-soft)'
+                      : isHovered
+                      ? 'var(--wz-accent-hover)'
+                      : 'transparent';
+                  // ONE expression, painted here and PUBLISHED as `--wz-convo-row-bg` for the
+                  // rename overlay to re-paint over its own opaque ground
+                  // (conversation-list.scss). #9018 review G1: the overlay used to hardcode the
+                  // hover tint, so it matched the row only while hovered-and-unselected — on a
+                  // SELECTED row (a 10% tint it under-painted at 6%) it read as a lighter patch.
+                  // Publishing the value instead of restating it makes the two agree in every
+                  // state, including any state added later.
+                  const rowStyle: React.CSSProperties &
+                    Record<'--wz-convo-row-bg', string> = {
+                    position: 'relative',
+                    cursor: selectMode ? 'default' : 'pointer',
+                    borderRadius: 8,
+                    background: rowBackground,
+                    '--wz-convo-row-bg': rowBackground,
+                  };
                   return (
                     <li key={conversation.id} className='wzConvoRailListItem'>
                       {/* Plain `div` (not EuiFlexGroup) carries the interactive/a11y attributes,
@@ -1025,23 +1049,11 @@ export const ConversationList: React.FC<ConversationListProps> = ({
                         // wzConvoRow (chat-page.scss) supplies a reduced-motion-safe transition timing
                         // for the background/border-color changes below — the colors themselves stay
                         // driven by this row's own hover/selected state, unchanged.
-                        className='wzConvoRow'
-                        style={{
-                          position: 'relative',
-                          cursor: selectMode ? 'default' : 'pointer',
-                          padding: '8px',
-                          // "Soft-tinted pill on the active row" (design language, "Navigation"): a
-                          // filled, well-rounded highlight rather than the old left-border indicator —
-                          // font-weight 600 plus `aria-current` above are what carry the
-                          // non-color-reliant signal now.
-                          borderRadius: 8,
-                          background:
-                            !selectMode && isSelected
-                              ? 'var(--wz-accent-soft)'
-                              : isHovered
-                              ? 'var(--wz-accent-hover)'
-                              : 'transparent',
-                        }}
+                        // wzConvoRowLayout (conversation-list.scss) owns the row's padding, which
+                        // the rename overlay's geometry is derived from: restating it as an inline
+                        // literal here let the two drift (#9018 review nit).
+                        className='wzConvoRow wzConvoRowLayout'
+                        style={rowStyle}
                       >
                         <EuiFlexGroup
                           responsive={false}
@@ -1126,8 +1138,13 @@ export const ConversationList: React.FC<ConversationListProps> = ({
                               {/* The relative timestamp moves onto the row's own line (design gap "a
                                 whole line spent on a relative timestamp") — `flexShrink: 0` and
                                 `whiteSpace: 'nowrap'` keep it from ever wrapping under the truncated
-                                title beside it. */}
-                              <EuiFlexItem grow={false}>
+                                title beside it. `wzConvoRowTimestamp` (conversation-list.scss)
+                                reserves the width the revealed rename pencil sits over, so that
+                                overlay can never reach the title's glyphs — see that rule. */}
+                              <EuiFlexItem
+                                grow={false}
+                                className='wzConvoRowTimestamp'
+                              >
                                 <EuiText
                                   size='xs'
                                   color='subdued'


### PR DESCRIPTION
## Description

Follow-up to the conversation rail shipped in #9018, addressing the review feedback in https://github.com/wazuh/wazuh-dashboard-plugins/pull/9018#issuecomment-5398727064: the hover-revealed rename button rendered on top of the conversation text.

## Proposed Changes

- The revealed action pill is now opaque: the row publishes its computed background as a CSS custom property (`--wz-convo-row-bg`) and the pill consumes it, so hover, selection and keyboard-focus states all match the row by construction. The rail's ground color is likewise published per container (docked panel vs flyout), so the pill's base always matches what it sits on, in both themes.
- The timestamp slot reserves a fixed width sized to the widest value it can hold (the `Jul 26` date form), so the action band never overlaps timestamp or title glyphs; the reservation is unconditional, so hovering reflows nothing.
- The action offsets use logical properties (`inset-inline-end`, `text-align: end`) and shared SCSS constants instead of magic numbers.

No changelog entry, matching #9018 (`no changelog`).

### Results and Evidence

<!-- screenshot: hovered row with the rename pill over a long title, docked rail, light and dark -->

### Artifacts Affected

`plugins/wazuh-ai-assistant` browser bundle only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Colocated tests pin the published per-state background values, the reserved timestamp slot at rest, and that hovering adds or removes no flex items. Rendered colors and geometry were verified against the compiled CSS; a visual pass on the running dashboard is listed under How to Test.

## How to Test

1. Open the AI Assistant chat with several conversations whose titles are long and whose ages span minutes to months.
2. Hover a row: the rename and delete controls appear on an opaque pill that matches the row background, without touching the title or timestamp.
3. Select a conversation and hover it: the pill still matches the selected row's tint.
4. Tab through the rail: keyboard focus reveals the same pill.