### PR TITLE
Neutralize formula values in CSV exports

### DIFF
--- a/plugins/main/common/services/neutralize-csv-formula.test.ts
+++ b/plugins/main/common/services/neutralize-csv-formula.test.ts
@@ -1,0 +1,148 @@
+import {
+  CSV_FORMULA_TRIGGER_CHARACTERS,
+  neutralizeCsvFormulaValues,
+} from './neutralize-csv-formula';
+
+describe('neutralizeCsvFormulaValues', () => {
+  describe('formula-leading strings are neutralized', () => {
+    it.each`
+      trigger | value         | description
+      ${'='}  | ${'=1+1'}     | ${'equals'}
+      ${'+'}  | ${'+1+1'}     | ${'plus'}
+      ${'-'}  | ${'-1+1'}     | ${'minus'}
+      ${'@'}  | ${'@SUM(1)'}  | ${'at'}
+      ${'\t'} | ${'\t=1+1'}   | ${'tab'}
+      ${'\r'} | ${'\r=1+1'}   | ${'carriage return'}
+      ${'＝'} | ${'＝1+1'}    | ${'full-width equals'}
+      ${'＋'} | ${'＋1+1'}    | ${'full-width plus'}
+      ${'－'} | ${'－1+1'}    | ${'full-width minus'}
+      ${'＠'} | ${'＠SUM(1)'} | ${'full-width at'}
+    `(
+      'neutralizes a value leading with $description ($trigger)',
+      ({ trigger, value }) => {
+        const result = neutralizeCsvFormulaValues(value);
+
+        expect(result.startsWith(trigger)).toBe(false);
+        expect(result).toContain(value);
+      },
+    );
+
+    it('exposes the exhaustive trigger set', () => {
+      expect(CSV_FORMULA_TRIGGER_CHARACTERS).toEqual([
+        '=',
+        '+',
+        '-',
+        '@',
+        '\t',
+        '\r',
+        '＝',
+        '＋',
+        '－',
+        '＠',
+      ]);
+    });
+
+    it('prefixes an apostrophe so the original text stays readable', () => {
+      expect(neutralizeCsvFormulaValues('=1+1')).toBe("'=1+1");
+    });
+  });
+
+  describe('values that must not change', () => {
+    it('does not neutralize a leading newline', () => {
+      expect(neutralizeCsvFormulaValues('\n=1+1')).toBe('\n=1+1');
+    });
+
+    it.each`
+      value             | description
+      ${'plain'}        | ${'a plain string'}
+      ${'Ubuntu 22.04'} | ${'an ordinary os name'}
+      ${'a=1+1'}        | ${'a trigger that is not leading'}
+      ${''}             | ${'an empty string'}
+      ${-5}             | ${'a negative number'}
+      ${0}              | ${'zero'}
+      ${true}           | ${'a boolean'}
+      ${null}           | ${'null'}
+      ${undefined}      | ${'undefined'}
+    `('returns $description unchanged', ({ value }) => {
+      expect(neutralizeCsvFormulaValues(value)).toBe(value);
+    });
+
+    it('returns a bigint unchanged', () => {
+      expect(neutralizeCsvFormulaValues(BigInt(-5))).toBe(BigInt(-5));
+    });
+
+    it('neutralizes the string "-5" but not the number -5', () => {
+      expect(neutralizeCsvFormulaValues({ a: -5, b: '-5' })).toEqual({
+        a: -5,
+        b: "'-5",
+      });
+    });
+  });
+
+  describe('recursion reaches every depth', () => {
+    it('reaches a value nested in an object', () => {
+      expect(
+        neutralizeCsvFormulaValues({ id: '001', os: { name: '=1+1' } }),
+      ).toEqual({ id: '001', os: { name: "'=1+1" } });
+    });
+
+    it('reaches a value inside an array', () => {
+      expect(neutralizeCsvFormulaValues(['default', '=1+1'])).toEqual([
+        'default',
+        "'=1+1",
+      ]);
+    });
+
+    it('reaches an array held by an object key', () => {
+      expect(
+        neutralizeCsvFormulaValues({ group: ['default', '=1+1'] }),
+      ).toEqual({ group: ['default', "'=1+1"] });
+    });
+
+    it('reaches an object nested inside an array of rows', () => {
+      expect(
+        neutralizeCsvFormulaValues([{ os: { name: '＝cmd' } }, { os: {} }]),
+      ).toEqual([{ os: { name: "'＝cmd" } }, { os: {} }]);
+    });
+  });
+
+  describe('structure is preserved', () => {
+    it('does not mutate the input', () => {
+      const input = { id: '001', os: { name: '=1+1' }, group: ['=1+1'] };
+
+      neutralizeCsvFormulaValues(input);
+
+      expect(input).toEqual({
+        id: '001',
+        os: { name: '=1+1' },
+        group: ['=1+1'],
+      });
+    });
+
+    it('returns a copy, not the same reference', () => {
+      const input = { os: { name: '=1+1' } };
+      const result = neutralizeCsvFormulaValues(input);
+
+      expect(result).not.toBe(input);
+      expect(result.os).not.toBe(input.os);
+    });
+
+    it('preserves key order and never rewrites a key', () => {
+      const result = neutralizeCsvFormulaValues({
+        '=x': '=1+1',
+        id: '001',
+        '@y': 'plain',
+      });
+
+      expect(Object.keys(result)).toEqual(['=x', 'id', '@y']);
+      expect(result['=x']).toBe("'=1+1");
+    });
+
+    it('returns a Date by reference so serialization is unchanged', () => {
+      const date = new Date('2026-01-01T00:00:00.000Z');
+      const result = neutralizeCsvFormulaValues({ dateAdd: date });
+
+      expect(result.dateAdd).toBe(date);
+    });
+  });
+});

