### PR TITLE
Prevent caller override of Server API auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Upgraded jsdom and its dependencies (`lodash` to `4.18.1`, `form-data` to `3.0.5`) [#8978](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8978)
 
+### Fixed
+
+- Fixed override of Server API authorization header [#9141](https://github.com/wazuh/wazuh-dashboard-plugins/pull/9141)
+
 ## Wazuh v4.14.8 - OpenSearch Dashboards 2.19.6 - Revision 00
 
 ### Added

--- a/plugins/wazuh-core/server/services/server-api-client.test.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Wazuh app - Server API client tests
+ * Copyright (C) 2015-2022 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import { Logger } from 'opensearch-dashboards/server';
+import { ServerAPIClient } from './server-api-client';
+import { ManageHosts } from './manage-hosts';
+import { ISecurityFactory } from './security-factory';
+
+const API_HOST = {
+  id: 'default',
+  url: 'https://server-api',
+  port: 55000,
+  username: 'wazuh-wui',
+  password: 'wazuh-wui',
+};
+
+interface RequestOptions {
+  headers: Record<string, unknown>;
+}
+
+/* The header allowlist is applied while building the outbound request, so the
+   test reaches for that private method instead of mocking the transport. */
+interface ClientInternals {
+  _buildRequestOptions: (
+    method: string,
+    path: string,
+    data: unknown,
+    options: unknown,
+  ) => Promise<RequestOptions>;
+}
+
+function createClient() {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const manageHosts = {
+    get: jest.fn().mockResolvedValue(API_HOST),
+    resolveVerifyCa: jest.fn().mockReturnValue(false),
+    isEnabledAuthWithRunAs: jest.fn().mockReturnValue(false),
+  };
+  const dashboardSecurity = {
+    getCurrentUser: jest.fn().mockResolvedValue({ username: 'admin' }),
+  };
+  const client = new ServerAPIClient(
+    logger as unknown as Logger,
+    manageHosts as unknown as ManageHosts,
+    dashboardSecurity as unknown as ISecurityFactory,
+  );
+
+  return { client, logger };
+}
+
+function buildRequestOptions(client: ServerAPIClient, data: unknown) {
+  return (client as unknown as ClientInternals)._buildRequestOptions(
+    'GET',
+    '/agents',
+    data,
+    { apiHostID: 'default', token: 'server-session-token' },
+  );
+}
+
+describe('ServerAPIClient._buildRequestOptions', () => {
+  it('uses the token resolved by the server as Authorization', async () => {
+    const { client } = createClient();
+    const options = await buildRequestOptions(client, {});
+
+    expect(options.headers.Authorization).toBe('Bearer server-session-token');
+  });
+
+  it('forwards the allowed content-type header', async () => {
+    const { client } = createClient();
+    const options = await buildRequestOptions(client, {
+      headers: { 'content-type': 'application/xml' },
+    });
+
+    expect(options.headers['content-type']).toBe('application/xml');
+  });
+
+  // header must never replace the credential chosen by the server.
+  it.each(['Authorization', 'authorization', 'AUTHORIZATION'])(
+    'ignores a caller-supplied %s header',
+    async headerName => {
+      const { client } = createClient();
+      const options = await buildRequestOptions(client, {
+        headers: { [headerName]: 'Bearer token-from-the-client' },
+      });
+
+      expect(options.headers.Authorization).toBe('Bearer server-session-token');
+      expect(JSON.stringify(options.headers)).not.toContain(
+        'token-from-the-client',
+      );
+    },
+  );
+
+  it('ignores other headers that are not allowlisted', async () => {
+    const { client, logger } = createClient();
+    const options = await buildRequestOptions(client, {
+      headers: {
+        Cookie: 'wz-token=stolen',
+        Host: 'attacker.local',
+        'X-Forwarded-For': '127.0.0.1',
+      },
+    });
+
+    expect(options.headers.Cookie).toBeUndefined();
+    expect(options.headers.Host).toBeUndefined();
+    expect(options.headers['X-Forwarded-For']).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('does not fail when headers are missing or not an object', async () => {
+    const { client } = createClient();
+
+    await expect(buildRequestOptions(client, {})).resolves.toMatchObject({
+      headers: { 'content-type': 'application/json' },
+    });
+    await expect(
+      buildRequestOptions(client, { headers: 'not-an-object' }),
+    ).resolves.toMatchObject({
+      headers: { Authorization: 'Bearer server-session-token' },
+    });
+  });
+});

--- a/plugins/wazuh-core/server/services/server-api-client.ts
+++ b/plugins/wazuh-core/server/services/server-api-client.ts
@@ -25,6 +25,13 @@ interface APIHost {
   port: number;
   run_as: boolean;
 }
+/**
+ * Request headers a caller is allowed to set on the outbound Server API
+ * request. Every other header - most importantly `Authorization` - is decided
+ * by this service, so a caller can never choose the credential that is used
+ * upstream.
+ */
+const ALLOWED_REQUEST_HEADERS = new Set(['content-type']);
 
 type RequestHTTPMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 type RequestPath = string;
@@ -149,13 +156,44 @@ export class ServerAPIClient {
       method: method,
       headers: {
         'content-type': 'application/json',
-        Authorization: 'Bearer ' + token,
-        ...(headers ? headers : {}),
+        ...this._filterRequestHeaders(headers),
+        // Set after the caller headers so it can never be overridden.
+        Authorization: `Bearer ${token}`,
       },
       data: body || rest || {},
       params: params || {},
       url: `${api.url}:${api.port}${path}`,
     };
+  }
+
+  /**
+   * Keep only the caller-provided headers that are safe to send upstream
+   * @param headers Headers provided by the caller
+   * @returns The subset of headers present in the allowlist
+   */
+  private _filterRequestHeaders(headers: unknown): Record<string, unknown> {
+    if (!headers || typeof headers !== 'object') {
+      return {};
+    }
+
+    const allowed: Record<string, unknown> = {};
+    const rejected: string[] = [];
+
+    for (const [name, value] of Object.entries(headers)) {
+      if (ALLOWED_REQUEST_HEADERS.has(name.toLowerCase())) {
+        allowed[name] = value;
+      } else {
+        rejected.push(name);
+      }
+    }
+
+    if (rejected.length > 0) {
+      this.logger.warn(
+        `Ignored request headers that are not allowed: ${rejected.join(', ')}`,
+      );
+    }
+
+    return allowed;
   }
 
   /**
@@ -178,9 +216,8 @@ export class ServerAPIClient {
         username: api.username,
         password: api.password,
       },
-      url: `${api.url}:${api.port}/security/user/authenticate${
-        options.useRunAs ? '/run_as' : ''
-      }`,
+      url: `${api.url}:${api.port}/security/user/authenticate${options.useRunAs ? '/run_as' : ''
+        }`,
       ...(!!options?.authContext ? { data: options?.authContext } : {}),
     };
 
@@ -213,14 +250,14 @@ export class ServerAPIClient {
 
         const token = useRunAs
           ? await this._authenticate(apiHostID, {
-              useRunAs: true,
-              authContext: (
-                await this.dashboardSecurity.getCurrentUser(request, context)
-              ).authContext,
-            })
+            useRunAs: true,
+            authContext: (
+              await this.dashboardSecurity.getCurrentUser(request, context)
+            ).authContext,
+          })
           : await this._authenticate(apiHostID, {
-              useRunAs: false,
-            });
+            useRunAs: false,
+          });
         return token;
       },
       request: async (
@@ -254,7 +291,7 @@ export class ServerAPIClient {
     try {
       const token =
         this._CacheInternalUserAPIHostToken.has(options.apiHostID) &&
-        !options.forceRefresh
+          !options.forceRefresh
           ? this._CacheInternalUserAPIHostToken.get(options.apiHostID)
           : await this._authenticateInternalUser(options.apiHostID);
       return await this._request(method, path, data, { ...options, token });


### PR DESCRIPTION
## Description

The dashboard proxies Server API calls through POST /api/request. When building the outbound request, ServerAPIClient spreads the caller-supplied headers after setting Authorization, so any header sent in the request body won. An authenticated dashboard user could therefore replace the credential the server presents to the Server API, which breaks the proxy trust model: the browser must never choose the identity used server-side.

### Closes

 - https://github.com/wazuh/wazuh-dashboard-plugins/issues/9139

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
