### PR TITLE
fix: relay the Server API status through the /api/request proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 | [#9015](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9015) | Fixed the Controls tab showing 0 results by adding missing regulatory compliance requirement definitions for PCI DSS, GDPR, HIPAA, NIST 800-53, FedRAMP, ISO 27001, CMMC, TSC, and NIS2, and added an "Others" breakdown showing findings tagged with unrecognized requirement values |
 | [#9023](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9023) | Fixed sorting not working in the Server management > Security tables (Roles, Policies, Users and Roles mapping), and removed the sort affordance from columns the server API cannot sort                                                                                              |
 | [#9037](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9037) | Fixed the Findings data grid crashing and losing every column when a configured column's field does not exist in the index pattern                                                                                                                                                    |
+| [#9048](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9048) | Fixed the Server API proxy reporting rejected requests as server errors: `POST /api/request` now answers with the status the Server API returned instead of turning every 400 or 404 into a 500                                                                                       |
 
 ### Removed
 

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -639,10 +639,26 @@ export class WazuhApiCtrl {
       if ((error || {}).code && ApiErrorEquivalence[error.code]) {
         error.message = ApiErrorEquivalence[error.code];
       }
+
+      /*
+        Answer with the status the Server API returned, so a rejected request is
+        not reported as a server error. Only a real HTTP error status is used:
+        error.code also holds axios codes and Wazuh codes, which are not statuses.
+      */
+      const upstreamStatus =
+        error?.response?.status ??
+        (typeof error?.code === 'number' ? error.code : undefined);
+      const statusCode =
+        typeof upstreamStatus === 'number' &&
+        upstreamStatus >= HTTP_STATUS_CODES.BAD_REQUEST &&
+        upstreamStatus < 600
+          ? upstreamStatus
+          : HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR;
+
       return ErrorResponse(
         errorMessage,
         error.code ? `API error: ${error.code}` : 3013,
-        HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+        statusCode,
         response,
       );
     }

--- a/plugins/main/server/routes/wazuh-api-http-status.test.ts
+++ b/plugins/main/server/routes/wazuh-api-http-status.test.ts
@@ -114,9 +114,13 @@ describe('[endpoint] POST /api/request - upstream API error status mapping', () 
   };
 
   it.each`
-    upstreamStatus | message                                           | expectedStatusCode
-    ${403}         | ${'3013 - Permission denied: Resource type: *:*'} | ${HTTP_STATUS_CODES.FORBIDDEN}
-    ${401}         | ${'3000 - Invalid credentials'}                   | ${HTTP_STATUS_CODES.UNAUTHORIZED}
+    upstreamStatus | message                                            | expectedStatusCode
+    ${403}         | ${'3013 - Permission denied: Resource type: *:*'}  | ${HTTP_STATUS_CODES.FORBIDDEN}
+    ${401}         | ${'3000 - Invalid credentials'}                    | ${HTTP_STATUS_CODES.UNAUTHORIZED}
+    ${400}         | ${"'../evil' is not a 'group_names' - 'group_id'"} | ${HTTP_STATUS_CODES.BAD_REQUEST}
+    ${404}         | ${'404: Not Found'}                                | ${HTTP_STATUS_CODES.NOT_FOUND}
+    ${405}         | ${'405: Method Not Allowed'}                       | ${HTTP_STATUS_CODES.METHOD_NOT_ALLOWED}
+    ${409}         | ${'409: Conflict'}                                 | ${HTTP_STATUS_CODES.CONFLICT}
   `(
     'API error with upstream status $upstreamStatus responds $expectedStatusCode',
     async ({ upstreamStatus, message, expectedStatusCode }) => {
@@ -147,6 +151,38 @@ describe('[endpoint] POST /api/request - upstream API error status mapping', () 
       .set('Cookie', 'wz-api=default')
       .send(requestBody)
       .expect(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  });
+
+  it('does not leak a Wazuh internal error code into the status line', async () => {
+    // 3013 is a Wazuh code, not a status.
+    mockApiRequest.mockRejectedValue({
+      message: 'Unexpected error',
+      code: 3013,
+    });
+
+    await supertest(innerServer.listener)
+      .post('/api/request')
+      .set('Cookie', 'wz-api=default')
+      .send(requestBody)
+      .expect(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  });
+
+  it('keeps the axios message on a 401 so the client can refresh the token', async () => {
+    // The client spots an expired session by matching "status code 401".
+    mockApiRequest.mockRejectedValue({
+      isAxiosError: true,
+      message: 'Request failed with status code 401',
+      code: 'ERR_BAD_REQUEST',
+      response: { status: 401, data: { detail: 'Invalid credentials' } },
+    });
+
+    const response = await supertest(innerServer.listener)
+      .post('/api/request')
+      .set('Cookie', 'wz-api=default')
+      .send(requestBody)
+      .expect(HTTP_STATUS_CODES.UNAUTHORIZED);
+
+    expect(response.body.message).toContain('status code 401');
   });
 });
 


### PR DESCRIPTION
## Description

Closes #9048

The dashboard proxies Server API calls through `POST /api/request`. When the Server API rejected a request, the proxy answered `500` and put the real status inside the error message. Only `401` and `403` were passed through.

A caller could not tell "the request was rejected" from "the server failed", and any dashboard metric counting `500`s reported a healthy system as failing whenever someone typed something invalid in a form.

## Proposed Changes

`POST /api/request` now answers with the status the Server API returned, and keeps `500` for failures that have no upstream status.

- The last error branch in `makeRequest` reuses the upstream status when the error carries one.
- Only a real HTTP error status is accepted. The same field can hold an axios code such as `ERR_BAD_REQUEST` or a Wazuh code such as `3013`, and neither may reach the status line.
- The `401` and `403` branches are unchanged. `401` in particular must keep its original message, because the client recognises an expired session by matching `status code 401` on it and refreshes the token.

Error messages are identical before and after. Only the status changes.

### Results and Evidence

Same stack and same session for both columns, compared against what the manager recorded in `api.log`:

| Request | Before | After | `api.log` |
| --- | --- | --- | --- |
| `GET /agents` | 200 | 200 | 200 |
| `GET /nonexistent-route-qa` | 500 | **404** | 404 |
| `POST /groups` with `group_id: "../evil"` | 500 | **400** | 400 |
| `POST /groups` with `group_id: ""` | 500 | **400** | 400 |
| `GET /agents?offset=notanumber` | 500 | **400** | 400 |

Before:

```console
{"statusCode":500,"error":"Internal Server Error","message":"API error: ERR_BAD_REQUEST - 404: Not Found"}
HTTP=500

{"statusCode":500,"error":"Internal Server Error","message":"API error: ERR_BAD_REQUEST - '../evil' is not a 'group_names' - 'group_id'"}
HTTP=500
```

After:

```console
{"statusCode":404,"error":"Not Found","message":"API error: ERR_BAD_REQUEST - 404: Not Found"}
HTTP=404

{"statusCode":400,"error":"Bad Request","message":"API error: ERR_BAD_REQUEST - '../evil' is not a 'group_names' - 'group_id'"}
HTTP=400
```

The manager, for the same requests:

```
"GET /nonexistent-route-qa" with parameters {} and body {} done in 0.001s: 404
"POST /groups" with parameters {} and body {"group_id": "../evil"} done in 0.009s: 400
"GET /agents" with parameters {"offset": "notanumber"} and body {} done in 0.006s: 400
```

### How to Test

Run these inside the OSD container. `/api/request` takes the Server API token from the `wz-token` cookie, so the first call is needed: without it the manager sees no user and answers `401`.

```bash
# 1. open a session, storing the cookies
curl -sk -u admin:admin -c /tmp/c.txt -H 'osd-xsrf: true' -H 'Content-Type: application/json' \
  -X POST https://localhost:5601/api/login -d '{"idHost":"manager-local","force":true}'

# 2. send the cookies with every request
req() { curl -sk -u admin:admin -b /tmp/c.txt -H 'osd-xsrf: true' -H 'Content-Type: application/json' \
  -X POST https://localhost:5601/api/request -d "$1" -w ' => HTTP %{http_code}\n'; }

req '{"method":"GET","path":"/agents","body":{},"id":"manager-local"}'                      # expect 200
req '{"method":"GET","path":"/nonexistent-route-qa","body":{},"id":"manager-local"}'        # expect 404
req '{"method":"POST","path":"/groups","body":{"group_id":"../evil"},"id":"manager-local"}' # expect 400
req '{"method":"GET","path":"/agents?offset=notanumber","body":{},"id":"manager-local"}'    # expect 400
```

Cross-check the manager with `docker exec <manager> tail /var/wazuh-manager/logs/api.log`. The status the proxy returns should match the one the manager logged.

In the UI, go to Server management > Groups and try to create a group named `../evil`. The error shown must read the same as before this change.

To confirm session handling still works, let the Server API token expire (or clear the `wz-token` cookie) and keep using the app. The session must refresh as before, with no new sign-in prompt.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Six cases added to `plugins/main/server/routes/wazuh-api-http-status.test.ts`, which already covered `401`, `403` and the fallback to `500`:

- `400`, `404`, `405` and `409` are passed through.
- A numeric Wazuh code (`3013`) does not become a status; the response stays `500`.
- A `401` keeps its original message, so the client can still detect an expired session. This is the guard for the one regression that would otherwise be silent.

Suite: 10 passed.

Regression run, all passing: 67 tests across `server/routes`, `server/controllers` and `react-services/error-management`, plus 26 across the public request layer (`generic-request`, `wz-api-check`, `wz-authentication`, `wz-agents`).

Lint on the touched files is unchanged: 33 pre-existing errors before and after, none on the new lines. Prettier 2.8.8 clean.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