--- a/plugins/main/common/services/neutralize-csv-formula.ts
+++ b/plugins/main/common/services/neutralize-csv-formula.ts
@@ -1,0 +1,83 @@
+/*
+ * Wazuh app - Neutralize spreadsheet-formula values before a CSV export
+ * Copyright (C) 2015-2026 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+/**
+ * Characters that make a spreadsheet engine evaluate a cell as a formula when
+ * they are the first character of the cell. Includes the full-width variants,
+ * which some engines normalize to their ASCII counterpart.
+ *
+ * A leading line feed is deliberately absent: it is not a formula trigger, and
+ * the CSV writer already quotes embedded newlines.
+ */
+export const CSV_FORMULA_TRIGGER_CHARACTERS = [
+  '=',
+  '+',
+  '-',
+  '@',
+  '\t',
+  '\r',
+  '＝',
+  '＋',
+  '－',
+  '＠',
+];
+
+const NEUTRALIZING_PREFIX = "'";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+};
+
+/**
+ * Return a copy of `value` in which every string that starts with a CSV formula
+ * trigger character is prefixed with an apostrophe, so a spreadsheet renders it
+ * as literal text instead of evaluating it.
+ *
+ * The traversal is recursive and structure-preserving: it walks into arrays and
+ * plain objects, keeps keys and key order untouched, and never mutates the
+ * input. Non-string primitives are returned unchanged, and non-plain objects
+ * (`Date`, `RegExp`, class instances, `Map`/`Set`) are returned by reference so
+ * the CSV writer serializes them exactly as it does today.
+ *
+ * @param value any value about to be handed to the CSV writer
+ * @returns a neutralized copy of `value`
+ */
+export function neutralizeCsvFormulaValues<T>(value: T): T {
+  if (typeof value === 'string') {
+    return (CSV_FORMULA_TRIGGER_CHARACTERS.some(trigger =>
+      value.startsWith(trigger),
+    )
+      ? NEUTRALIZING_PREFIX + value
+      : value) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => neutralizeCsvFormulaValues(item)) as unknown as T;
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        neutralizeCsvFormulaValues(item),
+      ]),
+    ) as unknown as T;
+  }
+
+  return value;
+}

--- a/plugins/main/public/components/agents/stats/table.test.tsx
+++ b/plugins/main/public/components/agents/stats/table.test.tsx
@@ -15,7 +15,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { AgentStatTable } from './table';
+import * as FileSaver from '../../../services/file-saver';
 
