### PR TITLE
fix(management): filter agent reported configuration by cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,6 @@
 | [#9023](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9023) | Fixed sorting not working in the Server management > Security tables (Roles, Policies, Users and Roles mapping), and removed the sort affordance from columns the server API cannot sort                                                                                              |
 | [#9037](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9037) | Fixed the Findings data grid crashing and losing every column when a configured column's field does not exist in the index pattern                                                                                                                                                    |
 | [#9048](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9048) | Fixed the Server API proxy reporting rejected requests as server errors: `POST /api/request` now answers with the status the Server API returned instead of turning every 400 or 404 into a 500                                                                                       |
-| [#9101](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9101) | Fixed the agent Configuration view reading another cluster's agent report when agent IDs collide across clusters, by filtering the reported configuration by cluster name in addition to agent ID                                                                                     |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 | [#9023](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9023) | Fixed sorting not working in the Server management > Security tables (Roles, Policies, Users and Roles mapping), and removed the sort affordance from columns the server API cannot sort                                                                                              |
 | [#9037](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9037) | Fixed the Findings data grid crashing and losing every column when a configured column's field does not exist in the index pattern                                                                                                                                                    |
 | [#9048](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9048) | Fixed the Server API proxy reporting rejected requests as server errors: `POST /api/request` now answers with the status the Server API returned instead of turning every 400 or 404 into a 500                                                                                       |
+| [#9101](https://github.com/wazuh/wazuh-dashboard-plugins/issues/9101) | Fixed the agent Configuration view reading another cluster's agent report when agent IDs collide across clusters, by filtering the reported configuration by cluster name in addition to agent ID                                                                                     |
 
 ### Removed
 

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/agent-config-service.test.ts
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/agent-config-service.test.ts
@@ -5,9 +5,14 @@ import {
   getAgentReportedConfiguration,
 } from './agent-config-service';
 import { getDataPlugin } from '../../../../../../kibana-services';
+import { AppState } from '../../../../../../react-services/app-state';
 
 jest.mock('../../../../../../kibana-services', () => ({
   getDataPlugin: jest.fn(),
+}));
+
+jest.mock('../../../../../../react-services/app-state', () => ({
+  AppState: { getClusterInfo: jest.fn() },
 }));
 
 /* The chainable setters return the search source itself, so it needs an
@@ -42,6 +47,9 @@ const mockDataPlugin = (fetchResult: unknown) => {
 describe('getAgentReportedConfiguration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (AppState.getClusterInfo as jest.Mock).mockReturnValue({
+      cluster: 'test-cluster',
+    });
     /* The cache outlives a test, so each one starts from an unread report. */
     clearAgentReportedConfigurationCache();
   });
@@ -83,14 +91,21 @@ describe('getAgentReportedConfiguration', () => {
     });
   });
 
-  it('queries the index by agent id', async () => {
+  it('queries the index by agent id and cluster name', async () => {
     const { searchSource } = mockDataPlugin({ hits: { hits: [] } });
 
     await getAgentReportedConfiguration('002');
 
     expect(searchSource.setField).toHaveBeenCalledWith('query', {
       language: 'lucene',
-      query: { term: { 'wazuh.agent.id': '002' } },
+      query: {
+        bool: {
+          must: [
+            { term: { 'wazuh.agent.id': '002' } },
+            { term: { 'wazuh.cluster.name': 'test-cluster' } },
+          ],
+        },
+      },
     });
   });
 
@@ -191,7 +206,14 @@ describe('getAgentReportedConfiguration', () => {
       expect(searchSource.fetch).toHaveBeenCalledTimes(2);
       expect(searchSource.setField).toHaveBeenLastCalledWith('query', {
         language: 'lucene',
-        query: { term: { 'wazuh.agent.id': '002' } },
+        query: {
+          bool: {
+            must: [
+              { term: { 'wazuh.agent.id': '002' } },
+              { term: { 'wazuh.cluster.name': 'test-cluster' } },
+            ],
+          },
+        },
       });
     });
 

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/agent-config-service.ts
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/agent-config-service.ts
@@ -11,6 +11,7 @@
  */
 
 import { getDataPlugin } from '../../../../../../kibana-services';
+import { AppState } from '../../../../../../react-services/app-state';
 import { WAZUH_AGENT_CONFIG_PATTERN } from '../../../../../../../common/constants';
 
 /**
@@ -49,17 +50,28 @@ const readAgentReportedConfiguration = async (
     WAZUH_AGENT_CONFIG_PATTERN,
   );
   const searchSource = await getDataPlugin().search.searchSource.create();
+  const clusterName = AppState.getClusterInfo().cluster;
 
   /* The whole document is read instead of trimming _source to the
   configuration subtree: it is a single configuration report, not a result set,
   and reading it whole keeps this independent of how the fields are mapped. */
+  // TODO: filter via the PatternDataSource/PatternDataSourceFilterManager
+  // cluster-filter helper (see other wazuh.agent.* indices) instead of a
+  // raw term here, if this read is ever migrated onto that framework.
   const response = await searchSource
     .setParent(undefined)
     .setField('index', indexPattern)
     .setField('size', 1)
     .setField('query', {
       language: 'lucene',
-      query: { term: { 'wazuh.agent.id': agentId } },
+      query: {
+        bool: {
+          must: [
+            { term: { 'wazuh.agent.id': agentId } },
+            { term: { 'wazuh.cluster.name': clusterName } },
+          ],
+        },
+      },
     })
     .fetch();
 


### PR DESCRIPTION
## Description

Closes #8851

`getAgentReportedConfiguration` reads an agent's last-reported configuration
from the `wazuh-agent-config*` index by matching `wazuh.agent.id` alone.
Agent IDs are only unique within a single manager/cluster, not globally, so
on a multi-cluster indexer another cluster's agent reusing the same ID can
shadow the intended document. A module the agent is actually reporting (for
example the `command` wodle reported in #9101) can then appear absent
in the Configuration view even though it is running and being indexed
correctly.

## Proposed Changes

- Added a `wazuh.cluster.name` term to the query, alongside the existing
  `wazuh.agent.id` term, sourced from the currently selected Server API's
  cluster info (`AppState.getClusterInfo().cluster`).
- This brings `agent-config-service.ts` in line with every other
  agent-scoped index already filtered this way (FIM, vulnerabilities,
  system-inventory, agent-stats).
- Left a `TODO` noting the raw query could eventually move onto the app's
  `PatternDataSource` framework; investigated that path and concluded it's
  not a good fit for this single cached point-read (it's built for
  paginated, live-filtered listing views wired to the global OSD filter
  bar, and would risk mutating shared filter-bar state for a background,
  non-visual helper) — kept as documented follow-up context instead of
  code.

### Results and Evidence

No UI/visual change — the fix is scoped to the query built by
`agent-config-service.ts`, so the Configuration view renders the same way
it already does once the correct document is fetched. Reproducing the
original defect requires a multi-cluster indexer setup with a colliding
agent ID across clusters, which wasn't available to verify end-to-end;
verification here is the updated unit test below, which pins the exact
query shape sent to `searchSource`.

### Tests Introduced

Updated `agent-config-service.test.ts`:

- Mocked `AppState.getClusterInfo()`.
- Updated the two query-shape assertions to expect a combined
  `bool`/`must` query with both the `wazuh.agent.id` and
  `wazuh.cluster.name` terms.

All 12 tests in the suite pass; `yarn lint` is clean on the touched files.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

