### PR TITLE
Add setting to override the CTI API base URL

### DIFF
--- a/docker/imposter/cti/README.md
+++ b/docker/imposter/cti/README.md
@@ -76,3 +76,19 @@ curl -i -X POST http://imposter:8080/api/v1/platform/environments/token \
   -H 'X-Mock-Scenario: expired_token' \
   -d 'grant_type=urn:ietf:params:oauth:grant-type:device_code&client_id=a17c21ed&device_code=mock_device_code_123'
 ```
+
+## Pointing the dashboard at this mock
+
+The CTI Console base URL defaults to the compiled constant
+(`WAZUH_CTI_CONSOLE_BASE_URL` in
+`plugins/wazuh-check-updates/common/constants.ts`). Override it in
+`opensearch_dashboards.yml` to target this mock — or any other CTI environment:
+
+```yml
+wazuh_check_updates.ctiApiUrl: 'http://imposter:8080'
+```
+
+The setting is absent from the shipped configuration file, so without it the
+device flow keeps going to the default CTI environment. Only the `http` and
+`https` schemes are accepted; an invalid value stops the dashboard at startup.
+A restart is required for a change to take effect.

--- a/plugins/wazuh-check-updates/common/constants.ts
+++ b/plugins/wazuh-check-updates/common/constants.ts
@@ -49,7 +49,10 @@ export const CTI_REGISTRATION_SUCCESS_STATUS_MESSAGE =
 /** Wazuh Cloud portal / product URL. Uses `#` in the UI until set. */
 export const WAZUH_CLOUD_PORTAL_HREF = '';
 
-/** Base URL of the Wazuh Cloud CTI Console API (server-side OAuth device flow). */
+/**
+ * Default base URL of the Wazuh Cloud CTI Console API (server-side OAuth device
+ * flow). Overridable with the `wazuh_check_updates.ctiApiUrl` setting.
+ */
 export const WAZUH_CTI_CONSOLE_BASE_URL = 'https://api.pre.cloud.wazuh.com';
 
 /**

--- a/plugins/wazuh-check-updates/server/index.ts
+++ b/plugins/wazuh-check-updates/server/index.ts
@@ -3,6 +3,7 @@ import {
   PluginConfigDescriptor,
   PluginInitializerContext,
 } from '../../../src/core/server';
+import { WAZUH_CTI_CONSOLE_BASE_URL } from '../common/constants';
 import { WazuhCheckUpdatesPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
@@ -15,6 +16,15 @@ export function plugin(initializerContext: PluginInitializerContext) {
 export const configSchema = schema.object({
   ctiRegistrationUiEnabled: schema.boolean({ defaultValue: false }),
   ctiRegistrationStatusPollIntervalSec: schema.number({ defaultValue: 30 }),
+  /**
+   * Base URL of the CTI API. Not present in the shipped configuration file:
+   * override it only to target another CTI environment (pre, production or the
+   * local Imposter mock, see `docker/imposter/cti/README.md`).
+   */
+  ctiApiUrl: schema.uri({
+    scheme: ['http', 'https'],
+    defaultValue: WAZUH_CTI_CONSOLE_BASE_URL,
+  }),
 });
 
 export type WazuhCheckUpdatesPluginConfigType = TypeOf<typeof configSchema>;

--- a/plugins/wazuh-check-updates/server/plugin.ts
+++ b/plugins/wazuh-check-updates/server/plugin.ts
@@ -1,3 +1,4 @@
+import { first } from 'rxjs/operators';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -25,6 +26,8 @@ import {
 } from './plugin-services';
 import { ISecurityFactory } from '../../wazuh-core/server/services/security-factory';
 import { initializeClientContentManager } from './services/plugins/content-manager';