+jest.mock('../../../services/file-saver', () => ({
+  saveAs: jest.fn(),
+}));
 jest.mock('../../../kibana-services', () => ({
   getHttp: () => ({
     basePath: {
@@ -53,7 +57,67 @@ const tableColumns = [
   },
 ];
 
+/**
+ * `new Blob([...])` cannot be read back synchronously in jsdom, so capture the
+ * parts the component hands to the Blob constructor.
+ */
+class CapturingBlob {
+  parts: string[];
+  type: string | undefined;
+
+  constructor(parts: string[], options?: { type?: string }) {
+    this.parts = parts;
+    this.type = options?.type;
+  }
+}
+
+/** Split one CSV row into cells, honouring RFC 4180 double quoting. */
+const splitCsvRow = (row: string): string[] => {
+  const cells: string[] = [];
+  let cell = '';
+  let quoted = false;
+
+  for (let index = 0; index < row.length; index++) {
+    const character = row[index];
+
+    if (quoted) {
+      if (character === '"') {
+        if (row[index + 1] === '"') {
+          cell += '"';
+          index++;
+        } else {
+          quoted = false;
+        }
+      } else {
+        cell += character;
+      }
+    } else if (character === '"') {
+      quoted = true;
+    } else if (character === ',') {
+      cells.push(cell);
+      cell = '';
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell);
+
+  return cells;
+};
+
 describe('AgentStatTable component', () => {
+  const originalBlob = global.Blob;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @ts-expect-error jsdom Blob replaced by a capturing stub
+    global.Blob = CapturingBlob;
+  });
+
+  afterEach(() => {
+    global.Blob = originalBlob;
+  });
+
   it('Renders correctly to match the snapshot', () => {
     const wrapper = mount(
       <AgentStatTable
@@ -104,5 +168,97 @@ describe('AgentStatTable component', () => {
     // @ts-ignore
     wrapper.find('EuiButtonEmpty').props().onClick();
     expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  describe('CSV export', () => {
+    const exportCsv = async (items: Record<string, unknown>[]) => {
+      const wrapper = mount(
+        <AgentStatTable
+          columns={tableColumns}
+          loading={false}
+          start={''}
+          end={''}
+          title='Test'
+          items={items}
+          exportCSVFilename={`agent-stats-10101-logcollector-global`}
+        />,
+      );
+
+      const downloadButton = wrapper
+        .find('EuiButtonEmpty')
+        .filterWhere(node => node.text() === 'Download CSV')
+        .first();
+
+      const onClick = downloadButton.props().onClick as () => Promise<void>;
+
+      await onClick();
+
+      const [blob, filename] = (FileSaver.saveAs as jest.Mock).mock.calls[0];
+
+      return { csv: blob.parts[0] as string, filename };
+    };
+
+    it('saves the file under the exportCSVFilename prop', async () => {
+      const { filename } = await exportCsv([
+        { location: '/var/log/syslog', events: 5, bytes: 10 },
+      ]);
+
+      expect(filename).toBe('agent-stats-10101-logcollector-global.csv');
+    });
+
+    it('emits the header row and column order of the table columns', async () => {
+      const { csv } = await exportCsv([
+        { location: '/var/log/syslog', events: 5, bytes: 10 },
+      ]);
+
+      expect(csv.split('\n')[0]).toBe('Location,Events,Bytes');
+      expect(csv).toBe('Location,Events,Bytes\n/var/log/syslog,5,10');
+    });
+
+    it('renders a missing field as an empty cell', async () => {
+      const { csv } = await exportCsv([{ location: '/var/log/syslog' }]);
+
+      expect(csv).toBe('Location,Events,Bytes\n/var/log/syslog,,');
+    });
+
+    it('round-trips a location containing a comma as a single cell', async () => {
+      const { csv } = await exportCsv([
+        { location: '/var/log/a,b.log', events: 5, bytes: 10 },
+      ]);
+
+      const [header, row] = csv.split('\n');
+      const cells = splitCsvRow(row);
+
+      expect(cells).toHaveLength(splitCsvRow(header).length);
+      expect(cells[0]).toBe('/var/log/a,b.log');
+      expect(csv).toBe('Location,Events,Bytes\n"/var/log/a,b.log",5,10');
+    });
+
+    it('round-trips a value containing a double quote as a single cell', async () => {
+      const { csv } = await exportCsv([
+        { location: 'say "hi"', events: 5, bytes: 10 },
+      ]);
+
+      const cells = splitCsvRow(csv.split('\n')[1]);
+
+      expect(cells).toHaveLength(3);
+      expect(cells[0]).toBe('say "hi"');
+    });
+
+    it('round-trips a value containing a newline as a single cell', async () => {
+      const { csv } = await exportCsv([
+        { location: 'line1\nline2', events: 5, bytes: 10 },
+      ]);
+
+      expect(csv).toBe('Location,Events,Bytes\n"line1\nline2",5,10');
+    });
+
+    it('neutralizes a formula-leading location', async () => {
+      const { csv } = await exportCsv([
+        { location: '=cmd', events: 5, bytes: 10 },
+      ]);
+
+      expect(csv).toBe("Location,Events,Bytes\n'=cmd,5,10");
+    });
   });
 });

--- a/plugins/main/public/components/agents/stats/table.tsx
+++ b/plugins/main/public/components/agents/stats/table.tsx
@@ -22,8 +22,10 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import converter from 'json-2-csv';
 import * as FileSaver from '../../../services/file-saver';
 import { formatUIDate } from '../../../react-services';
+import { neutralizeCsvFormulaValues } from '../../../../common/services/neutralize-csv-formula';
 import {
   UI_ERROR_SEVERITIES,
   UIErrorLog,
@@ -93,13 +95,17 @@ export function AgentStatTable({
   );
 }
 
-function downloadCsv(columns: any[], data: any[], filename: string) {
+async function downloadCsv(columns: any[], data: any[], filename: string) {
   try {
-    const header = columns.map(column => column.name).join(',');
-    const body = data
-      .map(row => columns.map(column => row[column.field]).join(','))
-      .join('\n');
-    const result = [header, body].join('\n');
+    const options = {
+      emptyFieldValue: '',
+      keys: columns.map(column => ({
+        field: column.field,
+        title: column.name,
+      })),
+    };
+    const rows = neutralizeCsvFormulaValues(data);
+    const result = await converter.json2csvAsync(rows, options);
     const blob = new Blob([result], { type: 'text/csv' }); // eslint-disable-line
     FileSaver.saveAs(blob, `${filename}.csv`);
   } catch (error) {

--- a/plugins/main/public/components/common/data-grid/data-grid-service.test.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.test.ts
@@ -1,5 +1,21 @@
-import { parseData } from './data-grid-service';
+import { exportSearchToCSV, parseData } from './data-grid-service';
 import { SearchResponse } from '../../../../../../src/core/server';
+import { search, type SearchParams } from '../search-bar/search-bar-service';
+import converter from 'json-2-csv';
+import * as FileSaver from '../../../services/file-saver';
+
+jest.mock('../search-bar/search-bar-service', () => ({
+  search: jest.fn(),
+}));
+jest.mock('json-2-csv', () => ({
+  json2csvAsync: jest.fn().mockResolvedValue('csv-body'),
+}));
+jest.mock('../../../services/file-saver', () => ({
+  saveAs: jest.fn(),
+}));
+jest.mock('../../../react-services', () => ({
+  formatUIDate: (date: string) => date,
+}));
 
 describe('describe-grid-test', () => {
   describe('parseData', () => {
@@ -42,6 +58,69 @@ describe('describe-grid-test', () => {
       const expectedResult = [{}, {}, {}];
 
       expect(parseData(resultsHits)).toEqual(expectedResult);
+    });
+  });
+
+  describe('exportSearchToCSV', () => {
+    const HIT_WITH_FORMULA = {
+      _id: 'id-1',
+      _index: 'index-1',
+      _source: {
+        'os.name': '=1+1',
+        group: ['default', '=cmd'],
+        'agent.id': '001',
+      },
+    };
+
+    const indexPattern = {
+      fields: { getByType: () => [] },
+      flattenHit: (hit: { _source: Record<string, unknown> }) => ({
+        ...hit._source,
+      }),
+    };
+
+    const buildParams = () => ({
+      indexPattern,
+      filters: [],
+      query: { query: '', language: 'kuery' },
+      sorting: [],
+      fields: ['os.name', 'group', 'agent.id'],
+      pagination: { pageIndex: 0, pageSize: 10 },
+      dateRange: { from: 'now-1d', to: 'now' },
+    });
+
+    const runExport = async () => {
+      (search as jest.Mock).mockResolvedValue({
+        hits: { hits: [HIT_WITH_FORMULA] },
+      });
+
+      await exportSearchToCSV(buildParams() as unknown as SearchParams);
+
+      return (converter.json2csvAsync as jest.Mock).mock.calls[0];
+    };
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('neutralizes a formula-leading field before writing the CSV', async () => {
+      const [data] = await runExport();
+
+      expect(data).toEqual([
+        {
+          'os.name': "'=1+1",
+          group: ['default', "'=cmd"],
+          'agent.id': '001',
+        },
+      ]);
+      expect(FileSaver.saveAs).toHaveBeenCalled();
+    });
+
+    it('keeps the writer options and column selectors untouched', async () => {
+      const [, options] = await runExport();
+
+      expect(options).toEqual({
+        emptyFieldValue: '',
+        keys: ['os.name', 'group', 'agent.id'],
+      });
     });
   });
 });

--- a/plugins/main/public/components/common/data-grid/data-grid-service.ts
+++ b/plugins/main/public/components/common/data-grid/data-grid-service.ts
@@ -12,6 +12,7 @@ import { cellFilterActions } from './cell-filter-actions';
 import { onFilterCellActions } from './filter-cell-actions';
 import converter from 'json-2-csv';
 import { formatUIDate } from '../../../react-services';
+import { neutralizeCsvFormulaValues } from '../../../../common/services/neutralize-csv-formula';
 
 type ParseData<T> =
   | {
@@ -154,7 +155,9 @@ export const exportSearchToCSV = async (
     keys: resultsFields,
   };
 
-  let csv = await converter.json2csvAsync(data, options);
+  const rows = neutralizeCsvFormulaValues(data);
+
+  let csv = await converter.json2csvAsync(rows, options);
 
   const blobData = new Blob([csv], {
     type: 'text/csv',

--- a/plugins/main/server/controllers/wazuh-api.test.ts
+++ b/plugins/main/server/controllers/wazuh-api.test.ts
@@ -1,0 +1,158 @@
+import type {
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from 'src/core/server';
+import { WazuhApiCtrl } from './wazuh-api';
+
+const AGENT_WITH_FORMULA_OS_NAME = {
+  id: '001',
+  status: 'active',
+  name: 'agent-1',
+  ip: '172.16.0.2',
+  group: ['default'],
+  manager: 'wazuh-manager',
+  dateAdd: '2026-01-01T00:00:00Z',
+  version: 'Wazuh v5.0.0',
+  lastKeepAlive: '2026-01-01T00:01:00Z',
+  os: {
+    arch: 'x86_64',
+    build: '1',
+    codename: 'jammy',
+    major: '22',
+    minor: '04',
+    name: '=1+1',
+    platform: 'ubuntu',
+    uname: 'Linux',
+    version: '22.04',
+  },
+};
+
+const makeContext = (
+  affectedItems: Record<string, unknown>[],
+  uiSettings: Record<string, unknown>,
+) => {
+  const request = jest.fn().mockResolvedValue({
+    data: {
+      data: {
+        /* eslint-disable camelcase -- Wazuh Server API response field names */
+        total_affected_items: affectedItems.length,
+        affected_items: affectedItems,
+        /* eslint-enable camelcase */
+      },
+    },
+  });
+
+  return {
+    context: {
+      core: {
+        uiSettings: {
+          client: {
+            get: jest.fn((key: string) => Promise.resolve(uiSettings[key])),
+          },
+        },
+      },
+      wazuh: {
+        logger: { debug: jest.fn(), error: jest.fn() },
+        api: { client: { asCurrentUser: { request } } },
+      },
+    } as unknown as RequestHandlerContext,
+    request,
+  };
+};
+
+const makeResponse = () => ({
+  ok: jest.fn(payload => payload),
+  badRequest: jest.fn(payload => payload),
+});
+
+const exportAgentsCsv = async (
+  uiSettings: Record<string, unknown> = { 'reports.csv.maxRows': 10_000 },
+  path = '/agents',
+) => {
+  const ctrl = new WazuhApiCtrl();
+  const { context } = makeContext([AGENT_WITH_FORMULA_OS_NAME], uiSettings);
+  const response = makeResponse();
+
+  const result = await ctrl.csv(
+    context,
+    {
+      body: { path, id: 'default', filters: [] },
+    } as unknown as OpenSearchDashboardsRequest,
+    response as unknown as OpenSearchDashboardsResponseFactory,
+  );
+
+  return { context, response, result };
+};
+
+const cellAt = (csv: string, title: string) => {
+  const [header, row] = csv.split('\n');
+  const index = header.split(',').indexOf(title);
+
+  expect(index).toBeGreaterThanOrEqual(0);
+
+  return row.split(',')[index];
+};
+
+describe('WazuhApiCtrl.csv', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('neutralizes a nested os.name reported as a formula', async () => {
+    const { response } = await exportAgentsCsv();
+
+    const { body } = response.ok.mock.calls[0][0];
+
+    expect(cellAt(body, 'OS name')).toBe("'=1+1");
+    expect(cellAt(body, 'Status')).toBe('active');
+  });
+
+  it('neutralizes without consulting any CSV escaping setting', async () => {
+    const { context, response } = await exportAgentsCsv();
+
+    const readKeys = (
+      context.core.uiSettings.client.get as jest.Mock
+    ).mock.calls.map(([key]: [string]) => key);
+
+    expect(readKeys).not.toContain('csv.escapeFormulaValues');
+    expect(cellAt(response.ok.mock.calls[0][0].body, 'OS name')).toBe("'=1+1");
+  });
+
+  it('responds with a Content-Disposition attachment filename', async () => {
+    const { response } = await exportAgentsCsv();
+
+    const { headers } = response.ok.mock.calls[0][0];
+
+    expect(headers['Content-Type']).toBe('text/csv');
+    expect(headers['Content-Disposition']).toBe(
+      'attachment; filename="agents.csv"',
+    );
+  });
+
+  // The filename is derived from the caller-supplied path, so it must not be
+  // able to break out of the quoted value or start a new header.
+  it.each`
+    path                              | expected
+    ${'/agents"; filename="evil.exe'} | ${'agents-filename-evil.exe'}
+    ${'/agents\r\nSet-Cookie: a=b'}   | ${'agents-Set-Cookie-a-b'}
+    ${'/agents/../../etc/passwd'}     | ${'agents-..-..-etc-passwd'}
+  `(
+    'neutralizes $path in the Content-Disposition filename',
+    async ({ path, expected }) => {
+      const { response } = await exportAgentsCsv(
+        { 'reports.csv.maxRows': 10_000 },
+        path as string,
+      );
+
+      const disposition = response.ok.mock.calls[0][0].headers[
+        'Content-Disposition'
+      ] as string;
+
+      expect(disposition).toBe(`attachment; filename="${expected}.csv"`);
+
+      const filename = disposition.match(/^attachment; filename="(.*)"$/)?.[1];
+
+      // Only characters the sanitizer allows: deleting it would fail here.
+      expect(filename).toMatch(/^[\w.-]+$/);
+    },
+  );
+});

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -34,6 +34,7 @@ import {
 } from '../../package.json';
 import { extractErrorMessage } from '../lib/extract-error-message';
 import { detectCCS } from '../lib/ccs-detector';
+import { neutralizeCsvFormulaValues } from '../../common/services/neutralize-csv-formula';
 
 export class WazuhApiCtrl {
   constructor() {}
@@ -925,10 +926,17 @@ export class WazuhApiCtrl {
             ? { [UnsupportedKeysJson2CsvAsyncSize]: size }
             : {}),
         }));
+        itemsArray = neutralizeCsvFormulaValues(itemsArray);
         let csv = await converter.json2csvAsync(itemsArray, options);
 
         return response.ok({
-          headers: { 'Content-Type': 'text/csv' },
+          headers: {
+            'Content-Type': 'text/csv',
+            'Content-Disposition': `attachment; filename="${tmpPath.replace(
+              /[^\w.-]+/g,
+              '-',
+            )}.csv"`,
+          },
           body: csv,
         });
       } else if (


### PR DESCRIPTION
## Description

CSV exports wrote cell values verbatim, so a value starting with `=`, `+`, `-` or `@` was
evaluated as a formula when an analyst opened the file in a spreadsheet (OWASP CSV Injection,
CWE-1236).

The values are not all operator-supplied: an agent's `os.*` fields are reported by the agent and
declared as free-form strings with no `pattern` in the Server API specification, so a compromised
host chooses them.

## Proposed Changes

- **New** `plugins/main/common/services/neutralize-csv-formula.ts` — a pure, recursive helper that
  prefixes an apostrophe to any string starting with a trigger character (`=` `+` `-` `@`, tab,
  carriage return, and the full-width variants OWASP calls out; a leading line feed is excluded on
  purpose). It lives in `common/` because one call site is in `server/` and two are in `public/`.
- Applied **unconditionally** at all three CSV writers in `plugins/main`: the `POST /api/csv` route
  (`server/controllers/wazuh-api.ts`), the data-grid export (`data-grid-service.ts`) and the
  agent-stats export (`agents/stats/table.tsx`).
- **`agents/stats/table.tsx` migrated to `json2csvAsync`.** Its hand-rolled `join(',')` writer
  emitted no quoting, so a value containing a comma shifted every later column.
- **`Content-Disposition: attachment` added** to `POST /api/csv`. Its filename derives from the
  caller-supplied path, so it is constrained to `[A-Za-z0-9_.-]` — without that, adding the header
  would have introduced response header injection while fixing a different injection.

**The traversal has to be recursive**, and that is the whole point: `json-2-csv` resolves its
dotted `options.keys` selectors against the still-nested object and flattens *afterwards*, so a
top-level-only pass leaves `os.name` live — the exact field the defect exploits.

### Results and Evidence

An agent reporting `os.name` as `=1337*2` was exported through each of the three writers, on a
5.0.0 stack:

| Writer | Downloaded via | Exported cell | Calc |
| --- | --- | --- | --- |
| `POST /api/csv` | the endpoint, `path: /agents` | `'=1337*2` | inert text |
| data-grid | IT Hygiene → System → OS → **Export Formatted** | `'=1337*2` | inert text |
| agent-stats | Agent → Stats → **Download CSV** | `'=1337*2` | inert text |

**Before** — the same export without the fix. `OS name` renders `2674`: Calc evaluated
`=1337*2`.

<img width="935" height="1210" alt="vulnerable-1" src="https://github.com/user-attachments/assets/54608f3d-821f-4420-a652-cd0d7a041d0a" />

**After** — `OS name` renders `'=1337*2` as literal text.

<img width="935" height="1210" alt="fixed-1" src="https://github.com/user-attachments/assets/5725f5f8-b1b6-4bfd-953f-46a5fd8fcae6" />

The agent-stats export also demonstrates the quoting fix, on a logcollector path with a comma:

```
fixed:    "/var/log/app,prod.log",120,4096   → 3 fields, aligned
pre-fix:   /var/log/app,prod.log,120,4096    → 4 fields, every later column shifted
```

Checks:

```
jest (full plugins/main)   246 suites, 1944 tests, 69 snapshots — pass
prettier                   clean
eslint                     zero delta against the base tree
tsc --noEmit --strict      clean on the new helper
knip                       nothing from this change reported
```

### How to Test

Requires a running `docker/osd-dev` stack with at least one enrolled agent. The blocks below
handle any number of agents.

**1. Plant the payload and download the server-side export.** One paste — it finds every agent
container and the API host id on its own, waits until all of them have synced, and writes
`agents.csv` to the current directory:

```bash
AGENTS=$(docker ps --format '{{.Names}}' | grep 'wazuh.agent')
for AGENT in $AGENTS; do
  docker exec "$AGENT" bash -c '
    [ -f /etc/os-release.orig ] || cp /etc/os-release /etc/os-release.orig
    sed -i "s|^NAME=.*|NAME=\"=1337*2\"|" /etc/os-release
    /var/ossec/bin/wazuh-control restart' >/dev/null 2>&1
  echo "payload planted on $AGENT"
done
EXPECTED=$(echo "$AGENTS" | grep -c .)

DASH=${DASH:-https://localhost:5601}
J=$(mktemp)
curl -sk -c "$J" -X POST "$DASH/auth/login" -H 'osd-xsrf: true' \
  -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin"}' -o /dev/null
HOST=$(curl -sk -b "$J" "$DASH/hosts/apis" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
curl -sk -b "$J" -c "$J" -X POST "$DASH/api/login" -H 'osd-xsrf: true' \
  -H 'Content-Type: application/json' -d "{\"idHost\":\"$HOST\"}" -o /dev/null

echo -n "waiting for $EXPECTED agent(s) to sync"
until [ "$(curl -sk -b "$J" -X POST "$DASH/api/request" -H 'osd-xsrf: true' \
  -H 'Content-Type: application/json' \
  -d "{\"id\":\"$HOST\",\"method\":\"GET\",\"path\":\"/agents\",\"body\":{}}" \
  | grep -o '=1337\*2' | wc -l)" -ge "$EXPECTED" ]; do echo -n .; sleep 5; done
echo " ok"

curl -sk -b "$J" -X POST "$DASH/api/csv" -H 'osd-xsrf: true' \
  -H 'Content-Type: application/json' \
  -d "{\"id\":\"$HOST\",\"path\":\"/agents\",\"filters\":[]}" -o agents.csv
echo "neutralized cells: $(grep -o "'=1337\*2" agents.csv | wc -l) of $EXPECTED expected"
```

Expected last line: `neutralized cells: N of N expected`. Without this change it reports `0`.

**2. Download the two browser-side exports** and check their `OS name` / `Location` cells the same
way:

- IT Hygiene → System → OS → **Export Formatted**
- Agent → Stats → **Download CSV**

**3. Open any of the three files in a spreadsheet.** The `OS name` cell must read `'=1337*2` as
literal text.

To see the defect itself, strip the apostrophe and reopen — this is what the previous writer
emitted:

```bash
sed "s/,'/,/g" agents.csv > agents-unfixed.csv
```

`OS name` then renders `2674`, because Calc evaluated `=1337*2`.

Two notes so the result is not misread. In LibreOffice's CSV import dialog **Evaluate formulas**
must be checked, or the payload renders as inert text with *and* without this change; and
**Merge delimiters** must be unchecked, or empty fields collapse and every later column shifts.
Both settings are sticky per user profile. Also, `=` is the only trigger LibreOffice evaluates on
import — the others apply to Excel and are covered by unit tests.

**4. Revert every agent.** Idempotent, and it only touches agents that actually hold a backup:

```bash
for AGENT in $(docker ps --format '{{.Names}}' | grep 'wazuh.agent'); do
  if docker exec "$AGENT" test -f /etc/os-release.orig; then
    docker exec "$AGENT" bash -c '
      mv /etc/os-release.orig /etc/os-release
      /var/ossec/bin/wazuh-control restart' >/dev/null 2>&1
    echo "reverted $AGENT"
  else
    echo "nothing to revert on $AGENT"
  fi
done
```

### Artifacts Affected

`plugins/main` only — one new `common/` service, three modified export paths, four test suites.
No dependency or build change: `json-2-csv` was already a dependency.

### Configuration Changes

None. Neutralisation is unconditional. `wazuh-dashboard-reporting` carries an equivalent
guard, but only on its Excel path (`params.excel`) and only over already-flattened top-level
fields, so it could not be reused here.

Accepted consequence: neutralised values are **not** byte-identical to the source. LibreOffice does
not consume a leading apostrophe on CSV import, so the analyst sees `'=1337*2` in the cell, and a
downstream script consuming these exports sees it too. Per OWASP no sanitisation strategy is safe
for all spreadsheets *and* all consumers, so the tradeoff can only be relocated. Only cells that
actually start with a trigger character are altered; every other value is byte-identical.

### Documentation Updates

None required.

### Tests Introduced

52 tests across four suites.

- `neutralize-csv-formula.test.ts` — every trigger including the full-width variants, `\n` pinned
  as *not* a trigger, nested-object and array depth, non-strings untouched (`-5` the number versus
  `"-5"` the string), key order preserved, input never mutated.
- `server/controllers/wazuh-api.test.ts` — **new file**; this controller had no test at all. Covers
  the nested `os.name` case through the real unmocked `json-2-csv`, plus hostile export paths
  against the `Content-Disposition` filename.
- `data-grid-service.test.ts` and `agents/stats/table.test.tsx` — extended with byte-exact
  assertions on header titles, column order, missing values and comma/quote/newline round-tripping.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes <!-- n/a -->
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (`no-changelog`)



