### PR TITLE
fix(check-updates): send Accept-Encoding: gzip, br on CTI console requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,8 @@ because Jest needs OSD's `setup_node_env`. See
 [`docs/dev/run-tests.md`](docs/dev/run-tests.md).
 
 ```bash
-# 1) Bring up the environment (from repo root)
+# 1) Bring up the environment (from repo root) if is not running already.
+docker ps # find the osd-dev-* container
 cd docker/osd-dev && ./dev.sh up
 
 # 2) Attach to the OSD container

--- a/plugins/wazuh-check-updates/server/services/cti-registration/token.test.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/token.test.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import { getCtiToken, pollCtiToken } from './token';
+import { getWazuhCheckUpdatesServices } from '../../plugin-services';
+
+jest.mock('axios');
+jest.mock('../../plugin-services', () => ({
+  getWazuhCheckUpdatesServices: jest.fn(),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedGetWazuhCheckUpdatesServices =
+  getWazuhCheckUpdatesServices as jest.Mock;
+
+describe('token', () => {
+  const logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+
+  beforeEach(() => {
+    logger.error.mockClear();
+    mockedGetWazuhCheckUpdatesServices.mockReturnValue({ logger });
+    mockedAxios.post.mockReset();
+  });
+
+  test('getCtiToken sends Accept-Encoding: gzip, br and preserves Content-Type', async () => {
+    mockedAxios.post.mockResolvedValue({ data: {} });
+
+    await getCtiToken('client-id');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept-Encoding': 'gzip, br',
+        },
+      }),
+    );
+  });
+
+  test('pollCtiToken sends Accept-Encoding: gzip, br and preserves validateStatus', async () => {
+    mockedAxios.post.mockResolvedValue({ data: {} });
+
+    await pollCtiToken('client-id', 'device-code');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept-Encoding': 'gzip, br',
+        },
+        validateStatus: expect.any(Function),
+      }),
+    );
+
+    const { validateStatus } = mockedAxios.post.mock.calls[0][2] as {
+      validateStatus: (status: number) => boolean;
+    };
+    expect(validateStatus(200)).toBe(true);
+    expect(validateStatus(400)).toBe(true);
+    expect(validateStatus(500)).toBe(false);
+  });
+});

--- a/plugins/wazuh-check-updates/server/services/cti-registration/token.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/token.ts
@@ -7,6 +7,11 @@ import { getWazuhCheckUpdatesServices } from '../../plugin-services';
 import { CtiConfigurationError, getCtiConsoleBaseUrl } from './cti-console-url';
 import { fetchClusterUuid } from './cluster-uuid';
 
+const CTI_CONSOLE_REQUEST_HEADERS = {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  'Accept-Encoding': 'gzip, br',
+};
+
 /**
  * OAuth `client_id` (environment UID): optional body override, then
  * `WAZUH_CTI_CLIENT_ID`, otherwise cluster `cluster_uuid` from `GET /`.
@@ -46,9 +51,7 @@ export const getCtiToken = async (clientId: string): Promise<any> => {
     const body = new URLSearchParams({ client_id: clientId }).toString();
 
     const response = await axios.post(url, body, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
+      headers: CTI_CONSOLE_REQUEST_HEADERS,
     });
 
     return response.data;
@@ -87,9 +90,7 @@ export const pollCtiToken = async (
     }).toString();
 
     const response = await axios.post<Record<string, unknown>>(url, body, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
+      headers: CTI_CONSOLE_REQUEST_HEADERS,
       validateStatus: status =>
         (status >= 200 && status < 300) || status === 400,
     });


### PR DESCRIPTION
## Description

Every request the dashboard makes against the CTI Console must include the
compression acceptance header `Accept-Encoding: gzip, br`. The two outbound
HTTP calls this repo makes directly to the CTI Console (the OAuth device
authorization token endpoint, used for CTI registration) relied on axios'
implicit default `Accept-Encoding` header rather than sending the exact value
expected by the CTI service.

## Proposed Changes

- Added an explicit `Accept-Encoding: gzip, br` header (alongside the existing
  `Content-Type`) to both CTI Console token requests in
  `plugins/wazuh-check-updates/server/services/cti-registration/token.ts`
  (`getCtiToken` and `pollCtiToken`), consolidated into a single
  `CTI_CONSOLE_REQUEST_HEADERS` constant so both call sites stay in sync.
- All other CTI-adjacent server code (update checks, content-manager
  subscription/update, consumers) talks to the indexer's own OpenSearch
  Content Manager plugin over the OpenSearch JS client transport, not
  directly to the CTI Console over HTTP, so it is unaffected by this change
  and out of scope here.

### Results and Evidence

<!-- Pending: validate the outgoing request against the CTI DEV endpoint
(VPN required) per the issue's curl example, and attach the evidence here
before marking this PR ready for review. -->

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- Added `plugins/wazuh-check-updates/server/services/cti-registration/token.test.ts`
  (previously missing at the service layer). Mocks `axios` and asserts that
  both `getCtiToken` and `pollCtiToken` call `axios.post` with
  `Accept-Encoding: gzip, br` and the existing `Content-Type` header, and
  that `pollCtiToken`'s `validateStatus` behavior (200/400 accepted, others
  rejected) is preserved.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