+import { setCtiConsoleBaseUrl } from './services/cti-registration/cti-console-url';
+import type { WazuhCheckUpdatesPluginConfigType } from './index';
 
 declare module 'opensearch-dashboards/server' {
   interface RequestHandlerContext {
@@ -39,13 +42,25 @@ export class WazuhCheckUpdatesPlugin
   implements Plugin<WazuhCheckUpdatesPluginSetup, WazuhCheckUpdatesPluginStart>
 {
   private readonly logger: Logger;
+  private readonly initializerContext: PluginInitializerContext;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
+    this.initializerContext = initializerContext;
   }
 
   public async setup(core: CoreSetup, plugins: PluginSetup) {
     this.logger.debug('wazuh_check_updates: Setup');
+
+    // The CTI API base URL is a compiled constant unless
+    // `wazuh_check_updates.ctiApiUrl` overrides it. Read it before the routes are
+    // defined so no handler can observe the pre-configuration value.
+    const pluginConfig = await this.initializerContext.config
+      .create<WazuhCheckUpdatesPluginConfigType>()
+      .pipe(first())
+      .toPromise();
+
+    setCtiConsoleBaseUrl(pluginConfig.ctiApiUrl);
 
     setWazuhCore(plugins.wazuhCore);
     setWazuhCheckUpdatesServices({ logger: this.logger });

--- a/plugins/wazuh-check-updates/server/services/cti-registration/cti-console-url.test.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/cti-console-url.test.ts
@@ -1,0 +1,30 @@
+import { WAZUH_CTI_CONSOLE_BASE_URL } from '../../../common/constants';
+import { getCtiConsoleBaseUrl, setCtiConsoleBaseUrl } from './cti-console-url';
+
+describe('getCtiConsoleBaseUrl', () => {
+  afterEach(() => {
+    setCtiConsoleBaseUrl(WAZUH_CTI_CONSOLE_BASE_URL);
+  });
+
+  test('falls back to the compiled constant when the setting is absent', () => {
+    expect(getCtiConsoleBaseUrl()).toBe(WAZUH_CTI_CONSOLE_BASE_URL);
+  });
+
+  test('returns the configured URL', () => {
+    setCtiConsoleBaseUrl('http://imposter:8080');
+
+    expect(getCtiConsoleBaseUrl()).toBe('http://imposter:8080');
+  });
+
+  test('strips the trailing slash of the configured URL', () => {
+    setCtiConsoleBaseUrl('http://imposter:8080/');
+
+    expect(getCtiConsoleBaseUrl()).toBe('http://imposter:8080');
+  });
+
+  test('trims the surrounding whitespace of the configured URL', () => {
+    setCtiConsoleBaseUrl('  http://imposter:8080  ');
+
+    expect(getCtiConsoleBaseUrl()).toBe('http://imposter:8080');
+  });
+});

--- a/plugins/wazuh-check-updates/server/services/cti-registration/cti-console-url.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/cti-console-url.ts
@@ -11,5 +11,16 @@ export class CtiConfigurationError extends Error {
   }
 }
 
+/**
+ * `wazuh_check_updates.ctiApiUrl` once the plugin has read its configuration.
+ * Seeded with the compiled constant so a read before `setup()` resolves behaves
+ * like a default installation, where the setting is absent.
+ */
+let ctiApiUrl: string = WAZUH_CTI_CONSOLE_BASE_URL;
+
+export const setCtiConsoleBaseUrl = (url: string): void => {
+  ctiApiUrl = url;
+};
+
 export const getCtiConsoleBaseUrl = (): string =>
-  WAZUH_CTI_CONSOLE_BASE_URL.trim().replace(/\/$/, '');
+  ctiApiUrl.trim().replace(/\/$/, '');

--- a/plugins/wazuh-check-updates/server/services/cti-registration/index.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/index.ts
@@ -2,7 +2,11 @@ export { fetchClusterUuid } from './cluster-uuid';
 export { getCtiToken, pollCtiToken, resolveCtiOAuthClientId } from './token';
 export { postContentManagerSubscription } from './content-manager-subscription';
 export { getCtiSubscriptionStatus } from './cti-credentials';
-export { getCtiConsoleBaseUrl, CtiConfigurationError } from './cti-console-url';
+export {
+  getCtiConsoleBaseUrl,
+  setCtiConsoleBaseUrl,
+  CtiConfigurationError,
+} from './cti-console-url';
 export {
   CtiRegistrationStore,
   parseDeviceAuthorizationForStore,

--- a/plugins/wazuh-check-updates/server/services/cti-registration/token.test.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/token.test.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
+import {
+  WAZUH_CTI_CONSOLE_BASE_URL,
+  ctiConsoleApiPaths,
+} from '../../../common/constants';
 import { getCtiToken, pollCtiToken } from './token';
 import { getWazuhCheckUpdatesServices } from '../../plugin-services';
+import { setCtiConsoleBaseUrl } from './cti-console-url';
 
 jest.mock('axios');
 jest.mock('../../plugin-services', () => ({
@@ -18,6 +23,36 @@ describe('token', () => {
     logger.error.mockClear();
     mockedGetWazuhCheckUpdatesServices.mockReturnValue({ logger });
     mockedAxios.post.mockReset();
+  });
+
+  afterEach(() => {
+    setCtiConsoleBaseUrl(WAZUH_CTI_CONSOLE_BASE_URL);
+  });
+
+  test('getCtiToken targets the configured CTI API URL', async () => {
+    setCtiConsoleBaseUrl('http://imposter:8080');
+    mockedAxios.post.mockResolvedValue({ data: {} });
+
+    await getCtiToken('client-id');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `http://imposter:8080${ctiConsoleApiPaths.environmentsToken}`,
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  test('pollCtiToken targets the configured CTI API URL', async () => {
+    setCtiConsoleBaseUrl('http://imposter:8080');
+    mockedAxios.post.mockResolvedValue({ data: {} });
+
+    await pollCtiToken('client-id', 'device-code');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `http://imposter:8080${ctiConsoleApiPaths.environmentsToken}`,
+      expect.any(String),
+      expect.any(Object),
+    );
   });
 
   test('getCtiToken sends Accept-Encoding: gzip, br and preserves Content-Type', async () => {

--- a/plugins/wazuh-check-updates/server/services/cti-registration/token.ts
+++ b/plugins/wazuh-check-updates/server/services/cti-registration/token.ts
@@ -39,7 +39,8 @@ export async function resolveCtiOAuthClientId(
 
 /**
  * Starts OAuth 2.0 device authorization against the CTI Console (not the Wazuh manager).
- * Base URL comes from {@link getCtiConsoleBaseUrl} (env var override or compiled constant).
+ * Base URL comes from {@link getCtiConsoleBaseUrl} (`wazuh_check_updates.ctiApiUrl`
+ * when set, otherwise the compiled constant).
  */
 export const getCtiToken = async (clientId: string): Promise<any> => {
   const { logger } = getWazuhCheckUpdatesServices();


### PR DESCRIPTION
## Description

The CTI API base URL was a compiled constant (`WAZUH_CTI_CONSOLE_BASE_URL` in
`plugins/wazuh-check-updates/common/constants.ts`), so testing against a different CTI
environment required editing the source and rebuilding.

This adds the `wazuh_check_updates.ctiApiUrl` setting to the `wazuh-check-updates` plugin
configuration schema. The setting is **not** present in the shipped
`opensearch_dashboards.yml`: when unset, the compiled constant is used, so the default
behavior is unchanged.

## Proposed Changes

- **`server/index.ts`** — new `ctiApiUrl` entry in `configSchema`, declared as
  `schema.uri({ scheme: ['http', 'https'], defaultValue: WAZUH_CTI_CONSOLE_BASE_URL })`.
  Validation happens at the configuration boundary, so an invalid value stops the
  dashboard at startup naming the setting, instead of failing later as an HTTP 500 during
  registration.
- **`server/plugin.ts`** — reads the plugin configuration once at the top of `setup()`
  (`config.create().pipe(first()).toPromise()`, the same idiom used by
  `plugins/wazuh-ai-assistant` and `plugins/main`), before `defineRoutes()`, so no route
  handler can observe a pre-configuration value.
- **`server/services/cti-registration/cti-console-url.ts`** — new `setCtiConsoleBaseUrl()`;
  `getCtiConsoleBaseUrl()` now resolves from the configured value, seeded with the
  compiled constant. The existing trim / trailing-slash normalization is kept, because
  `https://host/` is a valid URI and the schema will not reject that typo.
- **Doc comments** — `common/constants.ts` now points at the new setting, and
  `services/cti-registration/token.ts` no longer claims an env-var override that no
  longer exists.

The setting is server-side only and is deliberately **not** added to `exposeToBrowser`:
nothing under `public/` builds a CTI URL — the device flow runs entirely on the server and
the browser only receives `verification_uri` in the response body.

The resolver is also deliberately not routed through `server/plugin-services.ts`: widening
`createGetterSetter<{ logger: Logger }>('WazuhCheckUpdatesServices')` would ripple into the
~12 files that mock it, and `createGetterSetter` throws when unset, which would break the
one test that exercises the real resolver.

### How to Test

1. **Default (setting absent)** — with no `ctiApiUrl` in `opensearch_dashboards.yml`, start
   the dashboard and run CTI registration. The request still goes to
   `https://api.pre.cloud.wazuh.com/api/v1/platform/environments/token`.
2. **Override** — add to `opensearch_dashboards.yml`:
   ```yml
   wazuh_check_updates.ctiApiUrl: 'http://imposter:8080'
   ```
   Restart the dashboard and register again: the device flow now hits the local Imposter
   CTI mock. See `docker/imposter/cti/README.md` (the `X-Mock-Scenario` header forces a
   specific polling outcome).
3. **Trailing slash / whitespace** — set `'http://imposter:8080/'` and confirm the
   requested URL has no double slash.
4. **Invalid value** — set `wazuh_check_updates.ctiApiUrl: 'not a url'` (or an `ftp://`
   URL) and confirm the dashboard refuses to start, with
   `[wazuh_check_updates.ctiApiUrl]` named in the error.
5. **Unit tests** — inside the dev container:
   ```bash
   cd plugins/wazuh-check-updates
   yarn test:jest --runInBand --testPathPattern=cti-registration
   ```

### Results and Evidence

<!-- Attach screenshots / logs here -->

### Artifacts Affected

- `wazuh-check-updates` plugin (server side only). No packaging or default configuration
  file changes.

### Configuration Changes

New optional setting, absent from the default `opensearch_dashboards.yml`:

| Setting                            | Description                       | Default value                    | Allowed values                        |
| ---------------------------------- | --------------------------------- | -------------------------------- | ------------------------------------- |
| `wazuh_check_updates.ctiApiUrl`    | Base URL of the CTI API           | `https://api.pre.cloud.wazuh.com` | a valid URI with an `http`/`https` scheme |

Backward compatible: existing deployments that do not define it keep using the compiled
constant. A restart is required for a change to take effect, as with the other
`wazuh_check_updates.*` settings.

### Documentation Updates

- `docker/imposter/cti/README.md` — new "Pointing the dashboard at this mock" section. The
  Imposter CTI mock previously had no reachable configuration.
- Not added to `docs/ref/configuration.md`: neither of the two existing
  `wazuh_check_updates.*` settings is documented there, and this one is a
  development/QA override rather than a supported customer-facing setting.

### Tests Introduced

- **New** `server/services/cti-registration/cti-console-url.test.ts` (no test existed for
  this module): falls back to the compiled constant when the setting is absent, returns the
  configured URL, strips a trailing slash, and trims surrounding whitespace.
- **Extended** `server/services/cti-registration/token.test.ts`: this suite does not mock
  `cti-console-url`, so two cases assert the override actually reaches the wire — both
  `getCtiToken` and `pollCtiToken` POST to the configured host.

Full plugin suite: **25 suites / 97 tests passing** in the dev container. Prettier clean on
the whole diff. ESLint and `tsc --noEmit` show no new findings against the base branch
(remaining ones are pre-existing).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] Correct labels applied (`no-changelog`)
