### PR TITLE
fix(ai-assistant): pseudonymize compressed IPv6 addresses whole

### DIFF
--- a/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.test.ts
@@ -37,6 +37,69 @@ test('prescanAndMint: pseudonymizes an IPv4 address and is reversible', () => {
   assert.equal(p.reverseText(token), '10.0.2.15');
 });
 
+/* Every notation an operating system, a log line or a person actually writes. RFC 5952 requires
+the compressed form in generated text, so these are the common case rather than the edge one. */
+const IPV6_NOTATIONS = [
+  'fe80::a00:27ff:fe4e:66a1',
+  '2001:db8::1234',
+  'fe80::1',
+  '::1',
+  '2001:db8::',
+  '2001:db8:0:0:0:0:0:1',
+  '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+];
+
+for (const address of IPV6_NOTATIONS) {
+  test(`prescanAndMint: pseudonymizes IPv6 ${address} whole and reverses it`, () => {
+    const p = new Pseudonymizer();
+    const out = prescanAndMint(`peer ${address} went down`, p);
+
+    assert.match(out, /IP_\d+/);
+    /* The property that matters: no part of the address survives. Asserting the whole address is
+    absent would not catch this defect, which left the interface identifier appended to the
+    pseudonym ("IP_1a00:27ff:fe4e:66a1"). Pseudonyms come out first, since a short group like "1"
+    also occurs inside "IP_1". */
+    const remainder = out.replace(/IP_\d+/g, '');
+    for (const group of address.split(':').filter(Boolean)) {
+      assert.ok(
+        !remainder.includes(group),
+        `group "${group}" of ${address} reached the output: ${out}`,
+      );
+    }
+    assert.equal(p.reverseText(out), `peer ${address} went down`);
+  });
+}
+
+test('prescanAndMint: replaces the address inside a bracketed URL authority', () => {
+  const p = new Pseudonymizer();
+  const out = prescanAndMint('connect to [2001:db8::1234]:8443 now', p);
+
+  /* The port stays readable and the brackets stay balanced, so the authority is still parseable
+  once the colons are gone from the host. */
+  assert.match(out, /\[IP_\d+\]:8443/);
+  assert.doesNotMatch(out, /1234\]/);
+  assert.equal(p.reverseText(out), 'connect to [2001:db8::1234]:8443 now');
+});
+
+test('prescanAndMint: leaves colon-separated tokens that are not addresses untouched', () => {
+  const p = new Pseudonymizer();
+  const subject = 'mac 00:1a:2b:3c:4d:5e at 12:34:56 with level:7';
+  assert.equal(prescanAndMint(subject, p), subject);
+});
+
+test('prescanAndMintToolContent: pseudonymizes IPv6 in a digest message value', () => {
+  const p = new Pseudonymizer();
+  const digest = JSON.stringify({
+    samples: [
+      { message: 'sshd: connection from fe80::a00:27ff:fe4e:66a1 port 22' },
+    ],
+  });
+  const out = prescanAndMintToolContent(digest, p);
+
+  assert.doesNotMatch(out, /a00:27ff:fe4e:66a1/);
+  assert.equal(p.reverseText(out), digest);
+});
+
 test('prescanAndMint: pseudonymizes an FQDN but leaves bare words untouched', () => {
   const p = new Pseudonymizer();
   const out = prescanAndMint('the server webserver.corp.local is down', p);

--- a/plugins/wazuh-ai-assistant/server/tools/privacy.ts
+++ b/plugins/wazuh-ai-assistant/server/tools/privacy.ts
@@ -1032,12 +1032,25 @@ const IPV4_TOKEN_RE =
 
 /** Matches one IPv6 address in any of its standard textual forms (full 8-group, `::`-compressed at
  * any position, or a lone `::`). Every alternative requires at least two colons, so it can never
- * match a single `key:value`-shaped token. Known limitation (kept simple/conservative, same spirit
- * as the FQDN note below): an IPv4-mapped IPv6 literal (`::ffff:192.168.1.1`) is not matched as one
- * token — its embedded IPv4 suffix is still caught by `IPV4_TOKEN_RE` above, just not the `::ffff:`
- * prefix around it. */
+ * match a single `key:value`-shaped token.
+ *
+ * Anchored with colon-aware lookarounds rather than `\b`, and the reason is the whole point of
+ * this pattern. `\b` is defined over `[A-Za-z0-9_]`, so a colon does not close a word: against
+ * `fe80::a00:27ff:fe4e:66a1` a `\b` after the alternatives lets `(?:g:){1,7}:` match the `fe80::`
+ * prefix alone and stop there (alternation takes the FIRST match, never the longest), leaving the
+ * interface identifier — for a link-local SLAAC address, the EUI-64 form of the host MAC — in the
+ * clear next to the pseudonym, and unrecoverable by `reverseText` besides. The same `\b` cannot
+ * open a match on a leading `::` either, so `::1` and `2001:db8::` were not matched at all.
+ * Excluding `:` on both sides forces the match to span a maximal colon-run token: the trailing
+ * lookaround rejects any alternative that stops mid-address, so the engine backtracks into the one
+ * that consumes the whole thing. `Pseudonymizer.applyToText` anchors its own replacements the same
+ * way, for the same reason.
+ *
+ * Known limitation (kept simple/conservative, same spirit as the FQDN note below): an IPv4-mapped
+ * IPv6 literal (`::ffff:192.168.1.1`) is not matched as one token — its embedded IPv4 suffix is
+ * still caught by `IPV4_TOKEN_RE` above, just not the `::ffff:` prefix around it. */
 const IPV6_TOKEN_RE = new RegExp(
-  '\\b(?:' +
+  '(?<![A-Za-z0-9:])(?:' +
     '(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}|' +
     '(?:[A-Fa-f0-9]{1,4}:){1,7}:|' +
     '(?:[A-Fa-f0-9]{1,4}:){1,6}:[A-Fa-f0-9]{1,4}|' +
@@ -1047,7 +1060,7 @@ const IPV6_TOKEN_RE = new RegExp(
     '(?:[A-Fa-f0-9]{1,4}:){1,2}(?::[A-Fa-f0-9]{1,4}){1,5}|' +
     '[A-Fa-f0-9]{1,4}:(?:(?::[A-Fa-f0-9]{1,4}){1,6})|' +
     ':(?:(?::[A-Fa-f0-9]{1,4}){1,7}|:)' +
-    ')\\b',
+    ')(?![A-Za-z0-9:])',
   'g',
 );
 


### PR DESCRIPTION
## Description

Privacy mode replaces identifiers with reversible pseudonyms before anything
reaches the external model provider. Its value-shape scan anchored the IPv6
pattern with `\b`, which a colon does not close, so a compressed address matched
only up to the `::`:

```
in    "sshd: connection from fe80::a00:27ff:fe4e:66a1 port 22"
out   "sshd: connection from IP_1a00:27ff:fe4e:66a1 port 22"
```

That fails in both directions at once. Outbound, the surviving
`a00:27ff:fe4e:66a1` is the interface identifier, which for a link-local SLAAC
address is the EUI-64 form of the host MAC, so the pseudonym covers the network
prefix and the provider receives the half that identifies the machine. Inbound,
`IP_1a00:27ff:fe4e:66a1` is not a pseudonym `reverseText` recognises, so the
analyst never gets the address back.

The same anchor could not open a match on a leading `::`, so `::1` and
`2001:db8::` passed through untouched.

Compressed notation is the common case, not an edge one: RFC 5952 requires it in
generated text, and it is how every operating system and log line writes these
addresses. The forms the scan handled correctly, fully expanded across all eight
groups, almost never appear.

The typed path (`pseudonymize`) and the known-entity path (`applyToText`) were
already correct, since both match a whole known value rather than a shape.

## Proposed Changes

- `plugins/wazuh-ai-assistant/server/tools/privacy.ts`: anchored
  `IPV6_TOKEN_RE` with `(?<![A-Za-z0-9:])` / `(?![A-Za-z0-9:])` instead of `\b`.

`IPV6_TOKEN_RE` already carried every alternative of the canonical IPv6 pattern,
compressed forms included, so no grammar changed. Two behaviours followed from
the anchor alone:

- Regex alternation takes the first match, never the longest, and the
  prefix-only alternative `(?:[A-Fa-f0-9]{1,4}:){1,7}:` sits second. With `\b`
  after it, `fe80::` satisfied the pattern and the engine stopped. Excluding `:`
  from the trailing lookaround rejects any alternative that stops mid-address, so
  the engine backtracks into the one that consumes the whole token. Reordering
  the alternatives turned out to be unnecessary.
- `\b` is defined over `[A-Za-z0-9_]`, so it cannot open a match on a leading
  `::`. The lookarounds can.

`Pseudonymizer.applyToText` anchors its own replacements the same way, for the
same reason, thirty lines above in the same module. The scan now agrees with it.

### Results and Evidence

Measured through `prescanAndMint`, before and after, on the same input:

| Address | Before | After |
| --- | --- | --- |
| `fe80::a00:27ff:fe4e:66a1` | `IP_1a00:27ff:fe4e:66a1` | `IP_1` |
| `2001:db8::1234` | `IP_11234` | `IP_1` |
| `fe80::1` | `IP_11` | `IP_1` |
| `[2001:db8::1234]:8443` | `[IP_11234]:8443` | `[IP_1]:8443` |
| `::1` | `::1` | `IP_1` |
| `2001:db8::` | `2001:db8::` | `IP_1` |
| `2001:db8:0:0:0:0:0:1` | `IP_1` | `IP_1` |
| `10.1.2.3` | `IP_1` | `IP_1` |

Every row now reverses to the original text. Colon-separated tokens that are not
addresses stay untouched before and after: a MAC (`00:1a:2b:3c:4d:5e`), a clock
(`12:34:56`), and a `key:value` pair.

Through the digest path, `prescanAndMintToolContent`, which is what carries an
event's `message` field:

```
to provider: {"samples":[{"message":"sshd: connection from IP_1 port 22"}]}
reversed:    {"samples":[{"message":"sshd: connection from fe80::a00:27ff:fe4e:66a1 port 22"}]}
```

`privacy.test.ts` 191/191, and the whole plugin 2626 tests across 133 suites.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None. `IPV6_TOKEN_RE`'s doc comment now records why the anchor is not `\b`,
since a future edit back to `\b` would silently reopen this.

### Tests Introduced

`plugins/wazuh-ai-assistant/server/tools/privacy.test.ts`, which had no IPv6 case
at all:

- Seven notations through `prescanAndMint`. The assertion is that **no group of
  the address survives the output**, not merely that the whole address is absent:
  this defect left half the address in the clear, so the weaker assertion would
  have passed against it. Reversing must restore the text exactly.
- A bracketed URL authority, checking the port stays readable and the brackets
  stay balanced.
- Colon-separated non-addresses (MAC, clock, `key:value`) stay untouched.
- One digest case through `prescanAndMintToolContent`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
