### PR TITLE
Remove report footer known issue from docs

### DIFF
--- a/docs/ref/custom-branding/custom-branding.md
+++ b/docs/ref/custom-branding/custom-branding.md
@@ -119,11 +119,7 @@ The PDF reports can be customized through a report definition that allows to def
 1. Go to **Explore** > **Reporting**
 2. Click on **Create** button.
 3. Define the report name and description, source and other settings.
-4. In the **Report definition** section, click on the **Add header** option to customize it.
-
-> ⚠️ The UI allows to configure the footer using the **Add footer** button but the generated report does not include the footer. This is a known issue.
-
-<!-- Footer known issue: https://github.com/opensearch-project/dashboards-reporting/issues/53-->
+4. In the **Report definition** section, click on the **Add header** or **Add footer** option to customize them.
 
 For example, for the header, you can add the following HTML code to set a custom title:
 


### PR DESCRIPTION
## Description

The custom branding guide documented that the report definition UI offers an **Add footer** button but the generated report never includes the footer, pointing to opensearch-project/dashboards-reporting#53 as a known issue.

That bug is fixed by https://github.com/wazuh/wazuh-dashboard-reporting/pull/227, so the documentation must stop reporting it and should present the footer as a supported customization.

## Proposed Changes

- Remove the known-issue warning about the report footer and its accompanying HTML comment from `docs/ref/custom-branding/custom-branding.md`.
- Update step 4 of the Reporting section so it mentions both the **Add header** and **Add footer** options.

### Results and Evidence

Diff of the Reporting section:

```diff
-4. In the **Report definition** section, click on the **Add header** option to customize it.
-
-> ⚠️ The UI allows to configure the footer using the **Add footer** button but the generated report does not include the footer. This is a known issue.
-
-<!-- Footer known issue: https://github.com/opensearch-project/dashboards-reporting/issues/53-->
+4. In the **Report definition** section, click on the **Add header** or **Add footer** option to customize them.
```

Footer rendering itself is verified in wazuh/wazuh-dashboard-reporting#227, which covers PNG and both PDF paths with `reporting:useFOR` enabled and disabled.

### Artifacts Affected

None. Documentation only.

### Configuration Changes

None.

### Documentation Updates

- `docs/ref/custom-branding/custom-branding.md` — Reporting section.

### Tests Introduced

None. Documentation-only change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
