### PR TITLE
Add dynamic fields to the field drift

### DIFF
--- a/docker/osd-dev/indexer/entrypoint.sh
+++ b/docker/osd-dev/indexer/entrypoint.sh
@@ -14,7 +14,7 @@ if [ -x "$INDEXER_HOME/engine/run_engine.sh" ]; then
   nohup "$INDEXER_HOME/engine/run_engine.sh" > /dev/null 2>&1 &
   echo $! > /run/wazuh-indexer/wazuh-engine.pid
 
-  ENGINE_API_SOCK="$INDEXER_HOME/engine/sockets/engine-api.sock"
+  ENGINE_API_SOCK="$INDEXER_HOME/engine/sockets/engine-api-http.sock"
   (
     while [ ! -S "$ENGINE_API_SOCK" ]; do
       sleep 3

--- a/plugins/wazuh-ai-assistant/server/tools/field-drift-canary.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/field-drift-canary.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import {
+  buildDeclaredFieldMatcher,
   checkFieldDrift,
+  DynamicTemplateEntry,
   flattenMappedFieldPaths,
   MappingClient,
   MappingsResponseBody,
@@ -19,12 +21,46 @@ function fakeLogger() {
   };
 }
 
+/** Records every `getMapping` call the canary makes, so a test can assert HOW the mapping was
+ * read (which index the dynamic-template request targeted, how many of them there were) and not
+ * only what the canary concluded from it. */
+interface RecordedCall {
+  index: string;
+  filterPath?: string;
+}
+
+/** Fake client serving two distinct request shapes, matching `field-drift-canary.ts`:
+ * - the PATTERN request for `mappings.properties`, answered from `bodyByIndexPattern`;
+ * - the single-CONCRETE-INDEX request for `mappings.dynamic_templates`, recognised by its
+ *   `filter_path` and answered from `dynamicTemplatesByIndex` (defaulting to none, which is what
+ *   every `wazuh-states-*` index looks like live and keeps the pre-existing fixtures meaningful).
+ */
 function clientReturning(
   bodyByIndexPattern: Record<string, MappingsResponseBody>,
+  dynamicTemplatesByIndex: Record<string, DynamicTemplateEntry[]> = {},
+  calls: RecordedCall[] = [],
 ): MappingClient {
   return {
     indices: {
-      getMapping({ index }: { index: string }) {
+      getMapping({
+        index,
+        filter_path: filterPath,
+      }: {
+        index: string;
+        filter_path?: string;
+      }) {
+        calls.push({ index, filterPath });
+        if (filterPath?.includes('dynamic_templates')) {
+          return Promise.resolve({
+            body: {
+              [index]: {
+                mappings: {
+                  dynamic_templates: dynamicTemplatesByIndex[index] ?? [],
+                },
+              },
+            },
+          });
+        }
         const body = bodyByIndexPattern[index];
         if (!body) {
           return Promise.reject(
@@ -35,6 +71,15 @@ function clientReturning(
       },
     },
   };
+}
+
+/** One exact-`path_match` dynamic template per path, the shape Wazuh 5.0.0's WCS index templates
+ * actually use (`"dynamic": "strict_allow_templates"`, one template per declared field). Carries
+ * no `mapping` block, matching what the canary's `filter_path` leaves of each entry. */
+function exactPathTemplates(...paths: string[]): DynamicTemplateEntry[] {
+  return paths.map(path => ({
+    [`wcs_${path.replace(/\./g, '_')}`]: { path_match: path },
+  }));
 }
 
 /** Every OTHER queried family's index pattern resolving to "no backing index" (empty body) --
@@ -246,6 +291,161 @@ test('checkFieldDrift: never throws when the client itself errors for a family -
       message =>
         message.includes('[field-drift]') &&
         message.includes('simulated indexer unreachable'),
+    ),
+  );
+});
+
+test('buildDeclaredFieldMatcher: matches exact path_match rules and simple globs, and matches nothing when there are no templates', () => {
+  const matcher = buildDeclaredFieldMatcher([
+    ...exactPathTemplates('host.os.name', 'source.ip'),
+    { wcs_wazuh_rule_compliance: { path_match: 'wazuh.rule.compliance.*' } },
+    { wcs_multi_rule: { path_match: ['event.category', 'event.outcome'] } },
+    // No path_match at all: a datatype-only template declares no specific field path.
+    { wcs_strings: { match_mapping_type: 'string' } } as never,
+  ]);
+  assert.equal(matcher('host.os.name'), true);
+  assert.equal(matcher('source.ip'), true);
+  assert.equal(matcher('wazuh.rule.compliance.pci_dss'), true);
+  assert.equal(matcher('event.category'), true);
+  assert.equal(matcher('event.outcome'), true);
+  // A glob is anchored: "wazuh.rule.compliance.*" must not swallow a sibling namespace.
+  assert.equal(matcher('wazuh.rule.level'), false);
+  assert.equal(matcher('host.os.platform'), false);
+  assert.equal(buildDeclaredFieldMatcher([])('host.os.name'), false);
+  assert.equal(buildDeclaredFieldMatcher(undefined)('host.os.name'), false);
+});
+
+test('buildDeclaredFieldMatcher: a path_match is matched as a glob, never as a regexp', () => {
+  // "." is a regexp metacharacter; treating the rule as a regexp would make it match any
+  // separator, so "check.id" would wrongly declare "check-id".
+  const matcher = buildDeclaredFieldMatcher(exactPathTemplates('check.id'));
+  assert.equal(matcher('check.id'), true);
+  assert.equal(matcher('check-id'), false);
+});
+
+test('checkFieldDrift: a field DECLARED by a dynamic template but not yet materialized in properties is not drift', async () => {
+  // Reproduces the 5.0.0 report: on a deployment with no documents, an events/findings mapping
+  // declares each WCS field as an exact-path_match dynamic template and materializes none of them
+  // under `properties`. Reading `properties` alone warned on every tool-facing field of the family.
+  const { fieldsForFamily } = await import('./catalog/get-field-values');
+  const scaFields = fieldsForFamily('sca');
+  const properties: Record<string, unknown> = {};
+  // Only "@timestamp" has ever been written, exactly like a data stream with no ingested data.
+  setMappingLeaf(properties, '@timestamp', 'date');
+  const calls: RecordedCall[] = [];
+  const client = clientReturning(
+    {
+      'wazuh-states-sca*': {
+        'wazuh-states-sca-000001': { mappings: { properties } },
+      },
+      ...OTHER_EMPTY_FAMILY_INDICES,
+    },
+    { 'wazuh-states-sca-000001': exactPathTemplates(...scaFields) },
+    calls,
+  );
+  const logger = fakeLogger();
+  await checkFieldDrift(client, logger as never);
+  assert.deepEqual(logger.warnMessages, []);
+  // The declarations were read from the concrete backing index, not from the family pattern:
+  // asking the pattern would repeat the identical template list once per backing index.
+  const dynamicTemplateCalls = calls.filter(call =>
+    call.filterPath?.includes('dynamic_templates'),
+  );
+  assert.deepEqual(
+    dynamicTemplateCalls.map(call => call.index),
+    ['wazuh-states-sca-000001'],
+  );
+});
+
+test('checkFieldDrift: reads dynamic templates from ONE index even when the family pattern resolves to many', async () => {
+  const properties = await buildScaProperties();
+  const calls: RecordedCall[] = [];
+  const client = clientReturning(
+    {
+      'wazuh-states-sca*': {
+        'wazuh-states-sca-000003': { mappings: { properties } },
+        'wazuh-states-sca-000001': { mappings: { properties } },
+        'wazuh-states-sca-000002': { mappings: { properties } },
+      },
+      ...OTHER_EMPTY_FAMILY_INDICES,
+    },
+    {},
+    calls,
+  );
+  const logger = fakeLogger();
+  await checkFieldDrift(client, logger as never);
+  const dynamicTemplateCalls = calls.filter(call =>
+    call.filterPath?.includes('dynamic_templates'),
+  );
+  assert.equal(dynamicTemplateCalls.length, 1);
+  // Sorted-first, so the same index is consulted on every restart rather than whichever one the
+  // cluster happened to enumerate first.
+  assert.equal(dynamicTemplateCalls[0].index, 'wazuh-states-sca-000001');
+});
+
+test('checkFieldDrift: a field in neither properties nor dynamic templates is still real drift', async () => {
+  // The other side of the fix: dynamic templates must not turn the canary off. "policy.id" is
+  // dropped from BOTH sources -- under "strict_allow_templates" that field could not be indexed at
+  // all, which is exactly the removal/rename this canary exists to catch.
+  const scaFields = (
+    await import('./catalog/get-field-values')
+  ).fieldsForFamily('sca');
+  const properties = await buildScaProperties(['policy.id']);
+  const client = clientReturning(
+    {
+      'wazuh-states-sca*': {
+        'wazuh-states-sca-000001': { mappings: { properties } },
+      },
+      ...OTHER_EMPTY_FAMILY_INDICES,
+    },
+    {
+      'wazuh-states-sca-000001': exactPathTemplates(
+        ...scaFields.filter(field => field !== 'policy.id'),
+      ),
+    },
+  );
+  const logger = fakeLogger();
+  await checkFieldDrift(client, logger as never);
+  assert.equal(logger.warnMessages.length, 1);
+  assert.ok(logger.warnMessages[0].includes('"policy.id"'));
+});
+
+test('checkFieldDrift: a failing dynamic-templates request skips the family at debug rather than warning on every field', async () => {
+  // Without the declared-field side there is no way to tell "not materialized yet" from "removed",
+  // and guessing would re-emit exactly the false warnings this second request removes.
+  const properties: Record<string, unknown> = {};
+  setMappingLeaf(properties, '@timestamp', 'date');
+  const client: MappingClient = {
+    indices: {
+      getMapping({
+        index,
+        filter_path: filterPath,
+      }: {
+        index: string;
+        filter_path?: string;
+      }) {
+        if (filterPath?.includes('dynamic_templates')) {
+          return Promise.reject(new Error('simulated mapping read failure'));
+        }
+        if (index === 'wazuh-states-sca*') {
+          return Promise.resolve({
+            body: {
+              'wazuh-states-sca-000001': { mappings: { properties } },
+            },
+          });
+        }
+        return Promise.resolve({ body: {} });
+      },
+    },
+  };
+  const logger = fakeLogger();
+  await assert.doesNotReject(checkFieldDrift(client, logger as never));
+  assert.deepEqual(logger.warnMessages, []);
+  assert.ok(
+    logger.debugMessages.some(
+      message =>
+        message.includes('could not check "sca"') &&
+        message.includes('simulated mapping read failure'),
     ),
   );
 });

--- a/plugins/wazuh-ai-assistant/server/tools/field-drift-canary.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/field-drift-canary.ts
@@ -10,9 +10,10 @@ import { fieldsForFamily } from './catalog/get-field-values';
  * renames or drops a field the tools still reference -- the failure mode is silent: a filter on a
  * renamed field returns zero rows forever, indistinguishable from "no matching data" (exactly the
  * class of bug that affects the ruleset tools too). This
- * module runs ONE bounded live `_mapping` check per process start and logs a warning for every
- * catalog/allowlist field that is no longer mapped, so that drift shows up in the server log on
- * the day it happens instead of months later in a QA report.
+ * module runs ONE bounded live `_mapping` check per process start (per family: the pattern's
+ * `properties`, plus one index's `dynamic_templates` declarations -- see `checkFamily`) and logs a
+ * warning for every catalog/allowlist field that is neither mapped nor declared, so that drift
+ * shows up in the server log on the day it happens instead of months later in a QA report.
  *
  * Deliberately NOT a scheduled job: no timer, no interval, no retry loop. `runFieldDriftCanary`
  * fires once from `server/plugin.ts`'s `start()`, races against a fixed timeout, and swallows
@@ -91,14 +92,28 @@ const QUERIED_FAMILIES: ReadonlyArray<{
   },
 ];
 
+/** One `mappings.dynamic_templates` entry as OpenSearch returns it: a single-key object whose key
+ * is the template NAME (e.g. `wcs_host_os_name`) and whose value carries the matching rules. Only
+ * `path_match` is modelled -- it is the one rule that names a concrete field PATH, which is what
+ * `buildDeclaredFieldMatcher` needs; the other rules (`match`, `match_mapping_type`, and their
+ * negated forms) describe a field's name fragment or datatype, never a full path, so they can
+ * never establish that a specific catalog path is declared. */
+export interface DynamicTemplateEntry {
+  [templateName: string]: {
+    path_match?: string | string[];
+  };
+}
+
 /** Minimal shape of the OpenSearch `_mapping` response this canary needs -- one entry per
  * concrete index behind the pattern, each with a (possibly absent, on a brand-new/empty pattern)
- * `mappings.properties` tree. Kept narrow and structural rather than importing a full client
- * response type, so a mock in tests needs no more than this shape. */
+ * `mappings.properties` tree and the index's `mappings.dynamic_templates` list. Kept narrow and
+ * structural rather than importing a full client response type, so a mock in tests needs no more
+ * than this shape. */
 export interface MappingsResponseBody {
   [indexName: string]: {
     mappings?: {
       properties?: Record<string, unknown>;
+      dynamic_templates?: DynamicTemplateEntry[];
     };
   };
 }
@@ -121,6 +136,114 @@ export interface MappingClient {
  * per index cuts that payload (and the `JSON.parse` cost) down to just what
  * `flattenMappedFieldPaths` actually walks, across all `QUERIED_FAMILIES` on every process start. */
 const MAPPING_FILTER_PATH = '*.mappings.properties';
+
+/** Second, narrower request: only the `path_match` rule of every `dynamic_templates` entry -- see
+ * `checkFamily` for why the declared-but-not-yet-materialized fields matter and
+ * `DYNAMIC_TEMPLATES_SOURCE_COUNT` for why this is asked of ONE index rather than the pattern.
+ * Measured live on 5.0.0, one findings backing index: 311 KB for the whole `dynamic_templates`
+ * list, 209 KB filtered down to `path_match` alone. The deeper-looking `*.mappings
+ * .dynamic_templates.*.*.path_match` returns NOTHING -- `filter_path` already walks the array
+ * transparently, so the single `*` after `dynamic_templates` is the template-name wildcard. */
+const DYNAMIC_TEMPLATES_FILTER_PATH =
+  '*.mappings.dynamic_templates.*.path_match';
+
+/** How many of a family's concrete indices are asked for their `dynamic_templates` list.
+ *
+ * ONE, deliberately. Every backing index behind a family pattern is created from the same
+ * composable index template, so their `dynamic_templates` lists are identical -- asking the
+ * pattern would just return the same ~2,300-entry list once per backing index. Measured live on a
+ * populated 5.0.0 cluster (8 backing indices), for `wazuh-findings-v5*`: 1.78 MB for the pattern
+ * vs. 209 KB for a single index, per family, on every process start. The index picked is the
+ * first in sorted order, so the same one is read on every restart and the check stays reproducible
+ * rather than depending on the order the cluster happens to enumerate indices in.
+ *
+ * The cost of the shortcut: an index still backed by a SUPERSEDED template version (an upgrade
+ * that has not rolled its data streams over yet) declares that older field set, which can hide a
+ * genuine removal for one generation. That is the same direction this whole canary already errs
+ * in -- toward silence rather than a false alarm -- and it is bounded by the next rollover. */
+const DYNAMIC_TEMPLATES_SOURCE_COUNT = 1;
+
+/** Turns one `path_match` rule into a matcher. OpenSearch matches `path_match` with simple glob
+ * semantics -- `*` is the only metacharacter -- so every other regexp-special character is
+ * escaped and `*` alone becomes `.*`, anchored at both ends. */
+function pathMatchToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, character =>
+    character === '*' ? '.*' : `\\${character}`,
+  );
+  return new RegExp(`^${escaped}$`);
+}
+
+/** Builds "is this field path DECLARED by a dynamic template?" from one index's
+ * `dynamic_templates` list.
+ *
+ * This is the whole point of the second request: on Wazuh 5.0.0 the events/findings templates are
+ * `"dynamic": "strict_allow_templates"` and declare each WCS field as its own exact-`path_match`
+ * template (2,345 of them on findings, 2,299 on events) rather than as a `properties` entry. A
+ * leaf therefore only appears under `mappings.properties` once a document carrying it has been
+ * indexed -- so on a deployment with no agents, or on any index category that has simply not seen
+ * that field yet, `properties` legitimately lacks it while the mapping still fully declares it.
+ * Reading `properties` alone reports those as drift (the false positives this matcher removes),
+ * and it stays a real check: under `strict_allow_templates` a field in neither `properties` nor
+ * `dynamic_templates` cannot be indexed at all, so a genuinely dropped or renamed field is still
+ * missing from BOTH sources and still warns.
+ *
+ * Returns a predicate rather than a Set because `path_match` may contain a glob; an index with no
+ * `dynamic_templates` at all (every `wazuh-states-*` index today) yields a predicate that is
+ * always false, leaving that family's check exactly as it was. */
+export function buildDeclaredFieldMatcher(
+  entries: readonly DynamicTemplateEntry[] | undefined,
+): (path: string) => boolean {
+  const exactPaths = new Set<string>();
+  const globs: RegExp[] = [];
+  for (const entry of entries ?? []) {
+    for (const definition of Object.values(entry ?? {})) {
+      const pathMatch = definition?.path_match;
+      if (!pathMatch) {
+        continue;
+      }
+      for (const rule of Array.isArray(pathMatch) ? pathMatch : [pathMatch]) {
+        if (rule.includes('*')) {
+          globs.push(pathMatchToRegExp(rule));
+        } else {
+          exactPaths.add(rule);
+        }
+      }
+    }
+  }
+  if (exactPaths.size === 0 && globs.length === 0) {
+    return () => false;
+  }
+  return path => exactPaths.has(path) || globs.some(glob => glob.test(path));
+}
+
+/** Fetches `DYNAMIC_TEMPLATES_SOURCE_COUNT` index's dynamic templates and returns the matcher for
+ * them. Any failure PROPAGATES to `checkFieldDrift`'s per-family catch, which skips the family
+ * with a DEBUG line: without the declared-field side, this canary cannot tell a not-yet-
+ * materialized field from a removed one, and guessing would mean re-emitting exactly the false
+ * warnings this request exists to suppress. Skipping one startup's check for one family is the
+ * cheaper failure -- the same trade-off the properties request already makes. */
+async function fetchDeclaredFieldMatcher(
+  client: MappingClient,
+  indexNames: string[],
+): Promise<(path: string) => boolean> {
+  const sources = [...indexNames]
+    .sort()
+    .slice(0, DYNAMIC_TEMPLATES_SOURCE_COUNT);
+  const entries: DynamicTemplateEntry[] = [];
+  for (const source of sources) {
+    // At most DYNAMIC_TEMPLATES_SOURCE_COUNT (currently one) request; the loop exists so the
+    // constant, not the code shape, decides how many indices are consulted.
+    // eslint-disable-next-line no-await-in-loop
+    const response = await client.indices.getMapping({
+      index: source,
+      filter_path: DYNAMIC_TEMPLATES_FILTER_PATH,
+    });
+    for (const indexBody of Object.values(response.body ?? {})) {
+      entries.push(...(indexBody.mappings?.dynamic_templates ?? []));
+    }
+  }
+  return buildDeclaredFieldMatcher(entries);
+}
 
 /** Flattens one index's `mappings.properties` tree into the set of dot-path field names it maps --
  * the same shape `common/field-catalog.ts`'s `path` entries use. Recurses into nested
@@ -168,6 +291,12 @@ interface FamilyDriftResult {
  * the pattern currently resolves to zero indices -- an empty environment/family is not drift, it
  * is simply nothing to check yet.
  *
+ * A field is "present" if it is materialized under `mappings.properties` on any backing index OR
+ * declared by a `dynamic_templates` `path_match` -- see `buildDeclaredFieldMatcher` for why the
+ * second source is required (on 5.0.0's `strict_allow_templates` events/findings templates almost
+ * every field is declared that way and only materializes once a document carries it, so
+ * `properties` alone reports every tool-facing field of an unpopulated deployment as drift).
+ *
  * WCS is the schema, not what the live index TEMPLATE actually maps -- measured live,
  * `events.main` alone has 2,121 WCS fields the template never maps, none of which any tool
  * touches. Treating those as drift would produce ~2,100 false "drift" warnings on a perfectly
@@ -203,10 +332,16 @@ async function checkFamily(
     // No backing index yet (pattern matched nothing) -- nothing to compare against, not drift.
     return { toolMissing: [], catalogMissing: [] };
   }
+  const isDeclared = await fetchDeclaredFieldMatcher(
+    client,
+    Object.keys(response.body ?? {}),
+  );
+  const isPresent = (path: string): boolean =>
+    mapped.has(path) || isDeclared(path);
   const toolFilterFieldSet = new Set(toolFilterFields);
-  const toolMissing = toolFilterFields.filter(path => !mapped.has(path)).sort();
+  const toolMissing = toolFilterFields.filter(path => !isPresent(path)).sort();
   const catalogMissing = catalogFields
-    .filter(path => !toolFilterFieldSet.has(path) && !mapped.has(path))
+    .filter(path => !toolFilterFieldSet.has(path) && !isPresent(path))
     .sort();
   return { toolMissing, catalogMissing };
 }


### PR DESCRIPTION
## Description

On a 5.0.0 Central Components install the AI Assistant's startup field-drift check reports 31 tool-facing fields as missing from the live mapping, on every dashboard start, on every node — 960 occurrences in a single QA run, the most frequent line in the whole dashboard log, and enough to fail `test_02_restart::test_check_logs[Dashboard]`:

```
{"type":"log","tags":["warning","plugins","wazuhAiAssistant","field-drift"],"message":"[field-drift] \"events.findings\" (wazuh-findings-v5*): tool-facing field \"host.os.name\" is no longer present in the live mapping."}
```

The catalog is not out of sync — the mapping is read incompletely. The 5.0.0 `wazuh-events-v5*` / `wazuh-findings-v5*` index templates are `"dynamic": "strict_allow_templates"` and declare almost every WCS field as its own exact-`path_match` **dynamic template** (2,345 entries on findings, 2,299 on events) rather than as a `properties` entry. A leaf only materializes under `mappings.properties` once a document carrying it is indexed, so on a deployment with no agents — and on any index category that has simply not seen that field yet — the field is legitimately absent from `properties` while the mapping still fully declares it. The canary read `properties` only, so it reported every tool-facing field of those two families as drift.

Reading the declarations as well keeps the check honest rather than muting it: under `strict_allow_templates` a field present in neither `properties` nor `dynamic_templates` cannot be indexed at all, so a genuinely dropped or renamed field is still missing from both sources and still warns.

Closes #9073

## Proposed Changes

`server/tools/field-drift-canary.ts` — a field now counts as present when it is materialized under `mappings.properties` **or** declared by a `dynamic_templates` `path_match`:

- Added `DynamicTemplateEntry` and `mappings.dynamic_templates` to `MappingsResponseBody`.
- Added `buildDeclaredFieldMatcher()` (exported for tests): turns an index's `dynamic_templates` list into an "is this path declared?" predicate. Accepts `path_match` as a string or an array, and supports glob rules through `pathMatchToRegExp()` — OpenSearch glob semantics, `*` as the only metacharacter, every other regexp-special character escaped and the pattern anchored at both ends, so `check.id` never matches `check-id`. An index with no dynamic templates (every `wazuh-states-*` index today) yields an always-false predicate, leaving those families' checks byte-for-byte as they were.
- Added `fetchDeclaredFieldMatcher()`, which reads the declarations from **one** concrete index rather than from the family pattern. Every backing index behind a family is created from the same composable template, so their lists are identical; asking the pattern would return the same ~2,300-entry list once per backing index. The index is picked as the sorted-first key of the properties response, so no extra `_resolve/index` round trip is needed and the same index is consulted on every restart.
- New `filter_path`: `*.mappings.dynamic_templates.*.path_match`. (`filter_path` already walks the array transparently, so the deeper-looking `*.mappings.dynamic_templates.*.*.path_match` returns nothing.)
- A failure of the declarations request propagates into the existing per-family `catch`, which skips that family with a DEBUG line. Without the declared-field side there is no way to tell "not materialized yet" from "removed", and guessing would re-emit exactly the warnings this PR removes — the same silence-over-false-alarm trade-off the properties request already makes.
- `DYNAMIC_TEMPLATES_SOURCE_COUNT = 1` documents the single-index shortcut and its one cost: a backing index still on a superseded template version (an upgrade whose data streams have not rolled over yet) declares the older field set and can hide a genuine removal for one generation, bounded by the next rollover.

No change to the tool surface, the field catalog, `FIELD_LOCATIONS`, or the aggregation allowlist: this PR changes only how the live mapping is read.

### Results and Evidence

The change is server-log-only, so evidence is measurements against a live 5.0.0 indexer (`docker/osd-dev`, populated: 8 findings + 8 events backing indices).

**Root cause, straight from the live mapping.** `host.os` exists as a bare node with no children, while every WCS field is declared as a dynamic template:

```
$ curl -sk -u admin:admin 'https://localhost:9200/.ds-wazuh-findings-v5-other-000001/_mapping'
dynamic: "strict_allow_templates"
dynamic_templates: 2345 entries, all with an exact path_match (no wildcards)
host:   {"properties":{... "os":{"type":"object"} ...}}      <- no host.os.name
source: {"properties":{"as":{...},"geo":{...},"nat":{...},"user":{...}}}   <- no source.ip

path_match lookup: host.os.name IN-DT | host.os.platform IN-DT | source.ip IN-DT |
                   wazuh.agent.id IN-DT | wazuh.rule.compliance.pci_dss IN-DT | event.category IN-DT
```

**Before / after**, replaying the canary's exact request shapes against that cluster with the real `fieldsForFamily()` lists:

```
family                        tool fields   WARN before   WARN after
wazuh-findings-v5*                     27             4            0
wazuh-events-v5*                       11             2            0
wazuh-states-sca*                       7             0            0
wazuh-states-inventory-ports*           7             0            0

before (findings): host.os.name, host.os.platform, source.ip, wazuh.rule.category
before (events):   host.os.name, host.os.platform
```

This environment has ingested data, which is why only 4 + 2 fields are missing here; on the QA deployment with no agents nothing is materialized and the same code path produces the reported 20 + 11 lines (the findings list is capped at `MAX_MISSING_FIELDS_LOGGED_PER_FAMILY = 20`, so all 27 were missing there). Both sets go to zero with the fix, and the state families — which have no dynamic templates at all — are unaffected in both directions.

**Payload cost of the second request**, per family, once per process start:

```
                                        pattern (8 indices)   single index
properties only (unchanged)                        103.9 KB              —
dynamic_templates, full                             2.59 MB        311.1 KB
dynamic_templates, path_match only (chosen)         1.78 MB        209.4 KB
wazuh-states-* families                                   —            2  B
```

**Test run:**

```
PASS node server/tools/field-drift-canary.test.ts
  ✓ buildDeclaredFieldMatcher: matches exact path_match rules and simple globs, and matches nothing when there are no templates
  ✓ buildDeclaredFieldMatcher: a path_match is matched as a glob, never as a regexp
  ✓ checkFieldDrift: a field DECLARED by a dynamic template but not yet materialized in properties is not drift
  ✓ checkFieldDrift: reads dynamic templates from ONE index even when the family pattern resolves to many
  ✓ checkFieldDrift: a field in neither properties nor dynamic templates is still real drift
  ✓ checkFieldDrift: a failing dynamic-templates request skips the family at debug rather than warning on every field
Tests: 14 passed, 14 total          (field-drift-canary.test.ts)

Test Suites: 133 passed, 133 total  (full wazuh-ai-assistant suite)
Tests:       2572 passed, 2572 total
eslint exit=0 · prettier: All matched files use Prettier code style
yarn typecheck: 0 errors in the touched files (remaining output is pre-existing, in wazuh-core and OSD core)
```

### Artifacts Affected

- `plugins/wazuh-ai-assistant` (`wazuhAiAssistant`), server side only — `server/tools/field-drift-canary.ts`.
- No public/browser bundle, no route, no API contract change.
- Runtime effect: two `_mapping` requests per queried family at plugin start instead of one, both bounded by the existing 10 s canary timeout.

### Configuration Changes

None. No new settings, no changed defaults, no migration. The check remains a fire-and-forget, once-per-process-start canary with no timer and no retry.

### Documentation Updates

None required — the behaviour is internal to the startup canary and is documented inline in `field-drift-canary.ts` (`DYNAMIC_TEMPLATES_FILTER_PATH`, `DYNAMIC_TEMPLATES_SOURCE_COUNT`, `buildDeclaredFieldMatcher`, and the updated `checkFamily` and module doc comments). `CHANGELOG.md` gained one entry under `### Fixed` linking issue #9073.

### Tests Introduced

Six cases added to `server/tools/field-drift-canary.test.ts` (colocated, as per repo convention), plus a fake client extended to serve the two distinct request shapes and record which index each one targeted:

- `buildDeclaredFieldMatcher` over exact `path_match`, an array `path_match`, an anchored glob, and a template with no `path_match` at all (a datatype-only template declares no specific path); empty and `undefined` template lists yield an always-false predicate.
- `path_match` is matched as a glob and never as a regexp (`check.id` must not declare `check-id`).
- Regression for this issue: a mapping where only `@timestamp` is materialized and every tool field is declared through dynamic templates produces **no** warnings — and the declarations are read from the concrete backing index, asserted on the recorded call, not from the family pattern.
- Single-index sourcing when the pattern resolves to three backing indices: exactly one dynamic-templates request, against the sorted-first index.
- The check still fires: a field absent from both `properties` and `dynamic_templates` still produces exactly one WARN naming it.
- A failing dynamic-templates request produces no warnings and one DEBUG line for the skipped family.

The pre-existing cases (catalog-only demotion to DEBUG, empty pattern, per-family error isolation, the `properties`-subset fixture) are unchanged and still pass, since a fixture with no dynamic templates now exercises the untouched path.

## Review Checklist

Manual verification performed against a live 5.0.0 indexer (`docker/osd-dev`, populated with two agents): mapping inspection confirming `strict_allow_templates` + 2,345/2,299 exact-`path_match` templates, and a before/after replay of the canary's requests showing warnings drop from 4 + 2 to 0 with the state families unchanged.

Still worth covering before final approval: a dashboard start on a genuinely empty deployment (Manager + Indexer + Dashboard, no agents — the QA scenario), confirming zero `[field-drift]` warnings.

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none introduced)
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
