### PR TITLE
Prevent caller override of Server API auth header

### DIFF
--- a/plugins/wazuh-core/server/services/server-api-client.test.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Wazuh app - Server API client tests
+ * Copyright (C) 2015-2022 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import { Logger } from 'opensearch-dashboards/server';
+import { ServerAPIClient } from './server-api-client';
+import { ManageHosts } from './manage-hosts';
+import { ISecurityFactory } from './security-factory';
+
+const API_HOST = {
+  id: 'default',
+  url: 'https://server-api',
+  port: 55000,
+  username: 'wazuh-wui',
+  password: 'wazuh-wui',
+};
+
+interface RequestOptions {
+  headers: Record<string, unknown>;
+}
+
+/* The header allowlist is applied while building the outbound request, so the
+   test reaches for that private method instead of mocking the transport. */
+interface ClientInternals {
+  _buildRequestOptions: (
+    method: string,
+    path: string,
+    data: unknown,
+    options: unknown,
+  ) => Promise<RequestOptions>;
+}
+
+function createClient() {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const manageHosts = {
+    get: jest.fn().mockResolvedValue(API_HOST),
+    resolveVerifyCa: jest.fn().mockReturnValue(false),
+    isEnabledAuthWithRunAs: jest.fn().mockReturnValue(false),
+  };
+  const dashboardSecurity = {
+    getCurrentUser: jest.fn().mockResolvedValue({ username: 'admin' }),
+  };
+  const client = new ServerAPIClient(
+    logger as unknown as Logger,
+    manageHosts as unknown as ManageHosts,
+    dashboardSecurity as unknown as ISecurityFactory,
+  );
+
+  return { client, logger };
+}
+
+function buildRequestOptions(client: ServerAPIClient, data: unknown) {
+  return (client as unknown as ClientInternals)._buildRequestOptions(
+    'GET',
+    '/agents',
+    data,
+    { apiHostID: 'default', token: 'server-session-token' },
+  );
+}
+
+describe('ServerAPIClient._buildRequestOptions', () => {
+  it('uses the token resolved by the server as Authorization', async () => {
+    const { client } = createClient();
+    const options = await buildRequestOptions(client, {});
+
+    expect(options.headers.Authorization).toBe('Bearer server-session-token');
+  });
+
+  it('forwards the allowed content-type header', async () => {
+    const { client } = createClient();
+    const options = await buildRequestOptions(client, {
+      headers: { 'content-type': 'application/xml' },
+    });
+
+    expect(options.headers['content-type']).toBe('application/xml');
+  });
+
+  // Regression test for GHSA-7rvv-9467-96mc: a caller-supplied Authorization
+  // header must never replace the credential chosen by the server.
+  it.each(['Authorization', 'authorization', 'AUTHORIZATION'])(
+    'ignores a caller-supplied %s header',
+    async headerName => {
+      const { client } = createClient();
+      const options = await buildRequestOptions(client, {
+        headers: { [headerName]: 'Bearer token-from-the-client' },
+      });
+
+      expect(options.headers.Authorization).toBe('Bearer server-session-token');
+      expect(JSON.stringify(options.headers)).not.toContain(
+        'token-from-the-client',
+      );
+    },
+  );
+
+  it('ignores other headers that are not allowlisted', async () => {
+    const { client, logger } = createClient();
+    const options = await buildRequestOptions(client, {
+      headers: {
+        Cookie: 'wz-token=stolen',
+        Host: 'attacker.local',
+        'X-Forwarded-For': '127.0.0.1',
+      },
+    });
+
+    expect(options.headers.Cookie).toBeUndefined();
+    expect(options.headers.Host).toBeUndefined();
+    expect(options.headers['X-Forwarded-For']).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('does not fail when headers are missing or not an object', async () => {
+    const { client } = createClient();
+
+    await expect(buildRequestOptions(client, {})).resolves.toMatchObject({
+      headers: { 'content-type': 'application/json' },
+    });
+    await expect(
+      buildRequestOptions(client, { headers: 'not-an-object' }),
+    ).resolves.toMatchObject({
+      headers: { Authorization: 'Bearer server-session-token' },
+    });
+  });
+});

--- a/plugins/wazuh-core/server/services/server-api-client.test.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.test.ts
@@ -88,7 +88,6 @@ describe('ServerAPIClient._buildRequestOptions', () => {
     expect(options.headers['content-type']).toBe('application/xml');
   });
 
-  // Regression test for GHSA-7rvv-9467-96mc: a caller-supplied Authorization
   // header must never replace the credential chosen by the server.
   it.each(['Authorization', 'authorization', 'AUTHORIZATION'])(
     'ignores a caller-supplied %s header',

--- a/plugins/wazuh-core/server/services/server-api-client.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.ts
@@ -19,6 +19,14 @@ import { getCookieValueByName } from './cookie';
 import { ManageHosts, IAPIHost } from './manage-hosts';
 import { ISecurityFactory } from './security-factory';
 
+/**
+ * Request headers a caller is allowed to set on the outbound Server API
+ * request. Every other header - most importantly `Authorization` - is decided
+ * by this service, so a caller can never choose the credential that is used
+ * upstream. See GHSA-7rvv-9467-96mc.
+ */
+const ALLOWED_REQUEST_HEADERS = new Set(['content-type']);
+
 type RequestHTTPMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 type RequestPath = string;
 
@@ -376,14 +384,45 @@ export class ServerAPIClient {
       method: method,
       headers: {
         'content-type': 'application/json',
+        ...this._filterRequestHeaders(headers),
+        // Set after the caller headers so it can never be overridden.
         Authorization: `Bearer ${token}`,
-        ...(headers ? headers : {}),
       },
       data: body || rest || {},
       params: params || {},
       url: requestUrl,
       httpsAgent: httpsAgent,
     };
+  }
+
+  /**
+   * Keep only the caller-provided headers that are safe to send upstream
+   * @param headers Headers provided by the caller
+   * @returns The subset of headers present in the allowlist
+   */
+  private _filterRequestHeaders(headers: unknown): Record<string, unknown> {
+    if (!headers || typeof headers !== 'object') {
+      return {};
+    }
+
+    const allowed: Record<string, unknown> = {};
+    const rejected: string[] = [];
+
+    for (const [name, value] of Object.entries(headers)) {
+      if (ALLOWED_REQUEST_HEADERS.has(name.toLowerCase())) {
+        allowed[name] = value;
+      } else {
+        rejected.push(name);
+      }
+    }
+
+    if (rejected.length > 0) {
+      this.logger.warn(
+        `Ignored request headers that are not allowed: ${rejected.join(', ')}`,
+      );
+    }
+
+    return allowed;
   }
 
   /**

--- a/plugins/wazuh-core/server/services/server-api-client.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.ts
@@ -23,7 +23,7 @@ import { ISecurityFactory } from './security-factory';
  * Request headers a caller is allowed to set on the outbound Server API
  * request. Every other header - most importantly `Authorization` - is decided
  * by this service, so a caller can never choose the credential that is used
- * upstream. See GHSA-7rvv-9467-96mc.
+ * upstream.
  */
 const ALLOWED_REQUEST_HEADERS = new Set(['content-type']);
 


### PR DESCRIPTION
## Description

The dashboard proxies Wazuh Server API calls through `POST /api/request`. The server resolves the Server API token for the current session and then builds the outbound request in `ServerAPIClient._buildRequestOptions`, where the caller-supplied `headers` object was spread **after** `Authorization` was set:

```ts
headers: {
  'content-type': 'application/json',
  Authorization: `Bearer ${token}`,
  ...(headers ? headers : {}),   // caller headers win
},
```

Because `POST /api/request` accepts an arbitrary body (`schema.any()`) and that same `headers` object is the intended channel for the `content-type` overrides used by the configuration editors, an authenticated dashboard user could set `Authorization` and replace the credential the **server** presents to the Server API.

That breaks the trust model of a server-side proxy: the browser must never choose the identity the server uses upstream. Depending on what the caller supplies, the proxied call could be made under a different Server API identity, or with no credential at all.

The defect is the trust-boundary break rather than credential disclosure — a valid dashboard session is required, and using a specific identity requires already holding a token for it.

## Proposed Changes

- `plugins/wazuh-core/server/services/server-api-client.ts`
  - Add `ALLOWED_REQUEST_HEADERS`, an allowlist of the headers a caller may set on an outbound Server API request. It contains only `content-type`, which is the sole header any caller legitimately sets (`wazuh-api.ts` sets it for the XML and raw configuration editors).
  - Add `_filterRequestHeaders`, which keeps allowlisted headers, drops everything else, and logs the names it dropped. The comparison is case-insensitive, so `authorization` and `AUTHORIZATION` are rejected as well. Non-object and missing `headers` are handled without throwing.
  - Set `Authorization` **after** the caller headers, so the credential resolved by the server cannot be overridden even if the allowlist is widened later. The two measures are deliberately independent.

The change sits in the shared `_buildRequestOptions`, so it covers both the scoped-user and internal-user clients.

### Results and Evidence

Verified against the local `docker/osd-dev` environment (dashboard proxying a real Wazuh Server API, `wazuhCore` 5.0.0-08).

**Normal Server API traffic is unaffected.** All 44 parameterless `GET` endpoints from the catalogue the Dev Tools console ships (`plugins/main/common/api-info/endpoints.json`, path parameters resolved for the environment) answered `error: 0` through `POST /api/request`:

```
PASS  all 44 catalogue GET endpoints answered error:0 through the proxy
PASS  query params are forwarded (limit/offset/sort/select)
PASS  limit param honoured upstream (all=500 of 835, limit=2 -> 2)
PASS  Dev Tools path (body.devTools=true)
PASS  POST /api/csv streams a CSV export
PASS  JSON body on a write (POST /groups)
PASS  POST /api/login returned a token for the host
PASS  POST /api/check-stored-api reports the host is reachable
```

**The header can no longer be chosen by the caller.** The identity the Server API reports for the session (`GET /security/users/me`) stays the one the server resolved in every variant tried — an invalid bearer value, an empty value, a lowercase header name, a valid token belonging to a different Server API user, and `Cookie` / `Host` / `X-Forwarded-For`:

```
server-side identity for this session: 2:wazuh-wui
PASS  injected Authorization ignored (still 2:wazuh-wui)      [invalid value]
PASS  injected Authorization ignored (still 2:wazuh-wui)      [empty value]
PASS  lowercase authorization ignored (still 2:wazuh-wui)
PASS  token of another Server API user ignored (still 2:wazuh-wui)
PASS  Cookie/Host/X-Forwarded-For injection has no effect (still 2:wazuh-wui)
```

Before the change, the fourth line resolved to the *other* user's identity.

**The features that depend on a caller-supplied `content-type` still work.** Both live callers were exercised end to end:

| Feature | Request | content-type | Result |
|---|---|---|---|
| Group `agent.conf` editor | `PUT /groups/{group}/configuration` (`origin: xmleditor`) | `application/xml` | Accepted; content reads back unchanged |
| `wazuh-manager.conf` editor | `PUT /cluster/{node}/configuration` (`origin: raw`) | `application/octet-stream` | Accepted; node configuration byte-identical to the backup |

Server API configuration validation after those writes: `node01: OK`.

As a negative control, the same XML payload sent without `origin` — leaving `content-type: application/json` — is rejected upstream with `Invalid Content-type (application/json), expected ['application/xml']`. This confirms the Server API genuinely enforces the header and that the allowlist is still forwarding it; had the filter dropped `content-type`, both editors would have failed exactly that way.

No UI change, so there is no screenshot to attach.

### Artifacts Affected

- `wazuhCore` plugin package (`plugins/wazuh-core`), server-side only.

No changes to `public/` bundles, packaging, or default configuration files.

### Configuration Changes

None. No new settings, no changed defaults.

The allowlist is intentionally a code-level constant rather than a setting: making it configurable would let an operator re-open the same hole.

Backward compatibility: callers that only set `content-type` — every caller in the codebase — are unaffected. A caller that relied on setting any other header through the proxy body would now have that header dropped and a warning logged; no such caller exists in this repository.

### Documentation Updates

None required. The behaviour change is internal to the server-side proxy and no documented interface changes.

### Tests Introduced

New colocated unit test `plugins/wazuh-core/server/services/server-api-client.test.ts`, 7 cases over the outbound request built by `_buildRequestOptions`:

- the token resolved by the server is used as `Authorization`;
- the allowlisted `content-type` header is forwarded;
- a caller-supplied `Authorization`, `authorization` and `AUTHORIZATION` never reaches the outbound request, and the caller's value appears nowhere in the headers (three parameterised cases; this is the regression test for this defect);
- `Cookie`, `Host` and `X-Forwarded-For` are dropped and a warning is logged;
- missing or non-object `headers` do not throw.

Local gates, over the changed files:

```
Prettier:                    PASS
ESLint:                      PASS  (test file 0 problems; source file 31, identical
                                    to origin/5.0.0 — all pre-existing no-explicit-any
                                    and camelcase in untouched legacy code)
Typecheck (plugin tsconfig): PASS  (only pre-existing tsconfig deprecation notices)
Jest (plugins/wazuh-core):   PASS  (7 new; suite 94 passed, 36 skipped, 0 failed)
```

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — none introduced
- [x] Developer documentation reflects the changes — no documented interface changed
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s) — tracked in an internal request, so no issue is referenced here
- [x] Correct labels applied (e.g., `no-changelog`)
