### PR TITLE
Remove data grid columns with missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 | [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775) | Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters                                                                                                                                                                                                        |
 | [#9015](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9015) | Fixed the Controls tab showing 0 results by adding missing regulatory compliance requirement definitions for PCI DSS, GDPR, HIPAA, NIST 800-53, FedRAMP, ISO 27001, CMMC, TSC, and NIS2, and added an "Others" breakdown showing findings tagged with unrecognized requirement values |
 | [#9023](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9023) | Fixed sorting not working in the Server management > Security tables (Roles, Policies, Users and Roles mapping), and removed the sort affordance from columns the server API cannot sort                                                                                              |
+| [#9037](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9037) | Fixed the Findings data grid crashing and losing every column when a configured column's field does not exist in the index pattern                                                                                                                                                    |
 
 ### Removed
 

--- a/plugins/main/public/components/common/data-grid/data-grid-state-persistence-manager/use-data-grid-state-persistence-manager.test.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-state-persistence-manager/use-data-grid-state-persistence-manager.test.ts
@@ -87,7 +87,7 @@ describe('useDataGridStatePersistenceManager', () => {
     });
   });
 
-  it('should reset columns when invalid column ids are found', () => {
+  it('should remove invalid column ids and keep the valid ones', () => {
     const persistedState = {
       columns: ['col1', 'nonExistentColumn'],
     };
@@ -109,7 +109,7 @@ describe('useDataGridStatePersistenceManager', () => {
     });
 
     expect(mockStateManagement.retrieveState).toHaveBeenCalled();
-    expect(retrievedState.columns).toEqual([]);
+    expect(retrievedState.columns).toEqual(['col1']);
   });
 
   it('should reset column widths when invalid', () => {
@@ -214,6 +214,33 @@ describe('useDataGridStatePersistenceManager', () => {
       ...currentState,
       ...updatePayload,
     });
+  });
+
+  it('should drop only the invalid columns and persist the sanitized list', () => {
+    mockStateManagement.retrieveState.mockReturnValue({
+      columns: ['col1', 'missing-field', 'col3'],
+      columnWidths: { col1: 150 },
+      pageSize: 50,
+    });
+
+    const { result } = renderHook(() =>
+      useDataGridStatePersistenceManager({
+        stateManagement: mockStateManagement,
+        defaultState,
+        columnSchemaDefinitionsMap,
+        indexPatternExists: true,
+      }),
+    );
+
+    let retrievedState;
+    act(() => {
+      retrievedState = result.current.retrieveState();
+    });
+
+    expect(retrievedState.columns).toEqual(['col1', 'col3']);
+    expect(mockStateManagement.persistState).toHaveBeenCalledWith(
+      expect.objectContaining({ columns: ['col1', 'col3'] }),
+    );
   });
 
   it('should clear state correctly', () => {

--- a/plugins/main/public/components/common/data-grid/data-grid-state-persistence-manager/use-data-grid-state-persistence-manager.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-state-persistence-manager/use-data-grid-state-persistence-manager.ts
@@ -66,6 +66,42 @@ export const useDataGridStatePersistenceManager = ({
     [indexPatternExists],
   );
 
+  const sanitizeColumns = (
+    columnIds: DataGridState['columns'],
+  ): DataGridState['columns'] => {
+    if (!columnIds || !Array.isArray(columnIds)) {
+      return [];
+    }
+
+    const canCheckExistence = Boolean(
+      indexPatternExists &&
+        columnSchemaDefinitionsMap &&
+        Object.keys(columnSchemaDefinitionsMap).length > 0,
+    );
+    const seenColumnIds = new Set<string>();
+
+    return columnIds.filter(columnId => {
+      if (typeof columnId !== 'string' || columnId.length === 0) {
+        return false;
+      }
+
+      if (seenColumnIds.has(columnId)) {
+        return false;
+      }
+
+      if (
+        canCheckExistence &&
+        columnSchemaDefinitionsMap[columnId] === undefined
+      ) {
+        return false;
+      }
+
+      seenColumnIds.add(columnId);
+
+      return true;
+    });
+  };
+
   const validateColumnsState = (columnIds: DataGridState['columns']) => {
     // Validate that the state is an array
     if (!Array.isArray(columnIds)) {
@@ -183,9 +219,11 @@ export const useDataGridStatePersistenceManager = ({
     try {
       validateColumnsState(state.columns ?? []);
     } catch {
-      state.columns = [];
-      updateState({ columns: [] });
-      console.warn('Columns state was invalid, resetting to default.');
+      const sanitizedColumns = sanitizeColumns(state.columns ?? []);
+
+      state.columns = sanitizedColumns;
+      updateState({ columns: sanitizedColumns });
+      console.warn('Columns state was invalid, removed the invalid columns.');
     }
 
     try {

--- a/plugins/main/public/components/common/data-grid/use-data-grid-columns.test.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid-columns.test.ts
@@ -47,6 +47,20 @@ describe('useDataGridColumns', () => {
     isStateMatchingDefaults: false,
   };
 
+  const renderColumns = (
+    overrides: Partial<Parameters<typeof useDataGridColumns>[0]> = {},
+  ) =>
+    renderHook(() =>
+      useDataGridColumns({
+        moduleId,
+        defaultColumns,
+        columnSchemaDefinitionsMap,
+        indexPatternExists: true,
+        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
+        ...overrides,
+      }),
+    );
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -64,18 +78,14 @@ describe('useDataGridColumns', () => {
   });
 
   it('should initialize with default columns', () => {
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
-    expect(result.current.columns).toHaveLength(0);
-    expect(result.current.columnVisibility.visibleColumns).toEqual([]);
+    expect(result.current.columnVisibility.visibleColumns).toEqual(
+      defaultColumns.map(column => column.id),
+    );
+    expect(result.current.columns.map(column => column.id)).toEqual(
+      defaultColumns.map(column => column.id),
+    );
   });
 
   it('should load persisted columns when available', () => {
@@ -87,15 +97,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     expect(result.current.columnVisibility.visibleColumns).toEqual(
       persistedColumns,
@@ -103,15 +105,7 @@ describe('useDataGridColumns', () => {
   });
 
   it('should update visible columns when setVisibleColumns is called', () => {
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
     const newVisibleColumns = ['col2', 'col3'];
 
     act(() => {
@@ -134,15 +128,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     // First columns should be the visible ones in the correct order
     expect(result.current.columnsAvailable[0].id).toBe('col2');
@@ -169,15 +155,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     act(() => {
       result.current.onColumnResize({
@@ -207,15 +185,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     act(() => {
       result.current.onColumnResize({
@@ -241,15 +211,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
     const testColumnId = 'col1';
     const testColumnWidth = 150;
 
@@ -279,15 +241,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     // First resize
     act(() => {
@@ -340,15 +294,7 @@ describe('useDataGridColumns', () => {
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
     // Resize with invalid column ID
     act(() => {
@@ -361,42 +307,183 @@ describe('useDataGridColumns', () => {
     expect(mockUpdateState).toHaveBeenCalledTimes(0);
   });
 
-  it('should handle missing columns gracefully', () => {
-    // Constants for readability
-    const validColumnId = 'col1';
-    const nonexistentColumnId = 'nonexistent';
-    const mockPersistedColumns = [validColumnId, nonexistentColumnId];
+  it('should drop the column whose field is missing and persist only the valid ones', () => {
+    const mockPersistedColumns = ['col1', 'nonexistent'];
 
-    // Mock retrieving columns that don't exist in the schema
     mockRetrieveState.mockReturnValue({
       columns: mockPersistedColumns,
       columnWidths: {},
       pageSize: 10,
     });
 
-    const { result } = renderHook(() =>
-      useDataGridColumns({
-        moduleId,
-        defaultColumns,
-        columnSchemaDefinitionsMap,
-        indexPatternExists: true,
-        dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
-      }),
-    );
+    const { result } = renderColumns();
 
-    // It should filter out non-existent columns when persisting
-    expect(result.current.columnVisibility.visibleColumns).toEqual(
-      mockPersistedColumns,
+    expect(result.current.columnVisibility.visibleColumns).toEqual(['col1']);
+    expect(result.current.columns).toEqual([
+      expect.objectContaining({ id: 'col1' }),
+    ]);
+    expect(result.current.columns.every(column => Boolean(column.id))).toBe(
+      true,
     );
 
     act(() => {
-      // This will trigger filtering of invalid columns
       result.current.columnVisibility.setVisibleColumns(mockPersistedColumns);
     });
 
-    // Only the valid column should be persisted
-    expect(mockUpdateState).toHaveBeenCalledWith({
-      columns: [validColumnId],
+    expect(mockUpdateState).toHaveBeenCalledWith({ columns: ['col1'] });
+  });
+
+  it('should not filter columns while the index pattern has not loaded yet', () => {
+    const mockPersistedColumns = ['col1', 'nonexistent'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {},
+      pageSize: 10,
     });
+
+    const { result } = renderColumns({ indexPatternExists: false });
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual(
+      defaultColumns.map(column => column.id),
+    );
+  });
+
+  it('should not filter columns while the schema definitions map is empty', () => {
+    mockRetrieveState.mockReturnValue({
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns({ columnSchemaDefinitionsMap: {} });
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual(
+      defaultColumns.map(column => column.id),
+    );
+  });
+
+  it('should keep the output unchanged when all configured fields exist (no-op regression guard)', () => {
+    const mockPersistedColumns = ['col2', 'col1'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns();
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual(
+      mockPersistedColumns,
+    );
+    expect(result.current.columns.map(column => column.id)).toEqual(
+      mockPersistedColumns,
+    );
+  });
+
+  it('should preserve persisted column widths for surviving columns after filtering', () => {
+    const mockPersistedColumns = ['col1', 'nonexistent'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {
+        col1: 275,
+      },
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns();
+
+    expect(result.current.columns).toEqual([
+      expect.objectContaining({ id: 'col1', initialWidth: 275 }),
+    ]);
+  });
+
+  it('should return empty columns and visibleColumns when all configured fields are missing', () => {
+    const mockPersistedColumns = ['nonexistent1', 'nonexistent2'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns();
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual([]);
+    expect(result.current.columns).toEqual([]);
+  });
+
+  it('should keep columnsAvailable consistent with the filtered visible set', () => {
+    const mockPersistedColumns = ['col1', 'nonexistent'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns();
+
+    const availableIds = result.current.columnsAvailable.map(
+      column => column.id,
+    );
+
+    expect(availableIds).toEqual(
+      expect.arrayContaining(['col1', 'col2', 'col3']),
+    );
+    expect(availableIds).not.toContain('nonexistent');
+    expect(result.current.columnsAvailable.length).toBe(
+      columnSchemaDefinitions.length,
+    );
+  });
+
+  it('should keep the visible columns when the persisted state was reset to an empty list', () => {
+    mockRetrieveState.mockReturnValue({
+      columns: [],
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const { result } = renderColumns();
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual(
+      defaultColumns.map(column => column.id),
+    );
+  });
+
+  it('should self-heal and show the column again once its field appears in the schema map', () => {
+    const mockPersistedColumns = ['col1', 'col3'];
+
+    mockRetrieveState.mockReturnValue({
+      columns: mockPersistedColumns,
+      columnWidths: {},
+      pageSize: 10,
+    });
+
+    const partialSchemaMap = {
+      col1: { id: 'col1', display: 'Column 1' },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ columnSchemaDefinitionsMap: schemaMap }) =>
+        useDataGridColumns({
+          moduleId,
+          defaultColumns,
+          columnSchemaDefinitionsMap: schemaMap,
+          indexPatternExists: true,
+          dataGridStatePersistenceManager: mockDataGridStatePersistenceManager,
+        }),
+      { initialProps: { columnSchemaDefinitionsMap: partialSchemaMap } },
+    );
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual(['col1']);
+
+    rerender({ columnSchemaDefinitionsMap });
+
+    expect(result.current.columnVisibility.visibleColumns).toEqual([
+      'col1',
+      'col3',
+    ]);
   });
 });

--- a/plugins/main/public/components/common/data-grid/use-data-grid-columns.ts
+++ b/plugins/main/public/components/common/data-grid/use-data-grid-columns.ts
@@ -139,7 +139,7 @@ function useDataGridColumns({
 
     const currentState = dataGridStatePersistenceManager.retrieveState();
 
-    if (!currentState.columns) {
+    if (!currentState.columns || currentState.columns.length === 0) {
       return;
     }
 
@@ -177,10 +177,25 @@ function useDataGridColumns({
     }
   };
 
+  const canFilterInvalidColumns =
+    indexPatternExists &&
+    Boolean(columnSchemaDefinitionsMap) &&
+    Object.keys(columnSchemaDefinitionsMap).length > 0;
+
+  const isKnownColumnId = (columnId: string): boolean =>
+    columnSchemaDefinitionsMap?.[columnId] !== undefined;
+
   // Don't use `useMemo` here because otherwise the DataGrid cell filter doesn't work
-  const retrieveVisibleDataGridColumns = visibleColumns.map(
-    (columnId: string) => {
-      let column = { ...columnSchemaDefinitionsMap[columnId] };
+  const effectiveVisibleColumns: string[] = canFilterInvalidColumns
+    ? visibleColumns.filter(isKnownColumnId)
+    : visibleColumns;
+
+  const retrieveVisibleDataGridColumns: tDataGridColumn[] =
+    effectiveVisibleColumns.map((columnId: string) => {
+      const definition = columnSchemaDefinitionsMap?.[columnId];
+      const column: tDataGridColumn = definition
+        ? { ...definition }
+        : { id: columnId };
       const savedColumnWidth =
         dataGridStatePersistenceManager.retrieveState().columnWidths?.[
           columnId
@@ -191,18 +206,17 @@ function useDataGridColumns({
       }
 
       return column;
-    },
-  );
+    });
 
   return {
     // This is a custom property used by the Available fields and is not part of EuiDataGrid component specification
     columnsAvailable: orderFirstMatchedColumns(
       Object.values(columnSchemaDefinitionsMap),
-      visibleColumns,
+      effectiveVisibleColumns,
     ),
     columns: retrieveVisibleDataGridColumns,
     columnVisibility: {
-      visibleColumns,
+      visibleColumns: effectiveVisibleColumns,
       setVisibleColumns: setVisibleColumnsHandler,
     },
     onColumnResize,


### PR DESCRIPTION
## Description

The Findings data grid crashed when a configured column pointed at a field missing from the index pattern. The tab showed "Something went wrong." and nothing else.

`useDataGridColumns` seeded its visible columns from `defaultColumns` without checking them against the index pattern. With no matching entry in `columnSchemaDefinitionsMap`, `{ ...columnSchemaDefinitionsMap[columnId] }` spread `undefined` into `{}`, a column with no `id` and no `schema`. `EuiDataGrid` called `.toLowerCase()` on it:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
  at EuiDataGrid (osd-ui-shared-deps.@elastic.js:161932:37)
```

Fixing that alone stopped the crash but left the grid with zero columns, so this PR covers all three places an unknown column id causes damage.

Closes https://github.com/wazuh/wazuh-dashboard-plugins/issues/9037

## Proposed Changes

**`use-data-grid-columns.ts`: build no malformed column.** A single derived `effectiveVisibleColumns` now feeds `columns`, `columnVisibility.visibleColumns` and the `columnsAvailable` ordering. Those came from different sources before, so filtering one of them would hand `EuiDataGrid` a visible id with no definition behind it. The mapper falls back to `{ id: columnId }`, which makes the empty-object shape unreachable.

The value stays derived and never returns to state, so a column comes back on its own once its field returns to the index pattern. It also stays outside `useMemo`: the comment above it warns that memoizing breaks the DataGrid cell filter, and `effectiveVisibleColumns` feeds that same array. Filtering waits until the index pattern loads, because `indexPattern.fields` arrives asynchronously and an early filter would drop every column.

**`use-data-grid-state-persistence-manager.ts`: drop the invalid column, keep the rest.** `validateColumns` threw on the first invalid id and the `catch` reset `state.columns` to `[]`, then persisted it. One stale id erased every persisted column. The comment above that block already described the intent, "to avoid clearing the entire state if only columns are invalid", so `sanitizeColumns()` now removes the invalid, empty and duplicated ids and keeps the others.

**`use-data-grid-columns.ts`: stop applying a reset list.** The two effects read `columns: []` differently. The first treats it as nothing persisted and returns. The second applied it through `setVisibleColumns`, skipping the guard in `setVisibleColumnsHandler`. That mismatch emptied the grid. The second effect now agrees with the first.

### How to Test

1. Start the environment: `cd docker/osd-dev && ./dev.sh up`.
2. Index one finding so the grid has a row to render. The grid does not mount without data:

```bash
curl -sk -u admin:admin -X POST "https://localhost:9200/wazuh-findings-v5-cloud-services/_doc?refresh=true" \
  -H "Content-Type: application/json" -d '{
    "@timestamp": "<now, ISO 8601>",
    "wazuh": { "cluster": { "name": "wazuh" }, "agent": { "name": "test.agent", "id": "001" },
               "integration": { "name": "gcp" }, "space": { "name": "standard" } },
    "event": { "action": "google.cloud.audit.test", "outcome": "success", "category": "configuration" }
  }'
```

3. Add a column with an id absent from the index pattern to `plugins/main/public/components/overview/google-cloud/events/google-cloud-columns.tsx`:

```ts
{ id: 'gcp.this_field_is_not_in_the_index_pattern' },
```

4. Open Google Cloud and click the **Findings** tab. Reaching it by URL renders a blank page, so use the tab.

Before the fix the tab shows "Something went wrong." with the `toLowerCase` `TypeError` under Details. After it, the grid renders and the invalid column is absent from the grid and from the field selector. Every valid column keeps its data and its persisted width, including `cloud.*` and `dns.*`, which live in the index pattern with no data behind them.

Revert the extra column when finished.

### Results and Evidence

**Before**:

<img width="1713" height="987" alt="image" src="https://github.com/user-attachments/assets/8640ea03-5e69-4efe-81be-84816f39b780" />

**After**:

<img width="1712" height="746" alt="image" src="https://github.com/user-attachments/assets/4d9f31ee-1dd1-46d5-9ef8-672a018c7a64" />

### Artifacts Affected

None. The changes are browser-side and contained to the shared data grid in `plugins/main`.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`yarn test:jest --testPathPattern="data-grid"` passes 65 tests across 7 suites. Reverting the source change fails 5 of them.

The new cases cover the unknown column leaving both outputs, the two loading gates, unchanged output when every field exists, preserved column widths, `columnsAvailable` consistency, a column reappearing when its field returns, and the persistence manager keeping the valid ids.

Two existing tests asserted the old behaviour and now assert the corrected contract. Calling this out so it does not read as tests bent to fit the code:

- `should initialize with default columns` expected `toHaveLength(0)` and `toEqual([])`, which contradicted its own name.
- `should reset columns when invalid column ids are found` expected every column to be dropped. It is now `should drop only the invalid columns and persist the sanitized list`.

A `renderColumns()` helper replaces 18 repeated `renderHook` blocks, which accounts for the deletion count.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
